### PR TITLE
Updating npsupport.py to fail gracefully without numpy

### DIFF
--- a/comtypes/npsupport.py
+++ b/comtypes/npsupport.py
@@ -72,6 +72,8 @@ def isdatetime64(value):
     This cannot succeed if datetime64 is not available.
 
     """
+    if not HAVE_NUMPY:
+        return False
     return isinstance(value, datetime64)
 
 


### PR DESCRIPTION
Adding the check for numpy in isdatetime64 so that it doesn't fail when numpy is not present, which can cause comtypes.automation.tagVARIANT._set_value to except when called with certain datatypes:
TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types
