### PR TITLE
Do not convert empty string to NULL VARIANT.

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -218,7 +218,8 @@ class tagVARIANT(Structure):
         _VariantClear(self)
         if value is None:
             self.vt = VT_NULL
-        elif hasattr(value, '__len__') and len(value) == 0:
+        elif (hasattr(value, '__len__') and len(value) == 0
+                and not isinstance(value, basestring)):
             self.vt = VT_NULL
         # since bool is a subclass of int, this check must come before
         # the check for int

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -176,6 +176,11 @@ class VariantTestCase(unittest.TestCase):
         v.vt = VT_BSTR
         self.failUnless(v.value in ("", None))
 
+    def test_empty_BSTR(self):
+        v = VARIANT()
+        v.value = ""
+        self.assertEqual(v.vt, VT_BSTR)
+
     def test_UDT(self):
         from comtypes.gen.TestComServerLib import MYCOLOR
         v = VARIANT(MYCOLOR(red=1.0, green=2.0, blue=3.0))


### PR DESCRIPTION
Fixes #67.
