### PR TITLE
Fixes TypeError when wrapping `esriSystem.olb`

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -858,6 +858,9 @@ _ctype_to_vartype = {
     # such an array cannot be created.
     POINTER(VARIANT): VT_BYREF|VT_VARIANT,
 
+    POINTER(BSTR): VT_BYREF|VT_BSTR,
+        #fix for Esri ArcObjects (esriSystem.olb)
+
     # These are not yet implemented:
 ##    POINTER(IUnknown): VT_UNKNOWN,
 ##    POINTER(IDispatch): VT_DISPATCH,


### PR DESCRIPTION
More details at http://gis.stackexchange.com/questions/37672/arcobjects-comtypes-at-10-1. Comtypes is the most popular route to using the Esri ArcObjects com library for functions that are not exposed in the official ArcPy library.