### PR TITLE
Fixes TypeError when wrapping `esriSystem.olb` cleanup

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -858,8 +858,8 @@ _ctype_to_vartype = {
     # such an array cannot be created.
     POINTER(VARIANT): VT_BYREF|VT_VARIANT,
 
+    # This is needed to import Esri ArcObjects (esriSystem.olb).
     POINTER(BSTR): VT_BYREF|VT_BSTR,
-        #fix for Esri ArcObjects (esriSystem.olb)
 
     # These are not yet implemented:
 ##    POINTER(IUnknown): VT_UNKNOWN,

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -858,6 +858,9 @@ _ctype_to_vartype = {
     # such an array cannot be created.
     POINTER(VARIANT): VT_BYREF|VT_VARIANT,
 
+    POINTER(BSTR): VT_BYREF|VT_BSTR,
+        #fix for Esri ArcObjects (esriSystem.olb)
+
     # These are not yet implemented:
 ##    POINTER(IUnknown): VT_UNKNOWN,
 ##    POINTER(IDispatch): VT_DISPATCH,


### PR DESCRIPTION
Minor cleanup of #75.