### PR TITLE
Fix for Issue 92 - generated code has Python 3 syntax error

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -2,8 +2,8 @@ import types
 import sys
 import os
 
-# comtypes version numbers follow semver (http://semver.org/)
-__version__ = "1.1.3-0.fixIssue92"
+# comtypes version numbers follow semver (http://semver.org/) and PEP 440
+__version__ = "1.1.3.dev0"
 
 import logging
 class NullHandler(logging.Handler):

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # comtypes version numbers follow semver (http://semver.org/)
-__version__ = "1.1.2"
+__version__ = "1.1.3-0.fixIssue92"
 
 import logging
 class NullHandler(logging.Handler):

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -9,6 +9,8 @@ import comtypes.client._generate
 
 version = "$Rev$"[6:-2]
 
+__warn_on_munge__ = __debug__
+
 
 class lcid(object):
     def __repr__(self):
@@ -348,7 +350,7 @@ class Generator(object):
         value = int(tp.value)
         if keyword.iskeyword(tp.name):
             # XXX use logging!
-            if __debug__:
+            if __warn_on_munge__:
                 print "# Fixing keyword as EnumValue for %s" % tp.name
             tp.name += "_"
         print >> self.stream, \

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -2,6 +2,7 @@
 # libraries.
 import os
 import cStringIO
+import keyword
 from comtypes.tools import typedesc
 import comtypes.client
 import comtypes.client._generate
@@ -345,6 +346,8 @@ class Generator(object):
     _enumvalues = 0
     def EnumValue(self, tp):
         value = int(tp.value)
+        if keyword.iskeyword(tp.name):
+            tp.name += "_"
         print >> self.stream, \
               "%s = %d" % (tp.name, value)
         self.names.add(tp.name)

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -347,6 +347,9 @@ class Generator(object):
     def EnumValue(self, tp):
         value = int(tp.value)
         if keyword.iskeyword(tp.name):
+            # XXX use logging!
+            if __debug__:
+                print "# Fixing keyword as EnumValue for %s" % tp.name
             tp.name += "_"
         print >> self.stream, \
               "%s = %d" % (tp.name, value)


### PR DESCRIPTION
This only fixes the narrow case of EnumValues potentially being python keywords.

I've only tested it against the indicated problem child, MSHTML (for those of us using pywebview on python3), which only hits the keywords `True` and `False`.

I included the debug statement so those using other COM libraries will see what gets changed and be forewarned (just in case the name change messes up the COM interaction).

Many thanks to @takluyver for his detailed Issue report.