### PR TITLE
streamline module creation and import

### DIFF
--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -107,7 +107,7 @@ def _is_writeable(path):
     if not path:
         return False
     try:
-        tempfile.TemporaryFile(dir=path[0])
+        tempfile.TemporaryFile(dir=list(path)[0])
     except (OSError, IOError), details:
         logger.debug("Path is unwriteable: %s", details)
         return False


### PR DESCRIPTION
The way it was I frequently had problems on the first import of a
module, I played around, added time.sleep between the creation and the
import but the same import still failed, although i even could in the
meantime import the just generated module from another process fine.
No it always uses the same code as if no gen_dir was defined to import
the module on the first creation, however now one more test of the leak
test is failing on my test machine, don't know why.
