### PR TITLE
Embed timestamp of tlb used for cache gen.

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -23,21 +23,19 @@ from ctypes import *
 from _ctypes import COMError
 from comtypes import patcher
 
-def _check_version(actual):
+def _check_version(actual, tlib_cached_mtime=None):
     from comtypes.tools.codegenerator import version as required
     if actual != required:
         raise ImportError("Wrong version")
     if not hasattr(sys, "frozen"):
         g = sys._getframe(1).f_globals
-        mod_path = g.get("__file__")
         tlb_path = g.get("typelib_path")
         try:
-            mod_mtime = os.stat(mod_path).st_mtime
-            tlib_mtime = os.stat(tlb_path).st_mtime
+            tlib_curr_mtime = os.stat(tlb_path).st_mtime
         except (OSError, TypeError):
             return
-        if mod_mtime < tlib_mtime:
-            raise ImportError("Typelib newer than module")
+        if not tlib_cached_mtime or abs(tlib_curr_mtime - tlib_cached_mtime) >= 1:
+            raise ImportError("Typelib different than module")
 
 try:
     COMError()

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -257,7 +257,9 @@ class Generator(object):
 
         for line in wrapper.wrap(text):
             print >> self.output, line
-        print >> self.output, "from comtypes import _check_version; _check_version(%r)" % version
+
+        tlib_mtime = os.stat(self.filename).st_mtime
+        print >> self.output, "from comtypes import _check_version; _check_version(%r, %f)" % (version, tlib_mtime)
         return loops
 
     def type_name(self, t, generate=True):


### PR DESCRIPTION
Use the embedded timestamp for cache invalidation.
Fixes #115 