### PR TITLE
fix "List index out of range" bug

### DIFF
--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -67,7 +67,7 @@ def _find_gen_dir():
         if not os.path.exists(gen_dir):
             logger.info("Creating writeable comtypes cache directory: '%s'", gen_dir)
             os.makedirs(gen_dir)
-        gen.__path__.append(gen_dir)
+        gen_path.append(gen_dir)
     result = os.path.abspath(gen_path[-1])
     logger.info("Using writeable comtypes cache directory: '%s'", result)
     return result


### PR DESCRIPTION
If we landed in this branch because there were no paths, we must add one to be able to call "gen_path[-1]"