### PR TITLE
Fix crash or wrong path when using memory-only comtypes.gen

### DIFF
--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -67,7 +67,7 @@ def _find_gen_dir():
         if not os.path.exists(gen_dir):
             logger.info("Creating writeable comtypes cache directory: '%s'", gen_dir)
             os.makedirs(gen_dir)
-        gen.__path__.append(gen_dir)
+        gen_path.append(gen_dir)
     result = os.path.abspath(gen_path[-1])
     logger.info("Using writeable comtypes cache directory: '%s'", result)
     return result


### PR DESCRIPTION
Following changes in #137 the path list for the gen cache is not updated before a value is read, so this either crashes trying to index an empty list or gives you an incorrect path. I think this is probably just a missed change in variable name, but it is breaking anything using a memory only cache (explicitly sets the path to an empty list) or a cache in a temp location. As an example, here is what happens with PyInstaller.

Current behaviour:
<pre>_create_comtypes_gen_package	INFO	Imported existing <module 'comtypes.gen' from 'C:\\Users\\MWILLC~1\\AppData\\Local\\Temp\\12\\_MEI143962\\comtypes\\gen\\__init__.pyc'>
_is_writeable	DEBUG	Path is unwriteable: [Errno 2] No such file or directory: 'C:\\Users\\MWILLC~1\\AppData\\Local\\Temp\\12\\_MEI143962\\comtypes\\gen\\tmppr51znv2'
_find_gen_dir	INFO	Creating writeable comtypes cache directory: 'C:\Users\MWILLC~1\AppData\Local\Temp\12\comtypes_cache\overseer-36'
_find_gen_dir	INFO	Using writeable comtypes cache directory: 'C:\Users\MWILLC~1\AppData\Local\Temp\12\_MEI143962\comtypes\gen'</pre>

... so it makes a path and then doesn't use it, resulting in:<pre>FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\MWILLC~1\\AppData\\Local\\Temp\\12\\_MEI143962\\comtypes\\gen\\_50A7E9B0_70EF_11D1_B75A_00A0C90564FE_0_1_0.py'</pre>

New behaviour:
<pre>_create_comtypes_gen_package	INFO	Imported existing <module 'comtypes.gen' from 'C:\\Users\\MWILLC~1\\AppData\\Local\\Temp\\12\\_MEI61722\\comtypes\\gen\\__init__.pyc'>
_is_writeable	DEBUG	Path is unwriteable: [Errno 2] No such file or directory: 'C:\\Users\\MWILLC~1\\AppData\\Local\\Temp\\12\\_MEI61722\\comtypes\\gen\\tmp3hty8xpl'
_find_gen_dir	INFO	Creating writeable comtypes cache directory: 'C:\Users\MWILLC~1\AppData\Local\Temp\12\comtypes_cache\overseer-36'
_find_gen_dir	INFO	Using writeable comtypes cache directory: 'C:\Users\MWILLC~1\AppData\Local\Temp\12\comtypes_cache\overseer-36'</pre>