### PR TITLE
Bugfix: Append temp directory to the correct list

### DIFF
--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -68,6 +68,7 @@ def _find_gen_dir():
             logger.info("Creating writeable comtypes cache directory: '%s'", gen_dir)
             os.makedirs(gen_dir)
         gen.__path__.append(gen_dir)
+        gen_path.append(gen_dir)
     result = os.path.abspath(gen_path[-1])
     logger.info("Using writeable comtypes cache directory: '%s'", result)
     return result


### PR DESCRIPTION
Hi,
I'm using pyinstaller (freezing the application) and experienced a bug during the creation of `gen_dir`.
When using comtypes=1.1.4 the [gen directory](https://pythonhosted.org/comtypes/#accessing-type-libraries) will be created in the temp directory but it remains empty and the module crashes with following error message:
```
    self._word = comtypes.c]lient.CreateObject('Word.Application')
  File "site-packages\comtypes\client\__init__.py", line 253, in CreateObject
  File "site-packages\comtypes\client\__init__.py", line 191, in _manage
  File "site-packages\comtypes\client\__init__.py", line 113, in GetBestInterface
  File "site-packages\comtypes\client\_generate.py", line 110, in GetModule
  File "site-packages\comtypes\client\_generate.py", line 169, in _CreateWrapper
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\ ...{directory of my exe file}...\\comtypes\\gen\\_00020905_0000_0000_C000_000000000046_0_8_7.py'
```
After inspecting the logs I noticed that the `gen_dir` is located in the same directory as my executable even if it is not writable. This is because of a second array in the `_create_comtypes_gen_package()` function which didn't get updated if a temp directory was defined.

Just to mention what I found: [This](https://github.com/enthought/comtypes/commit/98f6a42e8b452c67a65848d1c4476fb37df2aa6a) was the commit producing the bug 😄

For now we're using comtypes==1.1.3.post2 to avoid this bug. I was wondering why the version got this weird suffix. What does it mean?

Greetings,
Thomas

PS: I guess [this test](https://github.com/enthought/comtypes/blob/master/comtypes/test/test_findgendir.py#L72) didn't fail before. Maybe something is broken in the pipeline because this unit test should have failed.