### PR TITLE
Clear cache as post-install step and fix #124

### DIFF
--- a/clear_comtypes_cache.py
+++ b/clear_comtypes_cache.py
@@ -1,61 +1,56 @@
 import os
 import sys
 import shutil
-from ctypes import windll
 
-def is_cache():
+def get_next_cache_dir():
     try:
-        import comtypes.gen
+        print("import comtypes.gen")
+        # change working directory to avoid import from local folder
+        # during installation process
+        os.chdir(os.path.dirname(sys.executable))
+        import comtypes
+        import comtypes.client
+        print("DONE")
+        return comtypes.client._code_cache._find_gen_dir()
     except ImportError:
-        return
-    return comtypes.gen.__path__[0]
+        return None
 
 
 def _remove(directory):
     shutil.rmtree(directory)
-    print("Removed directory %s" % directory)
+    print('Removed directory "%s"' % directory)
 
 
-install_text = """\
-When installing a new comtypes version, it is recommended to remove
-the comtypes\gen directory and the automatically generated modules
-it contains.  This directory and the modules will be regenerated
-on demand.
+def remove_directory(directory, silent):
+    if directory:
+        if silent:
+            _remove(directory)
+        else:
+            try:
+                confirm = raw_input('Remove directory "%s" ? (y/n)' % directory)
+            except NameError:
+                confirm = input('Remove cache directory "%s" ? (y/n)' % directory)
+            if confirm.lower() == 'y':
+                _remove(directory)
+            else:
+                print('Directory "%s" NOT removed' % directory)
+                return False
+    return True
 
-Should the installer delete all the files in this directory?"""
 
-deinstall_text = """\
-The comtypes\gen directory contains modules that comtypes
-automatically generates.
-
-Should this directory be removed?"""
-
-if len(sys.argv) > 1 and "-install" in sys.argv[1:]:
-    title = "Install comtypes"
-    text = install_text
-else:
-    title = "Remove comtypes"
-    text = deinstall_text
-
-if len(sys.argv) > 1 and "-silent" in sys.argv[1:]:
+if len(sys.argv) > 1 and "-y" in sys.argv[1:]:
     silent = True
 else:
     silent = False
 
 
+# First iteration may get folder with restricted rights.
+# Second iteration always gets temp cache folder (writable for all).
+directory = get_next_cache_dir()
+removed = remove_directory(directory, silent)
 
-IDYES = 6
-IDNO = 7
-MB_YESNO = 4
-MB_ICONWARNING = 48
-directory = is_cache()
-if directory:
-    if silent:
-        _remove(directory)
-    else:
-        res = windll.user32.MessageBoxA(0, text, title,
-                MB_YESNO|MB_ICONWARNING)
-        if res == IDYES:
-            _remove(directory)
-        else:
-            print("Directory %s NOT removed" % directory)
+if removed:
+    directory = get_next_cache_dir()
+
+    # do not request confirmation if already confirmed and removed
+    remove_directory(directory, silent=removed)

--- a/clear_comtypes_cache.py
+++ b/clear_comtypes_cache.py
@@ -3,17 +3,17 @@ import sys
 import shutil
 
 def get_next_cache_dir():
+    work_dir = os.getcwd()
     try:
-        print("import comtypes.gen")
         # change working directory to avoid import from local folder
         # during installation process
         os.chdir(os.path.dirname(sys.executable))
-        import comtypes
         import comtypes.client
-        print("DONE")
         return comtypes.client._code_cache._find_gen_dir()
     except ImportError:
         return None
+    finally:
+        os.chdir(work_dir)
 
 
 def _remove(directory):
@@ -27,9 +27,9 @@ def remove_directory(directory, silent):
             _remove(directory)
         else:
             try:
-                confirm = raw_input('Remove directory "%s" ? (y/n)' % directory)
+                confirm = raw_input('Remove comtypes cache directories? (y/n): ')
             except NameError:
-                confirm = input('Remove cache directory "%s" ? (y/n)' % directory)
+                confirm = input('Remove comtypes cache directories? (y/n): ')
             if confirm.lower() == 'y':
                 _remove(directory)
             else:
@@ -52,5 +52,6 @@ removed = remove_directory(directory, silent)
 if removed:
     directory = get_next_cache_dir()
 
-    # do not request confirmation if already confirmed and removed
+    # do not request the second confirmation
+    # if the first folder was already removed
     remove_directory(directory, silent=removed)

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # comtypes version numbers follow semver (http://semver.org/) and PEP 440
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 import logging
 class NullHandler(logging.Handler):

--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -119,12 +119,7 @@ def _is_writeable(path):
     which we can create files."""
     if not path:
         return False
-    try:
-        tempfile.TemporaryFile(dir=path[0])
-    except (OSError, IOError), details:
-        logger.debug("Path is unwriteable: %s", details)
-        return False
-    return True
+    return os.access(path, os.W_OK)
 
 def _get_module_filename(hmodule):
     """Call the Windows GetModuleFileName function which determines

--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -119,7 +119,8 @@ def _is_writeable(path):
     which we can create files."""
     if not path:
         return False
-    return os.access(path, os.W_OK)
+    # TODO: should we add os.X_OK flag as well? It seems unnecessary on Windows.
+    return os.access(path[0], os.W_OK)
 
 def _get_module_filename(hmodule):
     """Call the Windows GetModuleFileName function which determines

--- a/setup.py
+++ b/setup.py
@@ -105,9 +105,9 @@ class post_install(install):
             if not os.path.isfile(filename):
                 raise RuntimeError("Can't find '%s'" % (filename,))
             print("Executing post install script...")
-            print('"' + sys.executable + '" "' + filename + '"')
+            print('"' + sys.executable + '" "' + filename + '" -y')
             try:
-                subprocess.check_call([sys.executable, filename])
+                subprocess.check_call([sys.executable, filename, '-y'])
             except subprocess.CalledProcessError:
                 print("Failed to run post install script!")
 


### PR DESCRIPTION
* `clear_comtypes_cache.py` has been revived and added to post-install step (the idea was given from pyWin32 package).
* Fix for #124: use `os.access` to check write permission.

With these changes I'm planning to publish release 1.1.5.