### PR TITLE
Fix "pip install comtypes" error, add the test on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,5 @@ environment:
 
 test_script:
    - C:\%py%\python.exe setup.py install
+   - C:\%py%\Scripts\pip.exe uninstall comtypes -y
+   - C:\%py%\python.exe test_pip_install.py

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # comtypes version numbers follow semver (http://semver.org/) and PEP 440
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 import logging
 class NullHandler(logging.Handler):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-"comtypes package install script"
-
+"""comtypes package install script"""
 import sys
 import os
 import ctypes
@@ -94,6 +93,20 @@ def read_version():
 
 
 class post_install(install):
+
+    # both this static variable and method initialize_options() help to avoid
+    # weird setuptools error during "pip install comtypes"
+    user_options = install.user_options + [
+        ('old-and-unmanageable', None, "Try not to use this!"),
+        ('single-version-externally-managed', None,
+         "used by system package builders to create 'flat' eggs"),
+    ]
+
+    def initialize_options(self):
+        install.initialize_options(self)
+        self.old_and_unmanageable = None
+        self.single_version_externally_managed = None
+
     def run(self):
         install.run(self)
         # Custom script we run at the end of installing - this is the same script

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,10 @@ def read_version():
 class post_install(install):
 
     # both this static variable and method initialize_options() help to avoid
-    # weird setuptools error during "pip install comtypes"
+    # weird setuptools error with "pip install comtypes", details are here:
+    # https://github.com/enthought/comtypes/issues/155
+    # the working solution was found here:
+    # https://github.com/pypa/setuptools/blob/3b90be7bb6323eb44d0f28864509c1d47aa098de/setuptools/command/install.py
     user_options = install.user_options + [
         ('old-and-unmanageable', None, "Try not to use this!"),
         ('single-version-externally-managed', None,

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ def read_version():
     # Determine the version number by reading it from the file
     # 'comtypes\__init__.py'.  We cannot import this file (with py3,
     # at least) because it is in py2.x syntax.
-    ns = {}
     for line in open("comtypes/__init__.py"):
         if line.startswith("__version__ = "):
             var, value = line.split('=')

--- a/test_pip_install.py
+++ b/test_pip_install.py
@@ -16,7 +16,7 @@ def read_version():
 # prepare the same package that is usually uploaded to PyPI
 subprocess.check_call([sys.executable, 'setup.py', 'sdist', '--format=zip'])
 
-filename_for_upload = 'comtypes-{}.zip'.format(read_version())
+filename_for_upload = 'comtypes-%s.zip' % read_version()
 target_package = os.path.join(os.getcwd(), 'dist', filename_for_upload)
 
 # run "pip install comtypes-x.y.z.zip"

--- a/test_pip_install.py
+++ b/test_pip_install.py
@@ -1,3 +1,4 @@
+"""This test covers 'pip install' issue #155"""
 import os
 import sys
 import subprocess

--- a/test_pip_install.py
+++ b/test_pip_install.py
@@ -14,11 +14,11 @@ def read_version():
     raise NotImplementedError("__version__ is not found in __init__.py")
 
 # prepare the same package that is usually uploaded to PyPI
-subprocess.check_output([sys.executable, 'setup.py', 'sdist', '--format=zip'])
+subprocess.check_call([sys.executable, 'setup.py', 'sdist', '--format=zip'])
 
 filename_for_upload = 'comtypes-{}.zip'.format(read_version())
-target_package = os.path.join(os.getcwd(), 'sdist', filename_for_upload)
+target_package = os.path.join(os.getcwd(), 'dist', filename_for_upload)
 
 # run "pip install comtypes-x.y.z.zip"
 pip_exe = os.path.join(os.path.dirname(sys.executable), 'Scripts', 'pip.exe')
-subprocess.check_output([pip_exe, 'install', target_package])
+subprocess.check_call([pip_exe, 'install', target_package])

--- a/test_pip_install.py
+++ b/test_pip_install.py
@@ -6,7 +6,6 @@ def read_version():
     # Determine the version number by reading it from the file
     # 'comtypes\__init__.py'.  We cannot import this file (with py3,
     # at least) because it is in py2.x syntax.
-    ns = {}
     for line in open("comtypes/__init__.py"):
         if line.startswith("__version__ = "):
             var, value = line.split('=')

--- a/test_pip_install.py
+++ b/test_pip_install.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import subprocess
+
+def read_version():
+    # Determine the version number by reading it from the file
+    # 'comtypes\__init__.py'.  We cannot import this file (with py3,
+    # at least) because it is in py2.x syntax.
+    ns = {}
+    for line in open("comtypes/__init__.py"):
+        if line.startswith("__version__ = "):
+            var, value = line.split('=')
+            return value.strip().strip('"').strip("'")
+    raise NotImplementedError("__version__ is not found in __init__.py")
+
+# prepare the same package that is usually uploaded to PyPI
+subprocess.check_output([sys.executable, 'setup.py', 'sdist', '--format=zip'])
+
+filename_for_upload = 'comtypes-{}.zip'.format(read_version())
+target_package = os.path.join(os.getcwd(), 'sdist', filename_for_upload)
+
+# run "pip install comtypes-x.y.z.zip"
+pip_exe = os.path.join(os.path.dirname(sys.executable), 'Scripts', 'pip.exe')
+subprocess.check_output([pip_exe, 'install', target_package])


### PR DESCRIPTION
* Weird error #155 has been fixed after long googling for many similar issues and pypa GitHub repos. The working solution was found here: [setuptools/command/install.py](https://github.com/pypa/setuptools/blob/master/setuptools/command/install.py).
* Script `test_pip_install.py` covers issue #155.
  - Reproducing run: https://ci.appveyor.com/project/pywinauto/comtypes/build/1.1.x_build_11
  - Fixed run: https://ci.appveyor.com/project/pywinauto/comtypes/build/1.1.x_build_12

The issue was a big surprise for me. I'm already used to constant changes in PyPI upload process and twine usage models. But this one was completely unexpected. Don't know exactly why `pip install pywin32` still works: `.whl` package might be more reliable way.