### PR TITLE
automation.py: add HRESULT to _ctype_to_vartype

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -837,6 +837,8 @@ _ctype_to_vartype = {
     c_longlong: VT_I8,
     c_ulonglong: VT_UI8,
 
+    HRESULT: VT_HRESULT,
+
     VARIANT_BOOL: VT_BOOL,
 
     BSTR: VT_BSTR,


### PR DESCRIPTION
disclaimer: I have no idea how comtypes works, I edited things until CreateObject no longer failed for my particular object.