### PR TITLE
Correctly ignore error from CoWaitForMultipleHandles().

### DIFF
--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -276,7 +276,7 @@ def PumpEvents(timeout):
                                                                len(handles), handles,
                                                                ctypes.byref(ctypes.c_ulong()))
         except WindowsError, details:
-            if details.args[0] != RPC_S_CALLPENDING: # timeout expired
+            if details.winerror != RPC_S_CALLPENDING: # timeout expired
                 raise
         else:
             raise KeyboardInterrupt


### PR DESCRIPTION
The RPC_S_CALL_PENDING error is in args[3] aka winerror.

Fixes #138, #159.