### PR TITLE
Fix importing newly-created modules on Python 3

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -3,6 +3,7 @@ import os
 import sys
 import comtypes.client
 import comtypes.tools.codegenerator
+import importlib
 
 import logging
 logger = logging.getLogger(__name__)
@@ -143,6 +144,9 @@ def GetModule(tlib):
     ofi = open(os.path.join(comtypes.client.gen_dir, modulename + ".py"), "w")
     ofi.write(code)
     ofi.close()
+    # clear the import cache to make sure Python sees newly created modules
+    if hasattr(importlib, "invalidate_caches"):
+        importlib.invalidate_caches()
     return _my_import("comtypes.gen." + modulename)
 
 def _CreateWrapper(tlib, pathname=None):
@@ -181,6 +185,9 @@ def _CreateWrapper(tlib, pathname=None):
         setattr(comtypes.gen, modname, mod)
     else:
         ofi.close()
+        # clear the import cache to make sure Python sees newly created modules
+        if hasattr(importlib, "invalidate_caches"):
+            importlib.invalidate_caches()
         mod = _my_import(fullname)
     return mod
 


### PR DESCRIPTION
Python 3's import mechanism caches the contents of a directory
containing modules (such as comtypes.gen) and relies on the "modified
time" (mtime) attribute to determine if it needs to reload that
directory.

In Windows, the mtime is sometimes not updated very often when creating
modules in quick succession, which means that the mtime stays identical,
which then appears in comtype's case as random module import failures
when using a new COM object for the first time.

See https://stackoverflow.com/questions/52933869/why-does-importing-fails-after-creating-a-module-under-python-3-on-windows for a more detailed explanation.

(Fixes #161)