### PR TITLE
fix invalid handling of WindowsError on python 3

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -47,16 +47,17 @@ def HRESULT_FROM_WIN32(errcode):
 def winerror(exc):
     """Return the windows error code from a WindowsError or COMError
     instance."""
-    try:
-        code = exc[0]
+    if isinstance(exc, COMError):
+        return exc.hresult
+    elif isinstance(exc, WindowsError):
+        code = exc.winerror
         if isinstance(code, (int, long)):
             return code
-    except IndexError:
-        pass
-    # Sometimes, a WindowsError instance has no error code.  An access
-    # violation raised by ctypes has only text, for example.  In this
-    # cases we return a generic error code.
-    return E_FAIL
+        # Sometimes, a WindowsError instance has no error code.  An access
+        # violation raised by ctypes has only text, for example.  In this
+        # cases we return a generic error code.
+        return E_FAIL
+    raise TypeError("Expected comtypes.COMERROR or WindowsError instance, got %s" % type(exc).__name__)
 
 
 def _do_implement(interface_name, method_name):

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -275,8 +275,8 @@ def PumpEvents(timeout):
                                                                int(timeout * 1000),
                                                                len(handles), handles,
                                                                ctypes.byref(ctypes.c_ulong()))
-        except WindowsError, details:
-            if details.args[0] != RPC_S_CALLPENDING: # timeout expired
+        except WindowsError as details:
+            if details.winerror != RPC_S_CALLPENDING: # timeout expired
                 raise
         else:
             raise KeyboardInterrupt

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -275,7 +275,7 @@ def PumpEvents(timeout):
                                                                int(timeout * 1000),
                                                                len(handles), handles,
                                                                ctypes.byref(ctypes.c_ulong()))
-        except WindowsError as details:
+        except WindowsError, details:
             if details.winerror != RPC_S_CALLPENDING: # timeout expired
                 raise
         else:


### PR DESCRIPTION
fixes comtypes._comobj.winerror by no longer subscripting the exception. This pull requests makes this function use instance checking instead, raising a TypeError when the instance is neither COMError nor WindowsError.

Fixes #186

It also fixes comtypes.client.PumpEvents raising RPC_S_CALLPENDING.