### PR TITLE
Sets zip_safe flag in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ setup_params = dict(
         "comtypes.tools",
         "comtypes.test",
     ],
+    zip_safe=False
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
without the zip_safe set to False when setuptools installs the library
either using easy_install, setup_requires or install_requires these warnings
get produced. The issue lies in the use of a CI service like Appveyor, the
warnings are output using stderr and this triggers the build to fail.

```python
zip_safe flag not set; analyzing archive contents...
comtypes.__init__: module references __file__
comtypes.client._code_cache: module references __path__
comtypes.client._generate: module references __file__
comtypes.client._generate: module references __path__
comtypes.server.register: module references __file__
comtypes.test.TestComServer: module references __file__
comtypes.test.TestDispServer: module references __file__
comtypes.test.__init__: module references __path__
comtypes.test.test_dispinterface: module references __file__
comtypes.test.test_findgendir: module references __path__
comtypes.test.test_safearray: module references __file__
comtypes.test.test_server: module references __file__
comtypes.test.test_urlhistory: module references __file__
comtypes.test.test_win32com_interop: module references __file__
comtypes.tools.codegenerator: module references __path__
```