### PR TITLE
Remove Windows CE support

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -148,10 +148,7 @@ def CoInitialize():
 
 def CoInitializeEx(flags=None):
     if flags is None:
-        if os.name == "ce":
-            flags = getattr(sys, "coinit_flags", COINIT_MULTITHREADED)
-        else:
-            flags = getattr(sys, "coinit_flags", COINIT_APARTMENTTHREADED)
+        flags = getattr(sys, "coinit_flags", COINIT_APARTMENTTHREADED)
     logger.debug("CoInitializeEx(None, %s)", flags)
     _ole32.CoInitializeEx(None, flags)
 

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -275,12 +275,8 @@ _vtbl_types = {}
 ################################################################
 
 try:
-    if os.name == "ce":
-        _InterlockedIncrement = windll.coredll.InterlockedIncrement
-        _InterlockedDecrement = windll.coredll.InterlockedDecrement
-    else:
-        _InterlockedIncrement = windll.kernel32.InterlockedIncrement
-        _InterlockedDecrement = windll.kernel32.InterlockedDecrement
+    _InterlockedIncrement = windll.kernel32.InterlockedIncrement
+    _InterlockedDecrement = windll.kernel32.InterlockedDecrement
 except AttributeError:
     import threading
     _lock = threading.Lock()

--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -74,12 +74,8 @@ def _find_gen_dir():
 
 ################################################################
 
-if os.name == "ce":
-    SHGetSpecialFolderPath = ctypes.OleDLL("coredll").SHGetSpecialFolderPath
-    GetModuleFileName = ctypes.WinDLL("coredll").GetModuleFileNameW
-else:
-    SHGetSpecialFolderPath = ctypes.OleDLL("shell32.dll").SHGetSpecialFolderPathW
-    GetModuleFileName = ctypes.WinDLL("kernel32.dll").GetModuleFileNameW
+SHGetSpecialFolderPath = ctypes.OleDLL("shell32.dll").SHGetSpecialFolderPathW
+GetModuleFileName = ctypes.WinDLL("kernel32.dll").GetModuleFileNameW
 SHGetSpecialFolderPath.argtypes = [ctypes.c_ulong, ctypes.c_wchar_p,
                                    ctypes.c_int, ctypes.c_int]
 GetModuleFileName.restype = ctypes.c_ulong

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -7,13 +7,7 @@ import comtypes.tools.codegenerator
 import logging
 logger = logging.getLogger(__name__)
 
-if os.name == "ce":
-    # Windows CE has a hard coded PATH
-    # XXX Additionally there's an OEM path, plus registry settings.
-    # We don't currently use the latter.
-    PATH = ["\\Windows", "\\"]
-else:
-    PATH = os.environ["PATH"].split(os.pathsep)
+PATH = os.environ["PATH"].split(os.pathsep)
 
 def _my_import(fullname):
     # helper function to import dotted modules

--- a/comtypes/test/test_GUID.py
+++ b/comtypes/test/test_GUID.py
@@ -25,12 +25,6 @@ class Test(unittest.TestCase):
                                  GUID("{0002DF01-0000-0000-C000-000000000046}"))
             self.failUnlessEqual(GUID("{0002DF01-0000-0000-C000-000000000046}").as_progid(),
                                  u'InternetExplorer.Application.1')
-        elif os.name == "ce":
-            self.failUnlessEqual(GUID.from_progid("JScript"),
-                                 GUID("{f414c260-6ac0-11cf-b6d1-00aa00bbbb58}"))
-            self.failUnlessEqual(GUID("{f414c260-6ac0-11cf-b6d1-00aa00bbbb58}").as_progid(),
-                                 u'JScript')
-
 
         self.failIfEqual(GUID.create_new(), GUID.create_new())
 

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -39,13 +39,8 @@ class Test(unittest.TestCase):
 
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache
-        if os.name == "ce":
-            ma, mi = sys.version_info[:2]
-            path = r"%s\Python\Python%d%d\comtypes_cache" % \
-                       (_get_appdata_dir(), ma, mi)
-        else:
-            template = r"$APPDATA\Python\Python%d%d\comtypes_cache"
-            path = os.path.expandvars(template % sys.version_info[:2])
+        template = r"$APPDATA\Python\Python%d%d\comtypes_cache"
+        path = os.path.expandvars(template % sys.version_info[:2])
         gen_dir = comtypes.client._find_gen_dir()
         self.failUnlessEqual(path, gen_dir)
 

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -511,26 +511,11 @@ def CreateTypeLib(filename, syskind=SYS_WIN32):
     _oleaut32.CreateTypeLib2(syskind, c_wchar_p(filename), byref(ctlib))
     return ctlib
 
-if os.name == "ce":
-    # See also:
-    # http://blogs.msdn.com/larryosterman/archive/2006/01/09/510856.aspx
-    #
-    # windows CE does not have QueryPathOfRegTypeLib. Emulate by reading the registry:
-    def QueryPathOfRegTypeLib(libid, wVerMajor, wVerMinor, lcid=0):
-        "Return the path of a registered type library"
-        import _winreg
-        try:
-            hkey = _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, r"Typelib\%s\%s.%s\%x\win32" % (libid, wVerMajor, wVerMinor, lcid))
-        except WindowsError:
-            # On CE, some typelib names are not in the ..\win32 subkey:
-            hkey = _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, r"Typelib\%s\%s.%s\%x" % (libid, wVerMajor, wVerMinor, lcid))
-        return _winreg.QueryValueEx(hkey, "")[0]
-else:
-    def QueryPathOfRegTypeLib(libid, wVerMajor, wVerMinor, lcid=0):
-        "Return the path of a registered type library"
-        pathname = BSTR()
-        _oleaut32.QueryPathOfRegTypeLib(byref(GUID(libid)), wVerMajor, wVerMinor, lcid, byref(pathname))
-        return pathname.value.split("\0")[0]
+def QueryPathOfRegTypeLib(libid, wVerMajor, wVerMinor, lcid=0):
+    "Return the path of a registered type library"
+    pathname = BSTR()
+    _oleaut32.QueryPathOfRegTypeLib(byref(GUID(libid)), wVerMajor, wVerMinor, lcid, byref(pathname))
+    return pathname.value.split("\0")[0]
 
 ################################################################
 # Structures


### PR DESCRIPTION
I don't think the Windows CE kernel is supported by Microsoft any more. The latest release was 8.0 in 2013 according to Wikipedia (https://en.wikipedia.org/wiki/Windows_Embedded_Compact).

Python 3.6 and newer also no longer support Windows CE (https://docs.python.org/3.6/library/os.html#os.name).

I recommend to "Hide whitespace changes" when reviewing this PR.
![image](https://user-images.githubusercontent.com/2671400/84773497-c7531c00-afdc-11ea-8e10-fa0b2f2e989f.png)
