### PR TITLE
BUILD: End `bdist_wininst` support in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,8 +111,7 @@ class post_install(install):
 
     def run(self):
         install.run(self)
-        # Custom script we run at the end of installing - this is the same script
-        # run by bdist_wininst
+        # Custom script we run at the end of installing
         if not self.dry_run and not self.root:
             filename = os.path.join(self.install_scripts, "clear_comtypes_cache.py")
             if not os.path.isfile(filename):
@@ -124,8 +123,6 @@ class post_install(install):
             except subprocess.CalledProcessError:
                 print("Failed to run post install script!")
 
-
-options={"bdist_wininst": {"install_script": "clear_comtypes_cache.py"}}
 
 setup_params = dict(
     name="comtypes",
@@ -151,7 +148,6 @@ setup_params = dict(
     classifiers=classifiers,
 
     scripts=["clear_comtypes_cache.py"],
-    options=options,
 
     cmdclass={
         'test': test,


### PR DESCRIPTION
Fixes #191
Fixes #196 
Fixes #199 
Ref indygreg/PyOxidizer#202

I'll start with the post hoc justification for this change: `bdist_wininst` has been deprecated starting in Python 3.8. See
- notice:      https://docs.python.org/3/whatsnew/3.8.html#deprecated
- discussion:  https://discuss.python.org/t/deprecate-bdist-wininst/1929
- bug tracker: https://bugs.python.org/issue37481

The real reason for this change is that I can't seem to get around #199 when building a PyOxidizer package using PyOxidizer's `dist.pip_install` Skylark function. Upgrading Wheel to the latest version solves #199 for me in a regular virtual environment, but requiring the most recent Wheel version in my [`pyproject.toml`](https://www.python.org/dev/peps/pep-0518/)'s `build-system.requires` list doesn't solve #199. (Verbose output from Pip confirms the latest Wheel version is indeed installed.)

So removing `bdist_wininst` support solves my very niche problem, but because `bdist_wininst` is so rarely used and is deprecated anyway, I figure there's little harm to anyone else in removing it from comtypes.