### PR TITLE
Use absolute path to DLL before getting its timestamp (fix #222)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Comtypes CHANGELOG
 ==================
 
+Release 1.1.9
+-------------
+ * Fix loading module from relative path.
+ * Use comtypes release version in code generator version check.
+
 Release 1.1.8
 -------------
  * Fix No module named 'comtypes.gen.stdole'. Thanks @fxthomas.

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # comtypes version numbers follow semver (http://semver.org/) and PEP 440
-__version__ = "1.1.8"
+__version__ = "1.1.9"
 
 import logging
 class NullHandler(logging.Handler):

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -6,11 +6,12 @@ import keyword
 import ctypes
 
 from comtypes.tools import typedesc
+import comtypes
 import comtypes.client
 import comtypes.client._generate
 import comtypes.client._code_cache
 
-version = "$Rev$"[6:-2]
+version = comtypes.__version__
 
 __warn_on_munge__ = __debug__
 

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -261,12 +261,15 @@ class Generator(object):
         for line in wrapper.wrap(text):
             print >> self.output, line
 
-        # get full path to DLL first (os.stat can't work with relative DLL paths properly)
-        loaded_typelib = comtypes.typeinfo.LoadTypeLib(self.filename)
-        full_filename = comtypes.tools.tlbparser.get_tlib_filename(loaded_typelib)
+        tlib_mtime = None
+        if self.filename is not None:
+            # get full path to DLL first (os.stat can't work with relative DLL paths properly)
+            loaded_typelib = comtypes.typeinfo.LoadTypeLib(self.filename)
+            full_filename = comtypes.tools.tlbparser.get_tlib_filename(loaded_typelib)
 
-        # get DLL timestamp at the moment of wrapper generation
-        tlib_mtime = os.stat(full_filename).st_mtime
+            # get DLL timestamp at the moment of wrapper generation
+            tlib_mtime = os.stat(full_filename).st_mtime
+
         print >> self.output, "from comtypes import _check_version; _check_version(%r, %f)" % (version, tlib_mtime)
         return loops
 

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -9,7 +9,6 @@ from comtypes.tools import typedesc
 import comtypes
 import comtypes.client
 import comtypes.client._generate
-import comtypes.client._code_cache
 
 version = comtypes.__version__
 
@@ -263,8 +262,8 @@ class Generator(object):
             print >> self.output, line
 
         # get full path to DLL first (os.stat can't work with relative DLL paths properly)
-        dll = ctypes.OleDLL(self.filename)
-        full_filename = comtypes.client._code_cache._get_module_filename(dll._handle)
+        loaded_typelib = comtypes.typeinfo.LoadTypeLib(self.filename)
+        full_filename = comtypes.tools.tlbparser.get_tlib_filename(loaded_typelib)
 
         # get DLL timestamp at the moment of wrapper generation
         tlib_mtime = os.stat(full_filename).st_mtime

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -3,9 +3,12 @@
 import os
 import cStringIO
 import keyword
+import ctypes
+
 from comtypes.tools import typedesc
 import comtypes.client
 import comtypes.client._generate
+import comtypes.client._code_cache
 
 version = "$Rev$"[6:-2]
 
@@ -258,7 +261,12 @@ class Generator(object):
         for line in wrapper.wrap(text):
             print >> self.output, line
 
-        tlib_mtime = os.stat(self.filename).st_mtime
+        # get full path to DLL first (os.stat can't work with relative DLL paths properly)
+        dll = ctypes.OleDLL(self.filename)
+        full_filename = comtypes.client._code_cache._get_module_filename(dll._handle)
+
+        # get DLL timestamp at the moment of wrapper generation
+        tlib_mtime = os.stat(full_filename).st_mtime
         print >> self.output, "from comtypes import _check_version; _check_version(%r, %f)" % (version, tlib_mtime)
         return loops
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Operating System :: Microsoft :: Windows',
-    'Operating System :: Microsoft :: Windows :: Windows CE',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
PR #117 broken loading COM DLLs from relative path. This fix is tested with `UIAutomationCore.dll` which is located in the system path.