### PR TITLE
Workaround for Windows 7 bug in QueryPathOfRegTypeLib

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Comtypes CHANGELOG
 ==================
 
+Release 1.1.10
+-------------
+ * Fix loading module from relative path on Windows 7.
+
 Release 1.1.9
 -------------
  * Fix loading module from relative path.

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # comtypes version numbers follow semver (http://semver.org/) and PEP 440
-__version__ = "1.1.9"
+__version__ = "1.1.10"
 
 import logging
 class NullHandler(logging.Handler):

--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -5,6 +5,7 @@ comtypes.gen package and returns a directory where generated code can
 be written to.
 """
 import ctypes, logging, os, sys, tempfile, types
+from ctypes import wintypes
 logger = logging.getLogger(__name__)
 
 
@@ -79,7 +80,7 @@ GetModuleFileName = ctypes.WinDLL("kernel32.dll").GetModuleFileNameW
 SHGetSpecialFolderPath.argtypes = [ctypes.c_ulong, ctypes.c_wchar_p,
                                    ctypes.c_int, ctypes.c_int]
 GetModuleFileName.restype = ctypes.c_ulong
-GetModuleFileName.argtypes = [ctypes.c_ulong, ctypes.c_wchar_p, ctypes.c_ulong]
+GetModuleFileName.argtypes = [wintypes.HMODULE, ctypes.c_wchar_p, ctypes.c_ulong]
 
 CSIDL_APPDATA = 26
 MAX_PATH = 260

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -267,8 +267,11 @@ class Generator(object):
             loaded_typelib = comtypes.typeinfo.LoadTypeLib(self.filename)
             full_filename = comtypes.tools.tlbparser.get_tlib_filename(loaded_typelib)
 
-            # get DLL timestamp at the moment of wrapper generation
-            tlib_mtime = os.stat(full_filename).st_mtime
+            if full_filename is None:
+                tlib_mtime = 0
+            else:
+                # get DLL timestamp at the moment of wrapper generation
+                tlib_mtime = os.stat(full_filename).st_mtime
 
         print >> self.output, "from comtypes import _check_version; _check_version(%r, %f)" % (version, tlib_mtime)
         return loops


### PR DESCRIPTION
@nanonyme please test this fix on your Windows 7, especially on both 32-bit and 64-bit Python. @eltimen confirmed it works on his Windows 7.