### PR TITLE
Fix 64bit inproc server

### DIFF
--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -119,7 +119,7 @@ def DllGetClassObject(rclsid, riid, ppv):
         if not cls:
             return CLASS_E_CLASSNOTAVAILABLE
 
-        result = ClassFactory(cls).IUnknown_QueryInterface(None, ctypes.pointer(iid), ppv)
+        result = ClassFactory(cls).IUnknown_QueryInterface(None, ctypes.pointer(iid), ctypes.c_void_p(ppv))
         _debug("DllGetClassObject() -> %s", result)
         return result
     except Exception:


### PR DESCRIPTION
Passing memory address as int can fail with "int too long to convert" in 64bit python.
Casting it to c_void_p fixed the problem for me. Not sure whether this is the correct place for the conversion though.
Hopefully fixes #150, see the discussion for more details