### PR TITLE
Fix issue with timestamp errors when typelib DLL cannot be found

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -34,7 +34,7 @@ def _check_version(actual, tlib_cached_mtime=None):
             tlib_curr_mtime = os.stat(tlb_path).st_mtime
         except (OSError, TypeError):
             return
-        if not tlib_cached_mtime or abs(tlib_curr_mtime - tlib_cached_mtime) >= 1:
+        if tlib_cached_mtime is None or abs(tlib_curr_mtime - tlib_cached_mtime) >= 1:
             raise ImportError("Typelib different than module")
 
 try:

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -261,7 +261,7 @@ class Generator(object):
         for line in wrapper.wrap(text):
             print >> self.output, line
 
-        tlib_mtime = None
+        tlib_mtime = 0.0
         if self.filename is not None:
             # get full path to DLL first (os.stat can't work with relative DLL paths properly)
             loaded_typelib = comtypes.typeinfo.LoadTypeLib(self.filename)
@@ -270,6 +270,9 @@ class Generator(object):
             if full_filename is not None:
                 # get DLL timestamp at the moment of wrapper generation
                 tlib_mtime = os.stat(full_filename).st_mtime
+            else:
+                # Can't find the DLL, base time off of the TLB file
+                tlib_mtime = os.stat(self.filename).st_mtime
 
         print >> self.output, "from comtypes import _check_version; _check_version(%r, %f)" % (version, tlib_mtime)
         return loops


### PR DESCRIPTION
I still have the issue from #231 in that the committed fix resulted in a new error for me. My use case is I've hand generated a typelib file (TLB) and do not have a matching DLL that can be found and referenced.

```
  File "C:\scr\cli.py", line 1, in <module>
    from pybag import *
  File "C:\scr\myenv\lib\site-packages\pybag-2.2.1-py3.9.egg\pybag\__init__.py", line 26, in <module>
    from .pydbg      import DbgEng
  File "C:\scr\myenv\lib\site-packages\pybag-2.2.1-py3.9.egg\pybag\pydbg.py", line 7, in <module>
    from .dbgeng import core as DbgEng
  File "C:\scr\myenv\lib\site-packages\pybag-2.2.1-py3.9.egg\pybag\dbgeng\core.py", line 16, in <module>
    comtypes.client.GetModule(tlb)
  File "C:\scr\myenv\lib\site-packages\comtypes-1.1.10-py3.9.egg\comtypes\client\_generate.py", line 118, in GetModule
    mod = _CreateWrapper(tlib, pathname)
  File "C:\scr\myenv\lib\site-packages\comtypes-1.1.10-py3.9.egg\comtypes\client\_generate.py", line 183, in _CreateWrapper
    generate_module(tlib, ofi, pathname)
  File "C:\scr\myenv\lib\site-packages\comtypes-1.1.10-py3.9.egg\comtypes\tools\tlbparser.py", line 766, in generate_module
    gen.generate_code(list(items.values()), filename=pathname)
  File "C:\scr\myenv\lib\site-packages\comtypes-1.1.10-py3.9.egg\comtypes\tools\codegenerator.py", line 278, in generate_code
    print("from comtypes import _check_version; _check_version(%r, %f)" % (version, tlib_mtime), file=self.output)
TypeError: must be real number, not NoneType
````

In the process of the interface being generated, I added some debugging prints and observed the following:
```
self.filename=C:\scr\myenv\Lib\site-packages\Pybag-2.2.1-py3.9.egg\pybag\dbgeng\tlb\dbgeng.tlb
loaded_typelib=<POINTER(ITypeLib) ptr=0x1fed5838d20 at 1fed5ea8140>
full_filename=None
```

The issue is clearly that tlib_mtime was never set to anything other than None and the attempted string conversion to float failed. But even if we force this value to zero, then we are back to the same situation as issue #231.

From __init__.py
```python
        if not tlib_cached_mtime or abs(tlib_curr_mtime - tlib_cached_mtime) >= 1:
            raise ImportError("Typelib different than module")
```

So this pull request attempts to solve these issues. I'll admit I'm fairly unfamiliar with comtypes so I'm not sure if there are side effects of these changes that I'm unaware of.