### PR TITLE
Fix faulty logic - timestamping - another attempt!

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -1,8 +1,10 @@
 import types
 import os
 import sys
+import comtypes
 import comtypes.client
 import comtypes.tools.codegenerator
+import comtypes.tools.tlbparser
 import importlib
 
 import logging
@@ -27,6 +29,36 @@ def _name_module(tlib):
                libattr.wMajorVerNum,
                libattr.wMinorVerNum)
     return "comtypes.gen." + modname
+
+def _resolve_filename(tlib_string, dirpath):
+    """Tries to make sense of a type library specified as a string.
+    
+    Args:
+        tlib_string: type library designator
+        dirpath: a directory to relativize the location
+
+    Returns:
+
+      (abspath, True) or (relpath, False), 
+    
+    where relpath is an unresolved path."""
+    assert isinstance(tlib_string, basestring)
+    # pathname of type library
+    if os.path.isabs(tlib_string):
+        # a specific location
+        return tlib_string, True
+    elif dirpath:
+        abspath = os.path.normpath(os.path.join(dirpath, tlib_string))
+        if os.path.exists(abspath):
+            return abspath, True
+    # try with respect to cwd (if _getmodule executed from command line)
+    abspath = os.path.abspath(tlib_string)
+    if os.path.exists(abspath):
+        return abspath, True
+    # Otherwise it may still be that the file is on Windows search
+    # path for typelibs, and we leave the pathname alone.
+    return tlib_string, False
+
 
 def GetModule(tlib):
     """Create a module wrapping a COM typelibrary on demand.
@@ -71,23 +103,24 @@ def GetModule(tlib):
     """
     pathname = None
     if isinstance(tlib, basestring):
-        # pathname of type library
-        if not os.path.isabs(tlib):
-            # If a relative pathname is used, we try to interpret
-            # this pathname as relative to the callers __file__.
-            frame = sys._getframe(1)
-            _file_ = frame.f_globals.get("__file__", None)
-            if _file_ is not None:
-                directory = os.path.dirname(os.path.abspath(_file_))
-                abspath = os.path.normpath(os.path.join(directory, tlib))
-                # If the file does exist, we use it.  Otherwise it may
-                # still be that the file is on Windows search path for
-                # typelibs, and we leave the pathname alone.
-                if os.path.isfile(abspath):
-                    tlib = abspath
-        logger.debug("GetModule(%s)", tlib)
-        pathname = tlib
-        tlib = comtypes.typeinfo.LoadTypeLibEx(tlib)
+        tlib_string = tlib
+        # if a relative pathname is used, we try to interpret it relative to the 
+        # directory of the calling module (if not from command line)
+        frame = sys._getframe(1)
+        _file_ = frame.f_globals.get("__file__", None)
+        pathname, path_exists = _resolve_filename(tlib, _file_ and os.path.dirname(_file_))
+        logger.debug("GetModule(%s), resolved: %s", pathname, path_exists)
+        # in any case, attempt to load and if tlib_string is not valid, then raise
+        # as "OSError: [WinError -2147312566] Error loading type library/DLL"
+        tlib = comtypes.typeinfo.LoadTypeLibEx(pathname) # don't register
+        if not path_exists:
+            # try to get path after loading, but this only works if already registered            
+            pathname = comtypes.tools.tlbparser.get_tlib_filename(tlib)
+            if pathname is None:
+                logger.info("GetModule(%s): could not resolve to a filename", tlib)
+                pathname = tlib_string
+        # if above path torture resulted in an absolute path, then the file exists (at this point)!
+        assert not(os.path.isabs(pathname)) or os.path.exists(pathname)
     elif isinstance(tlib, comtypes.GUID):
         # tlib contain a clsid
         clsid = str(tlib)
@@ -156,7 +189,7 @@ def GetModule(tlib):
         importlib.invalidate_caches()
     return _my_import("comtypes.gen." + modulename)
 
-def _CreateWrapper(tlib, pathname=None):
+def _CreateWrapper(tlib, pathname):
     # helper which creates and imports the real typelib wrapper module.
     fullname = _name_module(tlib)
     try:

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -12,6 +12,9 @@ import comtypes.client._generate
 
 version = comtypes.__version__
 
+import logging
+logger = logging.getLogger(__name__)
+
 __warn_on_munge__ = __debug__
 
 
@@ -212,8 +215,12 @@ class Generator(object):
         parts2 = path2.split("\\")
         return "..\\" * len(parts2) + path1
 
-    def generate_code(self, items, filename=None):
-        self.filename = filename
+    def _generate_typelib_path(self, filename):
+        # NOTE: the logic in this function appears completely different from that
+        # of the handling of tlib (given as a string) in GetModule. There, relative 
+        # references are resolved wrt to the directory of the calling module. Here, 
+        # resolution is with respect to current working directory -- later to be 
+        # relativized to comtypes.gen.
         if filename is not None:
             # Hm, what is the CORRECT encoding?
             print >> self.output, "# -*- coding: mbcs -*-"
@@ -234,6 +241,10 @@ class Generator(object):
                 p = os.path.normpath(os.path.abspath(os.path.join(comtypes.gen.__path__[0],
                                                                   path)))
                 assert os.path.isfile(p)
+
+    def generate_code(self, items, filename):
+        self.filename = filename
+        self._generate_typelib_path(filename)
         print >> self.imports, "_lcid = 0 # change this if required"
         print >> self.imports, "from ctypes import *"
         items = set(items)
@@ -261,17 +272,12 @@ class Generator(object):
         for line in wrapper.wrap(text):
             print >> self.output, line
 
-        tlib_mtime = None
-        if self.filename is not None:
-            # get full path to DLL first (os.stat can't work with relative DLL paths properly)
-            loaded_typelib = comtypes.typeinfo.LoadTypeLib(self.filename)
-            full_filename = comtypes.tools.tlbparser.get_tlib_filename(loaded_typelib)
-
-            if full_filename is not None:
-                # get DLL timestamp at the moment of wrapper generation
-                tlib_mtime = os.stat(full_filename).st_mtime
-
-        print >> self.output, "from comtypes import _check_version; _check_version(%r, %f)" % (version, tlib_mtime)
+        if os.path.exists(filename):
+            tlib_mtime = os.stat(filename).st_mtime
+        else:
+            tlib_mtime = None
+        logger.debug("filename: \"%s\": tlib_mtime: %s", filename, tlib_mtime)
+        print >> self.output, "from comtypes import _check_version; _check_version(%r, %s)" % (version, tlib_mtime)
         return loops
 
     def type_name(self, t, generate=True):


### PR DESCRIPTION
Hi, may I kindly ask you for priority attention to the problems below? They have bugged the client side of comtypes for some time now. So I have to the best of my ability tried to analyze this in-depth. If I have a solution, then you'd be able to verify that it works without too much trouble I'd think.

My reading of the existing code is as follows. 

In GetModule, the pathname calculated https://github.com/enthought/comtypes/blob/8f3abc93c213fccdf9cae54aa88bfc1dfc17b8e9/comtypes/client/_generate.py#L70-L90
is absolute if the pathname can be resolved into an existing typelib on disk according to the directory of the calling module (when that directory exists). Otherwise, the pathname is relative, but may still be good if

 - it corresponds to a typelib in a file relative to cwd or 
 - it can be found with the default Windows typelib search path. 
 
This is confusing already because the two latter conditions are not separated; in both cases, a relative path is carried forward. 

But in all subcases of the outer `if` -- the initial tlib argument is a string -- the call:

https://github.com/enthought/comtypes/blob/8f3abc93c213fccdf9cae54aa88bfc1dfc17b8e9/comtypes/client/_generate.py#L90

is executed (with possible Windows exception).  [The "Ex" suffix here denotes that tlib is not being registered as a side-effect (as I understand it).]
 
In my proposed code, this distinction between the two cases above is made clearer with the flag `path_exists`; and most of this logic is moved to its own function  `_resolve_filename` for clarity.  Also, in the case of a path that corresponds to a file relative to cwd, the pathname is absolutized when carried forward. That ensures that a relative pathname is one that succeeds only by lookup in the default search path and for which no location was returned oracularly, that is, by `comtypes.tools.tlbparser.get_tlib_filename` . 

FOR THAT CASE ONLY IS THE TIMESTAMP NOT CHECKED (in the new code)! That is at least the idea.

To see this, we follow pathname. It is passed through _CreateWrapper https://github.com/enthought/comtypes/blob/8f3abc93c213fccdf9cae54aa88bfc1dfc17b8e9/comtypes/client/_generate.py#L159 to generate_module https://github.com/enthought/comtypes/blob/8f3abc93c213fccdf9cae54aa88bfc1dfc17b8e9/comtypes/tools/tlbparser.py#L736 to generate_code https://github.com/enthought/comtypes/blob/8f3abc93c213fccdf9cae54aa88bfc1dfc17b8e9/comtypes/tools/codegenerator.py#L215 where the current logic is https://github.com/enthought/comtypes/blob/8f3abc93c213fccdf9cae54aa88bfc1dfc17b8e9/comtypes/tools/codegenerator.py#L264-L274 

Thus,  the generated code will compare the future timestamp of pathname, now called filename, to the current timestamp, acquired by an os.stat on the filename. 

This code is problematic or wrong for several reasons I think:
- trivially, when tlib_mtime is None, the %-formatting in L274 fails, because None is not an "f", a float in %-formatting -- not good!
- the LoadTypeLib should be LoadTypeLibEx -- as it was in GetModule where the call was issued as LoadTypeLibEx (so as not to register) [I think]
- there is really no need to issue the call again I think
- if the typelib is not registered, then the subsequent call to get_tlib_filename will not return
  the filepath - that's another bug in my current opinion -- it means that timestamping will *not* be applied in such cases

My proposed patch should address all of these issues.

-----

So is my proposal correct? I don't know. The history here is a bad omen -- I think this PR may be the  fourth or fifth attempt at correcting the underlying unsoundness of the version control of the generated py file from the typelib file.

Also, I have not tested this except for playing around with test cases that look like this: (where I'm trying to get the tybelib of pyia2 to be wrapped)

 py -3.8-32 -c "from comtypes.client import GetModule; import logging; logging.getLogger().setLevel(logging.DEBUG); import comtypes.client._generate; comtypes.client._generate.logger.addHandler(logging.StreamHandler()); import comtypes.tools.codegenerator; comtypes.tools.codegenerator.logger.addHandler(logging.StreamHandler()); GetModule(r'C:\Users\fusen\AppData\Local\Programs\Python\Python38-32\Lib\site-packages\pyia2\ia2.tlb')"
