### PR TITLE
Python 3 build & install support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.eggs/
+build/
+*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .eggs/
-build/
 *.egg-info/
+build/
+dist/

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 """comtypes package install script"""
 import sys
 import os

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ except ImportError:
 with open('README') as readme_stream:
     readme = readme_stream.read()
 
+SETUPTOOLS_PY3_SUPPORT = "setuptools<=57.5.0"
+
+
 class test(Command):
     # Original version of this class posted
     # by Berthold Hoellmann to distutils-sig@python.org
@@ -124,7 +127,7 @@ class post_install(install):
 
 
 setup_params = dict(
-    name="comtypes",
+    name="comtypes-fork",
     description="Pure Python COM package",
     long_description = readme,
     author="Thomas Heller",
@@ -162,6 +165,10 @@ setup_params = dict(
         "comtypes.tools",
         "comtypes.test",
     ],
+    # Preserve Python 3 compatibility during building & installation with pip.
+    setup_requires=[SETUPTOOLS_PY3_SUPPORT,],
+    # Also trick pip to put the forked package replacement on top of the official one.
+    install_requires=[SETUPTOOLS_PY3_SUPPORT, "comtypes"],
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Installing this **comtypes-fork** package will replace the already existing **comtypes** Py2 one with its own Py3 flavour. (doesn't matter if **comtypes** isn't installed yet)

Drawback: each time we want to upgrade to a newer version of **comtypes**, we need to maintain in-sync this fork as well and publish the matching newer version.

Wheel to test with attached below. (should fix your broken env after install -- to be added in the next version of **rpaframework**)
[comtypes_fork-1.1.10-py3-none-any.whl.zip](https://github.com/enthought/comtypes/files/7882921/comtypes_fork-1.1.10-py3-none-any.whl.zip)
