### PR TITLE
Python 3 changes

### DIFF
--- a/comtypes/GUID.py
+++ b/comtypes/GUID.py
@@ -32,10 +32,10 @@ class GUID(Structure):
 
     def __init__(self, name=None):
         if name is not None:
-            _CLSIDFromString(unicode(name), byref(self))
+            _CLSIDFromString(str(name), byref(self))
 
     def __repr__(self):
-        return u'GUID("%s")' % unicode(self)
+        return 'GUID("%s")' % str(self)
 
     def __unicode__(self):
         p = c_wchar_p()
@@ -50,7 +50,7 @@ class GUID(Structure):
             return cmp(binary(self), binary(other))
         return -1
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self != GUID_null
 
     def __eq__(self, other):
@@ -62,7 +62,7 @@ class GUID(Structure):
         return hash(binary(self))
 
     def copy(self):
-        return GUID(unicode(self))
+        return GUID(str(self))
 
     def from_progid(cls, progid):
         """Get guid from progid, ...
@@ -71,11 +71,11 @@ class GUID(Structure):
             progid = progid._reg_clsid_
         if isinstance(progid, cls):
             return progid
-        elif isinstance(progid, basestring):
+        elif isinstance(progid, str):
             if progid.startswith("{"):
                 return cls(progid)
             inst = cls()
-            _CLSIDFromProgID(unicode(progid), byref(inst))
+            _CLSIDFromProgID(str(progid), byref(inst))
             return inst
         else:
             raise TypeError("Cannot construct guid from %r" % progid)

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -219,7 +219,7 @@ class tagVARIANT(Structure):
         if value is None:
             self.vt = VT_NULL
         elif (hasattr(value, '__len__') and len(value) == 0
-                and not isinstance(value, basestring)):
+                and not isinstance(value, str)):
             self.vt = VT_NULL
         # since bool is a subclass of int, this check must come before
         # the check for int
@@ -229,7 +229,7 @@ class tagVARIANT(Structure):
         elif isinstance(value, (int, c_int)):
             self.vt = VT_I4
             self._.VT_I4 = value
-        elif isinstance(value, long):
+        elif isinstance(value, int):
             u = self._
             # try VT_I4 first.
             u.VT_I4 = value
@@ -264,7 +264,7 @@ class tagVARIANT(Structure):
         elif isinstance(value, (float, c_double)):
             self.vt = VT_R8
             self._.VT_R8 = value
-        elif isinstance(value, (str, unicode)):
+        elif isinstance(value, str):
             self.vt = VT_BSTR
             # do the c_wchar_p auto unicode conversion
             self._.c_void_p = _SysAllocStringLen(value, len(value))
@@ -539,7 +539,7 @@ VARIANT.null = VARIANT(None)
 VARIANT.empty = VARIANT()
 VARIANT.missing = v = VARIANT()
 v.vt = VT_ERROR
-v._.VT_I4 = 0x80020004L
+v._.VT_I4 = 0x80020004
 del v
 
 _carg_obj = type(byref(c_int()))
@@ -583,7 +583,7 @@ class IEnumVARIANT(IUnknown):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         item, fetched = self.Next(1)
         if fetched:
             return item
@@ -773,7 +773,7 @@ class IDispatch(IUnknown):
         try:
             self.__com_Invoke(dispid, riid_null, _lcid, _invkind, byref(dp),
                               byref(result), byref(excepinfo), byref(argerr))
-        except COMError, err:
+        except COMError as err:
             (hresult, text, details) = err.args
             if hresult == DISP_E_EXCEPTION:
                 details = (excepinfo.bstrDescription, excepinfo.bstrSource,
@@ -867,7 +867,7 @@ _ctype_to_vartype = {
     }
 
 _vartype_to_ctype = {}
-for c, v in _ctype_to_vartype.iteritems():
+for c, v in _ctype_to_vartype.items():
     _vartype_to_ctype[v] = c
 _vartype_to_ctype[VT_INT] = _vartype_to_ctype[VT_I4]
 _vartype_to_ctype[VT_UINT] = _vartype_to_ctype[VT_UI4]

--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -104,7 +104,7 @@ def _create_comtypes_gen_package():
                 ofi = open(comtypes_init, "w")
                 ofi.write("# comtypes.gen package, directory for generated files.\n")
                 ofi.close()
-        except (OSError, IOError), details:
+        except (OSError, IOError) as details:
             logger.info("Creating comtypes.gen package failed: %s", details)
             module = sys.modules["comtypes.gen"] = types.ModuleType("comtypes.gen")
             comtypes.gen = module

--- a/comtypes/client/dynamic.py
+++ b/comtypes/client/dynamic.py
@@ -118,7 +118,7 @@ class _Dispatch(object):
         flags = comtypes.automation.DISPATCH_PROPERTYGET
         try:
             result = self._comobj.Invoke(dispid, _invkind=flags)
-        except COMError, err:
+        except COMError as err:
             (hresult, text, details) = err.args
             if hresult in ERRORS_BAD_CONTEXT:
                 result = MethodCaller(dispid, self)
@@ -153,7 +153,7 @@ class _Collection(object):
     def __init__(self, enum):
         self.enum = enum
 
-    def next(self):
+    def __next__(self):
         item, fetched = self.enum.Next(1)
         if fetched:
             return item

--- a/comtypes/connectionpoints.py
+++ b/comtypes/connectionpoints.py
@@ -26,7 +26,7 @@ class IEnumConnections(IUnknown):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         cp, fetched = self.Next(1)
         if fetched == 0:
             raise StopIteration
@@ -39,7 +39,7 @@ class IEnumConnectionPoints(IUnknown):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         cp, fetched = self.Next(1)
         if fetched == 0:
             raise StopIteration

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -73,7 +73,7 @@ def ReportError(text, iid,
     if helpcontext is not None:
         ei.SetHelpContext(helpcontext)
     if clsid is not None:
-        if isinstance(clsid, basestring):
+        if isinstance(clsid, str):
             clsid = GUID(clsid)
         try:
             progid = clsid.as_progid()

--- a/comtypes/logutil.py
+++ b/comtypes/logutil.py
@@ -9,13 +9,13 @@ class NTDebugHandler(logging.Handler):
         if isinstance(text, str):
             writeA(text + "\n")
         else:
-            writeW(text + u"\n")
+            writeW(text + "\n")
 logging.NTDebugHandler = NTDebugHandler
 
 def setup_logging(*pathnames):
-    import ConfigParser
+    import configparser
 
-    parser = ConfigParser.ConfigParser()
+    parser = configparser.ConfigParser()
     parser.optionxform = str # use case sensitive option names!
 
     parser.read(pathnames)
@@ -27,7 +27,7 @@ def setup_logging(*pathnames):
     def get(section, option):
         try:
             return parser.get(section, option, True)
-        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+        except (configparser.NoOptionError, configparser.NoSectionError):
             return DEFAULTS[option]
 
     levelname = get("logging", "level")
@@ -47,5 +47,5 @@ def setup_logging(*pathnames):
         for name, value in parser.items("logging.levels", True):
             value = getattr(logging, value)
             logging.getLogger(name).setLevel(value)
-    except ConfigParser.NoSectionError:
+    except configparser.NoSectionError:
         pass

--- a/comtypes/messageloop.py
+++ b/comtypes/messageloop.py
@@ -39,7 +39,7 @@ class _MessageLoop(object):
                 DispatchMessage(lpmsg)
 
     def filter_message(self, lpmsg):
-        return any(filter(lpmsg) for filter in self._filters)
+        return any(list(filter(lpmsg)) for filter in self._filters)
 
 _messageloop = _MessageLoop()
 

--- a/comtypes/patcher.py
+++ b/comtypes/patcher.py
@@ -52,7 +52,7 @@ class Patch(object):
         self.target = target
 
     def __call__(self, patches):
-        for name, value in vars(patches).items():
+        for name, value in list(vars(patches).items()):
             if name in vars(ReferenceEmptyClass):
                 continue
             no_replace = getattr(value, '__no_replace', False)

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -35,7 +35,7 @@ class _SafeArrayAsNdArrayContextManager(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.thread_local.count -= 1
 
-    def __nonzero__(self):
+    def __bool__(self):
         '''True if context manager is currently entered on given thread.
 
         '''
@@ -308,7 +308,7 @@ def _make_safearray_type(itemtype):
                         # XXX Only try to convert types known to
                         #     numpy.ctypeslib.
                         if (safearray_as_ndarray and self._itemtype_ in
-                                npsupport.typecodes.values()):
+                                list(npsupport.typecodes.values())):
                             arr = numpy.ctypeslib.as_array(ptr,
                                                            (num_elements,))
                             return arr.copy()

--- a/comtypes/server/automation.py
+++ b/comtypes/server/automation.py
@@ -28,7 +28,7 @@ class VARIANTEnumerator(COMObject):
         pCeltFetched[0] = 0
         try:
             for index in range(celt):
-                item = self.seq.next()
+                item = next(self.seq)
                 p = item.QueryInterface(IDispatch)
                 rgVar[index].value = p
                 pCeltFetched[0] += 1
@@ -47,7 +47,7 @@ class VARIANTEnumerator(COMObject):
         # skip some elements.
         try:
             for _ in range(celt):
-                self.seq.next()
+                next(self.seq)
         except StopIteration:
             return S_FALSE
         return S_OK

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -58,10 +58,10 @@ class ConnectionPointImpl(COMObject):
         if hasattr(self._sink_interface, "Invoke"):
             # for better performance, we could cache the dispids.
             dispid = self._typeinfo.GetIDsOfNames(name)[0]
-            for key, p in self._connections.items():
+            for key, p in list(self._connections.items()):
                 try:
                     result = p.Invoke(dispid, *args, **kw)
-                except COMError, details:
+                except COMError as details:
                     if details.hresult == -2147023174:
                         logger.warning("_call_sinks(%s, %s, *%s, **%s) failed; removing connection",
                                        self, name, args, kw,
@@ -76,10 +76,10 @@ class ConnectionPointImpl(COMObject):
                 else:
                     results.append(result)
         else:
-            for p in self._connections.values():
+            for p in list(self._connections.values()):
                 try:
                     result = getattr(p, name)(*args, **kw)
-                except COMError, details:
+                except COMError as details:
                     if details.hresult == -2147023174:
                         logger.warning("_call_sinks(%s, %s, *%s, **%s) failed; removing connection",
                                        self, name, args, kw,

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -3,7 +3,7 @@ import comtypes
 from comtypes.hresult import *
 from comtypes.server import IClassFactory
 import logging
-import Queue
+import queue
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -36,7 +36,7 @@ Now, debug the object, and when done delete logging info:
   python mycomobj.py /nodebug
 """
 import sys, os
-import _winreg
+import winreg
 import logging
 
 import comtypes
@@ -68,9 +68,9 @@ except NameError:
     from sets import Set #as set
 
 
-_KEYS = {_winreg.HKEY_CLASSES_ROOT: "HKCR",
-         _winreg.HKEY_LOCAL_MACHINE: "HKLM",
-         _winreg.HKEY_CURRENT_USER: "HKCU"}
+_KEYS = {winreg.HKEY_CLASSES_ROOT: "HKCR",
+         winreg.HKEY_LOCAL_MACHINE: "HKLM",
+         winreg.HKEY_CURRENT_USER: "HKCU"}
 
 def _explain(hkey):
     return _KEYS.get(hkey, hkey)
@@ -89,10 +89,10 @@ class Registrar(object):
         clsid = cls._reg_clsid_
         try:
             _debug('DeleteKey( %s\\CLSID\\%s\\Logging"' % \
-                    (_explain(_winreg.HKEY_CLASSES_ROOT), clsid))
-            hkey = _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, r"CLSID\%s" % clsid)
-            _winreg.DeleteKey(hkey, "Logging")
-        except WindowsError, detail:
+                    (_explain(winreg.HKEY_CLASSES_ROOT), clsid))
+            hkey = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s" % clsid)
+            winreg.DeleteKey(hkey, "Logging")
+        except WindowsError as detail:
             if get_winerror(detail) != 2:
                 raise
 
@@ -102,22 +102,22 @@ class Registrar(object):
         # format
         clsid = cls._reg_clsid_
         _debug('CreateKey( %s\\CLSID\\%s\\Logging"' % \
-                (_explain(_winreg.HKEY_CLASSES_ROOT), clsid))
-        hkey = _winreg.CreateKey(_winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\Logging" % clsid)
+                (_explain(winreg.HKEY_CLASSES_ROOT), clsid))
+        hkey = winreg.CreateKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\Logging" % clsid)
         for item in levels:
             name, value = item.split("=")
             v = getattr(logging, value)
             assert isinstance(v, int)
         _debug('SetValueEx(levels, %s)' % levels)
-        _winreg.SetValueEx(hkey, "levels", None, _winreg.REG_MULTI_SZ, levels)
+        winreg.SetValueEx(hkey, "levels", None, winreg.REG_MULTI_SZ, levels)
         if format:
             _debug('SetValueEx(format, %s)' % format)
-            _winreg.SetValueEx(hkey, "format", None, _winreg.REG_SZ, format)
+            winreg.SetValueEx(hkey, "format", None, winreg.REG_SZ, format)
         else:
             _debug('DeleteValue(format)')
             try:
-                _winreg.DeleteValue(hkey, "format")
-            except WindowsError, detail:
+                winreg.DeleteValue(hkey, "format")
+            except WindowsError as detail:
                 if get_winerror(detail) != 2:
                     raise
 
@@ -141,8 +141,8 @@ class Registrar(object):
         for hkey, subkey, valuename, value in table:
             _debug ('[%s\\%s]', _explain(hkey), subkey)
             _debug('%s="%s"', valuename or "@", value)
-            k = _winreg.CreateKey(hkey, subkey)
-            _winreg.SetValueEx(k, valuename, None, _winreg.REG_SZ, str(value))
+            k = winreg.CreateKey(hkey, subkey)
+            winreg.SetValueEx(k, valuename, None, winreg.REG_SZ, str(value))
 
         tlib = getattr(cls, "_reg_typelib_", None)
         if tlib is not None:
@@ -185,8 +185,8 @@ class Registrar(object):
                     SHDeleteKey(hkey, subkey)
                 else:
                     _debug("DeleteKey %s\\%s", _explain(hkey), subkey)
-                    _winreg.DeleteKey(hkey, subkey)
-            except WindowsError, detail:
+                    winreg.DeleteKey(hkey, subkey)
+            except WindowsError as detail:
                 if get_winerror(detail) != 2:
                     raise
         tlib = getattr(cls, "_reg_typelib_", None)
@@ -194,7 +194,7 @@ class Registrar(object):
             try:
                 _debug("UnRegisterTypeLib(%s, %s, %s)", *tlib)
                 UnRegisterTypeLib(*tlib)
-            except WindowsError, detail:
+            except WindowsError as detail:
                 if not get_winerror(detail) in (TYPE_E_REGISTRYACCESS, TYPE_E_CANTLOADLIBRARY):
                     raise
         _debug("Done")
@@ -243,7 +243,7 @@ class Registrar(object):
         Note that the first part of the progid string is typically the
         IDL library name of the type library containing the coclass.
         """
-        HKCR = _winreg.HKEY_CLASSES_ROOT
+        HKCR = winreg.HKEY_CLASSES_ROOT
 
         # table format: rootkey, subkey, valuename, value
         table = []

--- a/comtypes/shelllink.py
+++ b/comtypes/shelllink.py
@@ -185,7 +185,7 @@ class IShellLinkW(IUnknown):
         return buf.value, iIcon.value
 
 class ShellLink(CoClass):
-    u'ShellLink class'
+    'ShellLink class'
     _reg_clsid_ = GUID('{00021401-0000-0000-C000-000000000046}')
     _idlflags_ = []
     _com_interfaces_ = [IShellLinkW, IShellLinkA]
@@ -201,7 +201,7 @@ if __name__ == "__main__":
 
 
     shortcut = CreateObject(ShellLink)
-    print shortcut
+    print(shortcut)
     ##help(shortcut)
 
     shortcut.SetPath(sys.executable)
@@ -209,9 +209,9 @@ if __name__ == "__main__":
     shortcut.SetDescription("Python %s" % sys.version)
     shortcut.SetIconLocation(sys.executable, 1)
 
-    print shortcut.GetPath(2)
-    print shortcut.GetIconLocation()
+    print(shortcut.GetPath(2))
+    print(shortcut.GetIconLocation())
 
     pf = shortcut.QueryInterface(IPersistFile)
     pf.Save("foo.lnk", True)
-    print pf.GetCurFile()
+    print(pf.GetCurFile())

--- a/comtypes/test/TestComServer.py
+++ b/comtypes/test/TestComServer.py
@@ -115,7 +115,7 @@ class TestComServer(
     def ITestComServer_Exec2(self, what):
         exec(what)
 
-    _name = u"spam, spam, spam"
+    _name = "spam, spam, spam"
 
     def _get_name(self):
         return self._name
@@ -147,4 +147,4 @@ if __name__ == "__main__":
     except Exception:
         import traceback
         traceback.print_exc()
-        raw_input()
+        input()

--- a/comtypes/test/TestDispServer.py
+++ b/comtypes/test/TestDispServer.py
@@ -82,7 +82,7 @@ class TestDispServer(
     def DTestDispServer_Exec2(self, what):
         exec(what)
 
-    _name = u"spam, spam, spam"
+    _name = "spam, spam, spam"
 
     # Implementation of the DTestDispServer::Name propget
     def DTestDispServer__get_name(self, this, pname):

--- a/comtypes/test/__init__.py
+++ b/comtypes/test/__init__.py
@@ -73,7 +73,7 @@ def find_package_modules(package, mask):
     if hasattr(package, "__loader__"):
         path = package.__name__.replace(".", os.path.sep)
         mask = os.path.join(path, mask)
-        for fnm in package.__loader__._files.iterkeys():
+        for fnm in package.__loader__._files.keys():
             if fnmatch.fnmatchcase(fnm, mask):
                 yield os.path.splitext(fnm)[0].replace(os.path.sep, ".")
     else:
@@ -89,13 +89,13 @@ def get_tests(package, mask, verbosity):
     for modname in find_package_modules(package, mask):
         try:
             mod = __import__(modname, globals(), locals(), ['*'])
-        except ResourceDenied, detail:
+        except ResourceDenied as detail:
             skipped.append(modname)
             if verbosity > 1:
-                print >> sys.stderr, "Skipped %s: %s" % (modname, detail)
+                print("Skipped %s: %s" % (modname, detail), file=sys.stderr)
             continue
-        except Exception, detail:
-            print >> sys.stderr, "Warning: could not import %s: %s" % (modname, detail)
+        except Exception as detail:
+            print("Warning: could not import %s: %s" % (modname, detail), file=sys.stderr)
             continue
         for name in dir(mod):
             if name.startswith("_"):
@@ -110,7 +110,7 @@ def get_tests(package, mask, verbosity):
     return skipped, tests
 
 def usage():
-    print __doc__
+    print(__doc__)
     return 1
 
 def test_with_refcounts(runner, verbosity, testcase):
@@ -141,10 +141,10 @@ def test_with_refcounts(runner, verbosity, testcase):
         runner.run(test)
         cleanup()
         refcounts[i] = sys.gettotalrefcount() - rc
-    if filter(None, refcounts):
-        print "%s leaks:\n\t" % testcase, refcounts
+    if [_f for _f in refcounts if _f]:
+        print("%s leaks:\n\t" % testcase, refcounts)
     elif verbosity:
-        print "%s: ok." % testcase
+        print("%s: ok." % testcase)
 
 class TestRunner(unittest.TextTestRunner):
     def run(self, test, skipped):
@@ -160,7 +160,7 @@ class TestRunner(unittest.TextTestRunner):
         self.stream.writeln(result.separator2)
         run = result.testsRun
         if _unavail: #skipped:
-            requested = _unavail.keys()
+            requested = list(_unavail.keys())
             requested.sort()
             self.stream.writeln("Ran %d test%s in %.3fs (%s module%s skipped)" %
                                 (run, run != 1 and "s" or "", timeTaken,
@@ -173,7 +173,7 @@ class TestRunner(unittest.TextTestRunner):
         self.stream.writeln()
         if not result.wasSuccessful():
             self.stream.write("FAILED (")
-            failed, errored = map(len, (result.failures, result.errors))
+            failed, errored = list(map(len, (result.failures, result.errors)))
             if failed:
                 self.stream.write("failures=%d" % failed)
             if errored:
@@ -226,7 +226,7 @@ def run(args = []):
             try:
                 sys.gettotalrefcount
             except AttributeError:
-                print >> sys.stderr, "-r flag requires Python debug build"
+                print("-r flag requires Python debug build", file=sys.stderr)
                 return -1
             search_leaks = True
         elif flag == "-u":

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -20,7 +20,7 @@ class PROCESS_MEMORY_COUNTERS(Structure):
 
     def dump(self):
         for n, _ in self._fields_[2:]:
-            print n, getattr(self, n)/1e6
+            print(n, getattr(self, n)/1e6)
 
 try:
     windll.psapi.GetProcessMemoryInfo.argtypes = (HANDLE, POINTER(PROCESS_MEMORY_COUNTERS), DWORD)
@@ -41,8 +41,8 @@ else:
     def find_memleak(func, loops=LOOPS):
         # call 'func' several times, so that memory consumption
         # stabilizes:
-        for j in xrange(loops[0]):
-            for k in xrange(loops[1]):
+        for j in range(loops[0]):
+            for k in range(loops[1]):
                 func()
         gc.collect(); gc.collect(); gc.collect()
         bytes = wss()
@@ -50,8 +50,8 @@ else:
         # memory consumption before and after the call.  Repeat this a
         # few times, and return a list containing the memory
         # consumption differences.
-        for j in xrange(loops[0]):
-            for k in xrange(loops[1]):
+        for j in range(loops[0]):
+            for k in range(loops[1]):
                 func()
         gc.collect(); gc.collect(); gc.collect()
         # return the increased in process size

--- a/comtypes/test/test_BSTR.py
+++ b/comtypes/test/test_BSTR.py
@@ -10,18 +10,18 @@ from comtypes.test.find_memleak import find_memleak
 class Test(unittest.TestCase):
     def check_leaks(self, func, limit=0):
         bytes = find_memleak(func)
-        self.failIf(bytes > limit, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes > limit, "Leaks %d bytes" % bytes)
 
     def test_creation(self):
         def doit():
-            BSTR(u"abcdef" * 100)
+            BSTR("abcdef" * 100)
         # It seems this test is unreliable.  Sometimes it leaks 4096
         # bytes, sometimes not.  Try to workaround that...
         self.check_leaks(doit, limit=4096)
 
     def test_from_param(self):
         def doit():
-            BSTR.from_param(u"abcdef")
+            BSTR.from_param("abcdef")
         self.check_leaks(doit)
 
     def test_paramflags(self):
@@ -30,9 +30,9 @@ class Test(unittest.TestCase):
         func.restype = c_void_p
         func.argtypes = (BSTR, )
         def doit():
-            func(u"abcdef")
-            func(u"abc xyz")
-            func(BSTR(u"abc def"))
+            func("abcdef")
+            func("abc xyz")
+            func(BSTR("abc def"))
         self.check_leaks(doit)
 
     def test_inargs(self):
@@ -40,11 +40,11 @@ class Test(unittest.TestCase):
         SysStringLen.argtypes = BSTR,
         SysStringLen.restype = c_uint
 
-        self.failUnlessEqual(SysStringLen("abc xyz"), 7)
+        self.assertEqual(SysStringLen("abc xyz"), 7)
         def doit():
             SysStringLen("abc xyz")
-            SysStringLen(u"abc xyz")
-            SysStringLen(BSTR(u"abc def"))
+            SysStringLen("abc xyz")
+            SysStringLen(BSTR("abc def"))
         self.check_leaks(doit)
 
 if __name__ == "__main__":

--- a/comtypes/test/test_DISPPARAMS.py
+++ b/comtypes/test/test_DISPPARAMS.py
@@ -8,7 +8,7 @@ class TestCase(ut.TestCase):
         dp.rgvarg = (VARIANT * 3)()
 
         for i in range(3):
-            self.failUnlessEqual(dp.rgvarg[i].value, None)
+            self.assertEqual(dp.rgvarg[i].value, None)
 
         dp.rgvarg[0].value = 42
         dp.rgvarg[1].value = "spam"
@@ -16,7 +16,7 @@ class TestCase(ut.TestCase):
 
         # damn, there's still this old bug!
 
-        self.failUnlessEqual(dp.rgvarg[0].value, 42)
+        self.assertEqual(dp.rgvarg[0].value, 42)
         # these fail:
 ##        self.failUnlessEqual(dp.rgvarg[1].value, "spam")
 ##        self.failUnlessEqual(dp.rgvarg[2].value, "foo")
@@ -28,14 +28,14 @@ class TestCase(ut.TestCase):
         args = [42, None, "foo"]
 
         dp = DISPPARAMS()
-        dp.rgvarg = (VARIANT * 3)(*map(VARIANT, args[::-1]))
+        dp.rgvarg = (VARIANT * 3)(*list(map(VARIANT, args[::-1])))
 
         import gc
         gc.collect()
 
-        self.failUnlessEqual(dp.rgvarg[0].value, 42)
-        self.failUnlessEqual(dp.rgvarg[1].value, "spam")
-        self.failUnlessEqual(dp.rgvarg[2].value, "foo")
+        self.assertEqual(dp.rgvarg[0].value, 42)
+        self.assertEqual(dp.rgvarg[1].value, "spam")
+        self.assertEqual(dp.rgvarg[2].value, "foo")
 
 if __name__ == "__main__":
     ut.main()

--- a/comtypes/test/test_GUID.py
+++ b/comtypes/test/test_GUID.py
@@ -4,13 +4,13 @@ from comtypes import GUID
 
 class Test(unittest.TestCase):
     def test(self):
-        self.failUnlessEqual(GUID(), GUID())
-        self.failUnlessEqual(GUID("{00000000-0000-0000-C000-000000000046}"),
+        self.assertEqual(GUID(), GUID())
+        self.assertEqual(GUID("{00000000-0000-0000-C000-000000000046}"),
                              GUID("{00000000-0000-0000-C000-000000000046}"))
 
-        self.failUnlessEqual(str(GUID("{0002DF01-0000-0000-C000-000000000046}")),
+        self.assertEqual(str(GUID("{0002DF01-0000-0000-C000-000000000046}")),
                              "{0002DF01-0000-0000-C000-000000000046}")
-        self.failUnlessEqual(repr(GUID("{0002DF01-0000-0000-C000-000000000046}")),
+        self.assertEqual(repr(GUID("{0002DF01-0000-0000-C000-000000000046}")),
                              'GUID("{0002DF01-0000-0000-C000-000000000046}")')
 
         self.assertRaises(WindowsError, GUID, "abc")
@@ -21,12 +21,12 @@ class Test(unittest.TestCase):
 
 
         if os.name == "nt":
-            self.failUnlessEqual(GUID.from_progid("InternetExplorer.Application"),
+            self.assertEqual(GUID.from_progid("InternetExplorer.Application"),
                                  GUID("{0002DF01-0000-0000-C000-000000000046}"))
-            self.failUnlessEqual(GUID("{0002DF01-0000-0000-C000-000000000046}").as_progid(),
-                                 u'InternetExplorer.Application.1')
+            self.assertEqual(GUID("{0002DF01-0000-0000-C000-000000000046}").as_progid(),
+                                 'InternetExplorer.Application.1')
 
-        self.failIfEqual(GUID.create_new(), GUID.create_new())
+        self.assertNotEqual(GUID.create_new(), GUID.create_new())
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_QueryService.py
+++ b/comtypes/test/test_QueryService.py
@@ -21,7 +21,7 @@ class TestCase(unittest.TestCase):
         ie.navigate2("about:blank", 0)
         sp = ie.Document.Body.QueryInterface(comtypes.IServiceProvider)
         pacc = sp.QueryService(IAccessible._iid_, IAccessible)
-        self.failUnlessEqual(type(pacc), POINTER(IAccessible))
+        self.assertEqual(type(pacc), POINTER(IAccessible))
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_agilent.py
+++ b/comtypes/test/test_agilent.py
@@ -24,7 +24,7 @@ else:
             # the OANOCACHE environ variable is set.
             import os
             if "OANOCACHE" in os.environ:
-                print "Cannot test. buggy COM object?"
+                print("Cannot test. buggy COM object?")
                 return
 
             # Initialize the driver in simulation mode.  Resource descriptor is ignored.
@@ -72,17 +72,18 @@ else:
             self._check_result(pMeasurement.ReadWaveform(20000, psaWaveform))
             self._check_result(pMeasurement.ReadWaveform(20000, pXIncrement=9.0))
 
-        def _check_result(self, (array, initial_x, x_increment)):
+        def _check_result(self, xxx_todo_changeme):
             # ReadWaveform, in simulation mode, returns three values:
             #
             # - a safearray containing 100 random double values,
             #   unpacked and returned as tuple
             # - the initial_x value: 0.0
             # - the x_increment value: 0.0
-            self.failUnlessEqual(len(array), 100)
-            self.failIf([x for x in array if not isinstance(x, float)])
-            self.failUnlessEqual(initial_x, 0.0)
-            self.failUnlessEqual(x_increment, 0.0)
+            (array, initial_x, x_increment) = xxx_todo_changeme
+            self.assertEqual(len(array), 100)
+            self.assertFalse([x for x in array if not isinstance(x, float)])
+            self.assertEqual(initial_x, 0.0)
+            self.assertEqual(x_increment, 0.0)
 
 
 

--- a/comtypes/test/test_avmc.py
+++ b/comtypes/test/test_avmc.py
@@ -11,17 +11,17 @@ class Test(unittest.TestCase):
         # This returns an array (a list) of DeviceInfo records.
         devs = avmc.FindAllAvmc()
         
-        self.failUnlessEqual(devs[0].Flags, 12)
-        self.failUnlessEqual(devs[0].ID, 13)
-        self.failUnlessEqual(devs[0].LocId, 14)
-        self.failUnlessEqual(devs[0].Description, "Avmc")
-        self.failUnlessEqual(devs[0].SerialNumber, "1234")
+        self.assertEqual(devs[0].Flags, 12)
+        self.assertEqual(devs[0].ID, 13)
+        self.assertEqual(devs[0].LocId, 14)
+        self.assertEqual(devs[0].Description, "Avmc")
+        self.assertEqual(devs[0].SerialNumber, "1234")
 
-        self.failUnlessEqual(devs[1].Flags, 22)
-        self.failUnlessEqual(devs[1].ID, 23)
-        self.failUnlessEqual(devs[1].LocId, 24)
-        self.failUnlessEqual(devs[1].Description, "Avmc2")
-        self.failUnlessEqual(devs[1].SerialNumber, "5678")
+        self.assertEqual(devs[1].Flags, 22)
+        self.assertEqual(devs[1].ID, 23)
+        self.assertEqual(devs[1].LocId, 24)
+        self.assertEqual(devs[1].Description, "Avmc2")
+        self.assertEqual(devs[1].SerialNumber, "5678")
 
 ##        # Leaks... where?
 ##        def doit():
@@ -30,7 +30,7 @@ class Test(unittest.TestCase):
 
     def check_leaks(self, func, limit=0):
         bytes = find_memleak(func)
-        self.failIf(bytes > limit, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes > limit, "Leaks %d bytes" % bytes)
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -12,72 +12,72 @@ def method_count(interface):
 class BasicTest(ut.TestCase):
     def test_IUnknown(self):
         from comtypes import IUnknown
-        self.failUnlessEqual(method_count(IUnknown), 3)
+        self.assertEqual(method_count(IUnknown), 3)
 
     def test_release(self):
         POINTER(IUnknown)()
 
     def test_refcounts(self):
         p = POINTER(IUnknown)()
-        windll.oleaut32.CreateTypeLib2(1, u"blabla", byref(p))
+        windll.oleaut32.CreateTypeLib2(1, "blabla", byref(p))
         # initial refcount is 2
         for i in range(2, 10):
-            self.failUnlessEqual(p.AddRef(), i)
+            self.assertEqual(p.AddRef(), i)
         for i in range(8, 0, -1):
-            self.failUnlessEqual(p.Release(), i)
+            self.assertEqual(p.Release(), i)
 
     def test_qi(self):
         p = POINTER(IUnknown)()
-        windll.oleaut32.CreateTypeLib2(1, u"blabla", byref(p))
-        self.failUnlessEqual(p.AddRef(), 2)
-        self.failUnlessEqual(p.Release(), 1)
+        windll.oleaut32.CreateTypeLib2(1, "blabla", byref(p))
+        self.assertEqual(p.AddRef(), 2)
+        self.assertEqual(p.Release(), 1)
 
         other = p.QueryInterface(IUnknown)
-        self.failUnlessEqual(other.AddRef(), 3)
-        self.failUnlessEqual(p.AddRef(), 4)
-        self.failUnlessEqual(p.Release(), 3)
-        self.failUnlessEqual(other.Release(), 2)
+        self.assertEqual(other.AddRef(), 3)
+        self.assertEqual(p.AddRef(), 4)
+        self.assertEqual(p.Release(), 3)
+        self.assertEqual(other.Release(), 2)
 
         del p # calls p.Release()
 
-        self.failUnlessEqual(other.AddRef(), 2)
-        self.failUnlessEqual(other.Release(), 1)
+        self.assertEqual(other.AddRef(), 2)
+        self.assertEqual(other.Release(), 1)
 
     def test_derived(self):
         # XXX leaks 50 refs
-        self.failUnlessEqual(method_count(IUnknown), 3)
+        self.assertEqual(method_count(IUnknown), 3)
 
         class IMyInterface(IUnknown):
             pass
 
-        self.failUnlessEqual(method_count(IMyInterface), 3)
+        self.assertEqual(method_count(IMyInterface), 3)
 
         # assigning _methods_ does not work until we have an _iid_!
         self.assertRaises(AttributeError,
                           setattr, IMyInterface, "_methods_", [])
         IMyInterface._iid_ = GUID.create_new()
         IMyInterface._methods_ = []
-        self.failUnlessEqual(method_count(IMyInterface), 3)
+        self.assertEqual(method_count(IMyInterface), 3)
 
         IMyInterface._methods_ = [
             STDMETHOD(HRESULT, "Blah", [])]
-        self.failUnlessEqual(method_count(IMyInterface), 4)
+        self.assertEqual(method_count(IMyInterface), 4)
 
     def test_heirarchy(self):
         class IMyInterface(IUnknown):
             pass
 
-        self.failUnless(issubclass(IMyInterface, IUnknown))
-        self.failUnless(issubclass(POINTER(IMyInterface), POINTER(IUnknown)))
+        self.assertTrue(issubclass(IMyInterface, IUnknown))
+        self.assertTrue(issubclass(POINTER(IMyInterface), POINTER(IUnknown)))
 
     def test_mro(self):
         mro = POINTER(IUnknown).__mro__
 
-        self.failUnlessEqual(mro[0], POINTER(IUnknown))
-        self.failUnlessEqual(mro[1], IUnknown)
+        self.assertEqual(mro[0], POINTER(IUnknown))
+        self.assertEqual(mro[1], IUnknown)
 
         # the IUnknown class has the actual methods:
-        self.failUnless(IUnknown.__dict__.get("QueryInterface"))
+        self.assertTrue(IUnknown.__dict__.get("QueryInterface"))
         # but we can call it on the pointer instance
         POINTER(IUnknown).QueryInterface
 
@@ -102,29 +102,29 @@ class BasicTest(ut.TestCase):
         # these should be identical
         a = POINTER(IUnknown)()
         b = POINTER(IUnknown)()
-        self.failUnlessEqual(a, b)
-        self.failUnlessEqual(hash(a), hash(b))
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
 
         from comtypes.typeinfo import CreateTypeLib
 
         # we do not save the lib, so no file will be created.
         # these should NOT be identical
-        a = CreateTypeLib(u"blahblah")
-        b = CreateTypeLib(u"spam")
+        a = CreateTypeLib("blahblah")
+        b = CreateTypeLib("spam")
 
-        self.failIfEqual(a, b)
-        self.failIfEqual(hash(a), hash(b))
+        self.assertNotEqual(a, b)
+        self.assertNotEqual(hash(a), hash(b))
 
         a = a.QueryInterface(IUnknown)
         b = b.QueryInterface(IUnknown)
 
-        self.failIfEqual(a, b)
-        self.failIfEqual(hash(a), hash(b))
+        self.assertNotEqual(a, b)
+        self.assertNotEqual(hash(a), hash(b))
 
         # These must be identical
         c = a.QueryInterface(IUnknown)
-        self.failUnlessEqual(a, c)
-        self.failUnlessEqual(hash(a), hash(c))
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
 
 
 def main():

--- a/comtypes/test/test_casesensitivity.py
+++ b/comtypes/test/test_casesensitivity.py
@@ -15,8 +15,8 @@ class TestCase(unittest.TestCase):
 
 ##        print iem.IWebBrowser2.mro()
 
-        self.failUnless(issubclass(iem.IWebBrowser2, iem.IWebBrowserApp))
-        self.failUnless(issubclass(iem.IWebBrowserApp, iem.IWebBrowser))
+        self.assertTrue(issubclass(iem.IWebBrowser2, iem.IWebBrowserApp))
+        self.assertTrue(issubclass(iem.IWebBrowserApp, iem.IWebBrowser))
 
 ##        print sorted(iem.IWebBrowser.__map_case__.keys())
 ##        print "=" * 42
@@ -28,11 +28,11 @@ class TestCase(unittest.TestCase):
         # names in the base class __map_case__ must also appear in the
         # subclass.
         for name in iem.IWebBrowser.__map_case__:
-            self.failUnless(name in iem.IWebBrowserApp.__map_case__, "%s missing" % name)
-            self.failUnless(name in iem.IWebBrowser2.__map_case__, "%s missing" % name)
+            self.assertTrue(name in iem.IWebBrowserApp.__map_case__, "%s missing" % name)
+            self.assertTrue(name in iem.IWebBrowser2.__map_case__, "%s missing" % name)
 
         for name in iem.IWebBrowserApp.__map_case__:
-            self.failUnless(name in iem.IWebBrowser2.__map_case__, "%s missing" % name)
+            self.assertTrue(name in iem.IWebBrowser2.__map_case__, "%s missing" % name)
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -14,16 +14,16 @@ class Test(ut.TestCase):
     def test_progid(self):
         # create from ProgID
         obj = comtypes.client.CreateObject("Scripting.Dictionary")
-        self.failUnless(isinstance(obj, POINTER(Scripting.IDictionary)))
+        self.assertTrue(isinstance(obj, POINTER(Scripting.IDictionary)))
 
     def test_clsid(self):
         # create from the CoClass' clsid
         obj = comtypes.client.CreateObject(Scripting.Dictionary)
-        self.failUnless(isinstance(obj, POINTER(Scripting.IDictionary)))
+        self.assertTrue(isinstance(obj, POINTER(Scripting.IDictionary)))
 
     def test_clsid_string(self):
         # create from string clsid
-        comtypes.client.CreateObject(unicode(Scripting.Dictionary._reg_clsid_))
+        comtypes.client.CreateObject(str(Scripting.Dictionary._reg_clsid_))
         comtypes.client.CreateObject(str(Scripting.Dictionary._reg_clsid_))
 
     def test_GetModule_clsid(self):
@@ -33,12 +33,12 @@ class Test(ut.TestCase):
     def test_remote(self):
         ie = comtypes.client.CreateObject("InternetExplorer.Application",
                                           machine="localhost")
-        self.failUnlessEqual(ie.Visible, False)
+        self.assertEqual(ie.Visible, False)
         ie.Visible = 1
         # on a remote machine, this may not work.  Probably depends on
         # how the server is run.
-        self.failUnlessEqual(ie.Visible, True)
-        self.failUnlessEqual(0, ie.Quit()) # 0 == S_OK
+        self.assertEqual(ie.Visible, True)
+        self.assertEqual(0, ie.Quit()) # 0 == S_OK
 
     def test_server_info(self):
         serverinfo = COSERVERINFO()
@@ -50,12 +50,12 @@ class Test(ut.TestCase):
                 pServerInfo=pServerInfo)
         ie = comtypes.client.CreateObject("InternetExplorer.Application",
                                           pServerInfo=pServerInfo)
-        self.failUnlessEqual(ie.Visible, False)
+        self.assertEqual(ie.Visible, False)
         ie.Visible = 1
         # on a remote machine, this may not work.  Probably depends on
         # how the server is run.
-        self.failUnlessEqual(ie.Visible, True)
-        self.failUnlessEqual(0, ie.Quit()) # 0 == S_OK
+        self.assertEqual(ie.Visible, True)
+        self.assertEqual(0, ie.Quit()) # 0 == S_OK
 
 def test_main():
     from test import test_support

--- a/comtypes/test/test_collections.py
+++ b/comtypes/test/test_collections.py
@@ -13,56 +13,56 @@ class Test(unittest.TestCase):
         # apps has a _NewEnum property that implements IEnumVARIANT
         services = fwmgr.LocalPolicy.CurrentProfile.Services
 
-        self.failUnlessEqual(services.Count, len(services))
+        self.assertEqual(services.Count, len(services))
 
         cv = iter(services)
 
         names = [p.Name for p in cv]
-        self.failUnlessEqual(len(services), len(names))
+        self.assertEqual(len(services), len(names))
 
         # The iterator is consumed now:
-        self.failUnlessEqual([p.Name for p in cv], [])
+        self.assertEqual([p.Name for p in cv], [])
 
         # But we can reset it:
         cv.Reset()
-        self.failUnlessEqual([p.Name for p in cv], names)
+        self.assertEqual([p.Name for p in cv], names)
 
         # Reset, then skip:
         cv.Reset()
         cv.Skip(3)
-        self.failUnlessEqual([p.Name for p in cv], names[3:])
+        self.assertEqual([p.Name for p in cv], names[3:])
 
         # Reset, then skip:
         cv.Reset()
         cv.Skip(300)
-        self.failUnlessEqual([p.Name for p in cv], names[300:])
+        self.assertEqual([p.Name for p in cv], names[300:])
 
         # Hm, do we want to allow random access to the iterator?
         # Should the iterator support __getitem__ ???
-        self.failUnlessEqual(cv[0].Name, names[0])
-        self.failUnlessEqual(cv[0].Name, names[0])
-        self.failUnlessEqual(cv[0].Name, names[0])
+        self.assertEqual(cv[0].Name, names[0])
+        self.assertEqual(cv[0].Name, names[0])
+        self.assertEqual(cv[0].Name, names[0])
 
         if len(names) > 1:
-            self.failUnlessEqual(cv[1].Name, names[1])
-            self.failUnlessEqual(cv[1].Name, names[1])
-            self.failUnlessEqual(cv[1].Name, names[1])
+            self.assertEqual(cv[1].Name, names[1])
+            self.assertEqual(cv[1].Name, names[1])
+            self.assertEqual(cv[1].Name, names[1])
 
         # We can now call Next(celt) with celt != 1, the call always returns a
         # list:
         cv.Reset()
-        self.failUnlessEqual(names[:3],
+        self.assertEqual(names[:3],
                             [p.Name for p in cv.Next(3)])
 
         # calling Next(0) makes no sense, but should work anyway:
-        self.failUnlessEqual(cv.Next(0), [])
+        self.assertEqual(cv.Next(0), [])
 
         cv.Reset()
-        self.failUnlessEqual(len(cv.Next(len(names) * 2)), len(names))
+        self.assertEqual(len(cv.Next(len(names) * 2)), len(names))
 
         # slicing is not (yet?) supported
         cv.Reset()
-        self.failUnlessRaises(ArgumentError, lambda: cv[:])
+        self.assertRaises(ArgumentError, lambda: cv[:])
 
     def test_leaks_1(self):
         # The XP firewall manager.
@@ -74,7 +74,7 @@ class Test(unittest.TestCase):
             for item in iter(apps):
                 item.ProcessImageFileName
         bytes = find_memleak(doit, (20, 20))
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_leaks_2(self):
         # The XP firewall manager.
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
         def doit():
             iter(apps).Next(99)
         bytes = find_memleak(doit, (20, 20))
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_leaks_3(self):
         # The XP firewall manager.
@@ -98,7 +98,7 @@ class Test(unittest.TestCase):
                 for what in iter(apps):
                     pass
         bytes = find_memleak(doit, (20, 20))
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
 
 class TestCollectionInterface(unittest.TestCase):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -18,11 +18,11 @@ class TestInproc(unittest.TestCase):
 
     def _find_memleak(self, func):
         bytes = find_memleak(func)
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_mixedinout(self):
         o = self.create_object()
-        self.failUnlessEqual(o.MixedInOut(2, 4), (3, 5))
+        self.assertEqual(o.MixedInOut(2, 4), (3, 5))
 
     def test_getname(self):
         from ctypes import byref, pointer
@@ -45,7 +45,7 @@ class TestInproc(unittest.TestCase):
         for i in range(10):
             BSTR("f" * len(name))
         # Make sure the pointer is still valid:
-        self.failUnlessEqual(pb[0], name)
+        self.assertEqual(pb[0], name)
 
     if is_resource_enabled("memleaks"):
         def test_get_id(self):
@@ -59,13 +59,13 @@ class TestInproc(unittest.TestCase):
         def test_set_name(self):
             obj = self.create_object()
             def func():
-                obj.name = u"abcde"
+                obj.name = "abcde"
             self._find_memleak(func)
 
         def test_SetName(self):
             obj = self.create_object()
             def func():
-                obj.SetName(u"abcde")
+                obj.SetName("abcde")
             self._find_memleak(func)
 
 
@@ -73,7 +73,7 @@ class TestInproc(unittest.TestCase):
             obj = self.create_object()
             def func():
                 return obj.eval("(1, 2, 3)")
-            self.failUnlessEqual(func(), (1, 2, 3))
+            self.assertEqual(func(), (1, 2, 3))
             self._find_memleak(func)
 
         def test_get_typeinfo(self):
@@ -179,7 +179,7 @@ class TestCase(unittest.TestCase):
             >>>
             '''
 
-    def GetEvents():
+    def GetEvents(self):
         """
         >>> from comtypes.client import CreateObject, GetEvents
         >>>

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -75,7 +75,7 @@ for fname in glob.glob(os.path.join(progdir, r"Microsoft Office\Office*\*.olb"))
 
 path = os.path.join(progdir, r"Microsoft Visual Studio .NET 2003\Visual Studio SDKs\DIA SDK\bin\msdia71.dll")
 if os.path.isfile(path):
-    print "ADD", path
+    print("ADD", path)
     add_test(path)
 
 for fname in glob.glob(os.path.join(common_progdir, r"Microsoft Shared\Speech\*.dll")):

--- a/comtypes/test/test_dict.py
+++ b/comtypes/test/test_dict.py
@@ -9,56 +9,56 @@ from comtypes.automation import VARIANT
 class Test(unittest.TestCase):
     def test_dict(self):
         d = CreateObject("Scripting.Dictionary", dynamic=True)
-        self.failUnlessEqual(type(d), Dispatch)
+        self.assertEqual(type(d), Dispatch)
 
         # Count is a normal propget, no propput
-        self.failUnlessEqual(d.Count, 0)
+        self.assertEqual(d.Count, 0)
         self.assertRaises(AttributeError, lambda: setattr(d, "Count", -1))
 
         # HashVal is a 'named' propget, no propput
         ##d.HashVal
 
         # Add(Key, Item) -> None
-        self.failUnlessEqual(d.Add("one", 1), None)
-        self.failUnlessEqual(d.Count, 1)
+        self.assertEqual(d.Add("one", 1), None)
+        self.assertEqual(d.Count, 1)
 
         # RemoveAll() -> None
-        self.failUnlessEqual(d.RemoveAll(), None)
-        self.failUnlessEqual(d.Count, 0)
+        self.assertEqual(d.RemoveAll(), None)
+        self.assertEqual(d.Count, 0)
 
         # CompareMode: propget, propput
         # (Can only be set when dict is empty!)
-        self.failUnlessEqual(d.CompareMode, 0)
+        self.assertEqual(d.CompareMode, 0)
         d.CompareMode = 1
-        self.failUnlessEqual(d.CompareMode, 1)
+        self.assertEqual(d.CompareMode, 1)
         d.CompareMode = 0
 
         # Exists(key) -> bool
-        self.failUnlessEqual(d.Exists(42), False)
+        self.assertEqual(d.Exists(42), False)
         d.Add(42, "foo")
-        self.failUnlessEqual(d.Exists(42), True)
+        self.assertEqual(d.Exists(42), True)
 
         # Keys() -> array
         # Items() -> array
-        self.failUnlessEqual(d.Keys(), (42,))
-        self.failUnlessEqual(d.Items(), ("foo",))
+        self.assertEqual(d.Keys(), (42,))
+        self.assertEqual(d.Items(), ("foo",))
         d.Remove(42)
-        self.failUnlessEqual(d.Exists(42), False)
-        self.failUnlessEqual(d.Keys(), ())
-        self.failUnlessEqual(d.Items(), ())
+        self.assertEqual(d.Exists(42), False)
+        self.assertEqual(d.Keys(), ())
+        self.assertEqual(d.Items(), ())
 
         # Item[key] : propget
         d.Add(42, "foo")
-        self.failUnlessEqual(d.Item[42], "foo")
+        self.assertEqual(d.Item[42], "foo")
 
         d.Add("spam", "bar")
-        self.failUnlessEqual(d.Item["spam"], "bar")
+        self.assertEqual(d.Item["spam"], "bar")
 
         # Item[key] = value: propput, propputref
         d.Item["key"] = "value"
-        self.failUnlessEqual(d.Item["key"], "value")
+        self.assertEqual(d.Item["key"], "value")
         d.Item[42] = 73, 48
-        self.failUnlessEqual(d.Item[42], (73, 48))
+        self.assertEqual(d.Item[42], (73, 48))
 
         ################################################################
         # part 2, testing propput and propputref
@@ -73,31 +73,31 @@ class Test(unittest.TestCase):
 
         a = d.Item["object"]
  
-        self.failUnlessEqual(d.Item["object"], s)
-        self.failUnlessEqual(d.Item["object"].CompareMode, 42)
-        self.failUnlessEqual(d.Item["value"], 42)
+        self.assertEqual(d.Item["object"], s)
+        self.assertEqual(d.Item["object"].CompareMode, 42)
+        self.assertEqual(d.Item["value"], 42)
 
         # Changing a property of the object
         s.CompareMode = 5
-        self.failUnlessEqual(d.Item["object"], s)
-        self.failUnlessEqual(d.Item["object"].CompareMode, 5)
-        self.failUnlessEqual(d.Item["value"], 42)
+        self.assertEqual(d.Item["object"], s)
+        self.assertEqual(d.Item["object"].CompareMode, 5)
+        self.assertEqual(d.Item["value"], 42)
 
         # This also calls propputref since we assign an Object
         d.Item["var"] = VARIANT(s)
-        self.failUnlessEqual(d.Item["var"], s)
+        self.assertEqual(d.Item["var"], s)
 
         # iter(d)
         keys = [x for x in d]
-        self.failUnlessEqual(d.Keys(),
+        self.assertEqual(d.Keys(),
                              tuple([x for x in d]))
 
         # d[key] = value
         # d[key] -> value
         d["blah"] = "blarg"
-        self.failUnlessEqual(d["blah"], "blarg")
+        self.assertEqual(d["blah"], "blarg")
         # d(key) -> value
-        self.failUnlessEqual(d("blah"), "blarg")
+        self.assertEqual(d("blah"), "blarg")
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -112,7 +112,7 @@ class Test(unittest.TestCase):
         import os
         jscript = os.path.join(os.path.dirname(__file__), "test_jscript.js")
         errcode = os.system("cscript -nologo %s" % jscript)
-        self.failUnlessEqual(errcode, 0)
+        self.assertEqual(errcode, 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_dyndispatch.py
+++ b/comtypes/test/test_dyndispatch.py
@@ -17,7 +17,7 @@ class Test(unittest.TestCase):
         del self.d
 
     def test_type(self):
-        self.failUnless(isinstance(self.d, Dispatch))
+        self.assertTrue(isinstance(self.d, Dispatch))
 
     def test_index_setter(self):
         d = self.d

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -25,9 +25,9 @@ class Test(unittest.TestCase):
 
         xl = self.xl
         xl.Visible = 0
-        self.failUnlessEqual(xl.Visible, False)
+        self.assertEqual(xl.Visible, False)
         xl.Visible = 1
-        self.failUnlessEqual(xl.Visible, True)
+        self.assertEqual(xl.Visible, True)
 
         wb = xl.Workbooks.Add()
 
@@ -40,25 +40,25 @@ class Test(unittest.TestCase):
 ##        xl.Range["A4:C4"].Value = ('3','2','1')
 
         # call property to retrieve value
-        self.failUnlessEqual(xl.Range["A1:C3"].Value(),
+        self.assertEqual(xl.Range["A1:C3"].Value(),
                              ((10.0, 20.0, 31.4),
                               ("x", "y", "z"),
                               (3.0, 2.0, 1.0)))
         # index with empty tuple
-        self.failUnlessEqual(xl.Range["A1:C3"].Value[()],
+        self.assertEqual(xl.Range["A1:C3"].Value[()],
                              ((10.0, 20.0, 31.4),
                               ("x", "y", "z"),
                               (3.0, 2.0, 1.0)))
         # index with empty slice
-        self.failUnlessEqual(xl.Range["A1:C3"].Value[:],
+        self.assertEqual(xl.Range["A1:C3"].Value[:],
                              ((10.0, 20.0, 31.4),
                               ("x", "y", "z"),
                               (3.0, 2.0, 1.0)))
-        self.failUnlessEqual(xl.Range["A1:C3"].Value[xlRangeValueDefault],
+        self.assertEqual(xl.Range["A1:C3"].Value[xlRangeValueDefault],
                              ((10.0, 20.0, 31.4),
                               ("x", "y", "z"),
                               (3.0, 2.0, 1.0)))
-        self.failUnlessEqual(xl.Range["A1", "C3"].Value[()],
+        self.assertEqual(xl.Range["A1", "C3"].Value[()],
                              ((10.0, 20.0, 31.4),
                               ("x", "y", "z"),
                               (3.0, 2.0, 1.0)))
@@ -67,7 +67,7 @@ class Test(unittest.TestCase):
         i = iter(r)
 
         # Test for iteration support in 'Range' interface
-        self.failUnlessEqual([c.Value() for c in xl.Range["A1:C3"]],
+        self.assertEqual([c.Value() for c in xl.Range["A1:C3"]],
                              [10.0, 20.0, 31.4,
                               "x", "y", "z",
                               3.0, 2.0, 1.0])
@@ -75,26 +75,26 @@ class Test(unittest.TestCase):
         # With pywin32, one could write xl.Cells(a, b)
         # With comtypes, one must write xl.Cells.Item(1, b)
 
-        for i in xrange(20):
+        for i in range(20):
             xl.Cells.Item[i+1,i+1].Value[()] = "Hi %d" % i
-            print xl.Cells.Item[i+1, i+1].Value[()]
+            print(xl.Cells.Item[i+1, i+1].Value[()])
 
-        for i in xrange(20):
+        for i in range(20):
             xl.Cells(i+1,i+1).Value[()] = "Hi %d" % i
-            print xl.Cells(i+1, i+1).Value[()]
+            print(xl.Cells(i+1, i+1).Value[()])
 
         # test dates out with Excel
         xl.Range["A5"].Value[()] = "Excel time"
         xl.Range["B5"].Formula = "=Now()"
-        self.failUnlessEqual(xl.Cells.Item[5,2].Formula, "=NOW()")
+        self.assertEqual(xl.Cells.Item[5,2].Formula, "=NOW()")
 
         xl.Range["A6"].Calculate()
         excel_time = xl.Range["B5"].Value[()]
-        self.failUnlessEqual(type(excel_time), datetime.datetime)
+        self.assertEqual(type(excel_time), datetime.datetime)
         python_time = datetime.datetime.now()
 
-        self.failUnless(python_time >= excel_time)
-        self.failUnless(python_time - excel_time < datetime.timedelta(seconds=1))
+        self.assertTrue(python_time >= excel_time)
+        self.assertTrue(python_time - excel_time < datetime.timedelta(seconds=1))
 
         # some random code, grabbed from c.l.p
         sh = wb.Worksheets[1]

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -1,4 +1,5 @@
 import types, os, unittest, sys, tempfile
+import importlib
 
 if sys.version_info >= (2, 6):
     from imp import reload
@@ -35,14 +36,14 @@ class Test(unittest.TestCase):
         # restore the original comtypes.gen module
         comtypes.gen = self.orig_comtypesgen
         sys.modules["comtypes.gen"] = self.orig_comtypesgen
-        reload(comtypes.gen)
+        importlib.reload(comtypes.gen)
 
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache
         template = r"$APPDATA\Python\Python%d%d\comtypes_cache"
         path = os.path.expandvars(template % sys.version_info[:2])
         gen_dir = comtypes.client._find_gen_dir()
-        self.failUnlessEqual(path, gen_dir)
+        self.assertEqual(path, gen_dir)
 
     def test_frozen_dll(self):
         sys.frozen = "dll"
@@ -53,7 +54,7 @@ class Test(unittest.TestCase):
         path = os.path.join(tempfile.gettempdir(),
                             r"comtypes_cache\%s%d%d-%d%d" % (imgbase, ma, mi, ma, mi))
         gen_dir = comtypes.client._find_gen_dir()
-        self.failUnlessEqual(path, gen_dir)
+        self.assertEqual(path, gen_dir)
 
     def test_frozen_console_exe(self):
         sys.frozen = "console_exe"
@@ -62,7 +63,7 @@ class Test(unittest.TestCase):
                             r"comtypes_cache\%s-%d%d" % (
             imgbase, sys.version_info[0], sys.version_info[1]))
         gen_dir = comtypes.client._find_gen_dir()
-        self.failUnlessEqual(path, gen_dir)
+        self.assertEqual(path, gen_dir)
 
     def test_frozen_windows_exe(self):
         sys.frozen = "windows_exe"
@@ -71,7 +72,7 @@ class Test(unittest.TestCase):
                             r"comtypes_cache\%s-%d%d" % (
             imgbase, sys.version_info[0], sys.version_info[1]))
         gen_dir = comtypes.client._find_gen_dir()
-        self.failUnlessEqual(path, gen_dir)
+        self.assertEqual(path, gen_dir)
 
 
 def main():

--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -28,7 +28,7 @@ class Test(unittest.TestCase):
         w2 = comtypes.client.GetActiveObject("Word.Application")
 
         # check if they are referring to the same object
-        self.failUnlessEqual(w1.QueryInterface(comtypes.IUnknown),
+        self.assertEqual(w1.QueryInterface(comtypes.IUnknown),
                              w2.QueryInterface(comtypes.IUnknown))
 
         w1.Quit()
@@ -39,9 +39,9 @@ class Test(unittest.TestCase):
 
         try:
             w2.Visible
-        except comtypes.COMError, err:
+        except comtypes.COMError as err:
             variables = err.hresult, err.text, err.details
-            self.failUnlessEqual(variables, err[:])
+            self.assertEqual(variables, err[:])
         else:
             raise AssertionError("COMError not raised")
 

--- a/comtypes/test/test_ie.py
+++ b/comtypes/test/test_ie.py
@@ -78,7 +78,7 @@ class Test(ut.TestCase):
         ie.Visible = False
         ie.Quit()
 
-        self.failUnlessEqual(sink._events, ['OnVisible', 'BeforeNavigate2',
+        self.assertEqual(sink._events, ['OnVisible', 'BeforeNavigate2',
                                             'NavigateComplete2', 'DocumentComplete',
                                             'OnVisible'])
 
@@ -100,7 +100,7 @@ class Test(ut.TestCase):
         ie.Visible = False
         ie.Quit()
 
-        self.failUnlessEqual(sink._events, ['BeforeNavigate', 'NavigateComplete'])
+        self.assertEqual(sink._events, ['BeforeNavigate', 'NavigateComplete'])
         del ie
 
 if __name__ == "__main__":

--- a/comtypes/test/test_msscript.py
+++ b/comtypes/test/test_msscript.py
@@ -50,19 +50,19 @@ else:
             # comtypes.client works around this bug, by not trying to
             # high-level wrap the dispatch pointer because QI for the real
             # interface fails.
-            self.failUnlessEqual(type(res), POINTER(IDispatch))
+            self.assertEqual(type(res), POINTER(IDispatch))
 
             tinfo_1 = engine.Eval("[1, 2, 3]")._comobj.GetTypeInfo(0)
             tinfo_2 = engine.Eval("[1, 2, 3, 4]")._comobj.GetTypeInfo(0)
             tinfo_3 = engine.Eval("[1, 2, 3, 4, 5]")._comobj.GetTypeInfo(0)
 
 
-            self.failUnlessEqual(tinfo_1.GetTypeAttr().cVars, 3)
-            self.failUnlessEqual(tinfo_2.GetTypeAttr().cVars, 4)
-            self.failUnlessEqual(tinfo_3.GetTypeAttr().cVars, 5)
+            self.assertEqual(tinfo_1.GetTypeAttr().cVars, 3)
+            self.assertEqual(tinfo_2.GetTypeAttr().cVars, 4)
+            self.assertEqual(tinfo_3.GetTypeAttr().cVars, 5)
 
             # These tests simply describe the current behaviour ;-)
-            self.failUnlessEqual(tinfo_1.GetTypeAttr().guid,
+            self.assertEqual(tinfo_1.GetTypeAttr().guid,
                                  tinfo_1.GetTypeAttr().guid)
 
             ## print (res[0], res[1], res[2])

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -37,10 +37,10 @@ def from_outparm(self):
 c_wchar_p.__ctypes_from_outparam__ = from_outparm
 
 def comstring(text, typ=c_wchar_p):
-    text = unicode(text)
+    text = str(text)
     size = (len(text) + 1) * sizeof(c_wchar)
     mem = windll.ole32.CoTaskMemAlloc(size)
-    print "malloc'd 0x%x, %d bytes" % (mem, size)
+    print("malloc'd 0x%x, %d bytes" % (mem, size))
     ptr = cast(mem, typ)
     memmove(mem, text, size)
     return ptr
@@ -58,7 +58,7 @@ class Test(unittest.TestCase):
         z = comstring("spam, spam, and spam")
 
 ##        (x.__ctypes_from_outparam__(), x.__ctypes_from_outparam__())
-        print (x.__ctypes_from_outparam__(), None) #x.__ctypes_from_outparam__())
+        print((x.__ctypes_from_outparam__(), None)) #x.__ctypes_from_outparam__())
 
 ##        print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
 ##        print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()

--- a/comtypes/test/test_propputref.py
+++ b/comtypes/test/test_propputref.py
@@ -14,19 +14,19 @@ class Test(unittest.TestCase):
         # This calls propput, since we assing a Value
         d.Item["value"] = s.name
 
-        self.failUnlessEqual(d.Item["object"], s)
-        self.failUnlessEqual(d.Item["object"].name, "the value")
-        self.failUnlessEqual(d.Item["value"], "the value")
+        self.assertEqual(d.Item["object"], s)
+        self.assertEqual(d.Item["object"].name, "the value")
+        self.assertEqual(d.Item["value"], "the value")
 
         # Changing the default property of the object
         s.name = "foo bar"
-        self.failUnlessEqual(d.Item["object"], s)
-        self.failUnlessEqual(d.Item["object"].name, "foo bar")
-        self.failUnlessEqual(d.Item["value"], "the value")
+        self.assertEqual(d.Item["object"], s)
+        self.assertEqual(d.Item["object"].name, "foo bar")
+        self.assertEqual(d.Item["value"], "the value")
 
         # This also calls propputref since we assign an Object
         d.Item["var"] = VARIANT(s)
-        self.failUnlessEqual(d.Item["var"], s)
+        self.assertEqual(d.Item["var"], s)
 
     def test_dispatch(self):
         return self.test(dynamic=True)

--- a/comtypes/test/test_safearray.py
+++ b/comtypes/test/test_safearray.py
@@ -34,39 +34,39 @@ class VariantTestCase(unittest.TestCase):
     def test_VARIANT_array(self):
         v = VARIANT()
         v.value = ((1, 2, 3), ("foo", "bar", None))
-        self.failUnlessEqual(v.vt, VT_ARRAY | VT_VARIANT)
-        self.failUnlessEqual(v.value, ((1, 2, 3), ("foo", "bar", None)))
+        self.assertEqual(v.vt, VT_ARRAY | VT_VARIANT)
+        self.assertEqual(v.value, ((1, 2, 3), ("foo", "bar", None)))
 
         def func():
             VARIANT((1, 2, 3), ("foo", "bar", None))
 
         bytes = find_memleak(func)
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_double_array(self):
         a = array.array("d", (3.14, 2.78))
         v = VARIANT(a)
-        self.failUnlessEqual(v.vt, VT_ARRAY | VT_R8)
-        self.failUnlessEqual(tuple(a.tolist()), v.value)
+        self.assertEqual(v.vt, VT_ARRAY | VT_R8)
+        self.assertEqual(tuple(a.tolist()), v.value)
 
         def func():
             VARIANT(array.array("d", (3.14, 2.78)))
 
         bytes = find_memleak(func)
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_float_array(self):
         a = array.array("f", (3.14, 2.78))
         v = VARIANT(a)
-        self.failUnlessEqual(v.vt, VT_ARRAY | VT_R4)
-        self.failUnlessEqual(tuple(a.tolist()), v.value)
+        self.assertEqual(v.vt, VT_ARRAY | VT_R4)
+        self.assertEqual(tuple(a.tolist()), v.value)
 
     def test_2dim_array(self):
         data = ((1, 2, 3, 4),
                 (5, 6, 7, 8),
                 (9, 10, 11, 12))
         v = VARIANT(data)
-        self.failUnlessEqual(v.value, data)
+        self.assertEqual(v.value, data)
 
 
 class SafeArrayTestCase(unittest.TestCase):
@@ -74,18 +74,18 @@ class SafeArrayTestCase(unittest.TestCase):
     def test_equality(self):
         a = _midlSAFEARRAY(c_long)
         b = _midlSAFEARRAY(c_long)
-        self.failUnless(a is b)
+        self.assertTrue(a is b)
 
         c = _midlSAFEARRAY(BSTR)
         d = _midlSAFEARRAY(BSTR)
-        self.failUnless(c is d)
+        self.assertTrue(c is d)
 
-        self.failIfEqual(a, c)
+        self.assertNotEqual(a, c)
 
         # XXX remove:
-        self.failUnlessEqual((a._itemtype_, a._vartype_),
+        self.assertEqual((a._itemtype_, a._vartype_),
                              (c_long, VT_I4))
-        self.failUnlessEqual((c._itemtype_, c._vartype_),
+        self.assertEqual((c._itemtype_, c._vartype_),
                              (BSTR, VT_BSTR))
 
     def test_nested_contexts(self):
@@ -104,18 +104,18 @@ class SafeArrayTestCase(unittest.TestCase):
             fourth = sa[0]
         fifth = sa[0]
 
-        self.failUnless(isinstance(first, tuple))
-        self.failUnless(isinstance(second, np.ndarray))
-        self.failUnless(isinstance(third, np.ndarray))
-        self.failUnless(isinstance(fourth, np.ndarray))
-        self.failUnless(isinstance(fifth, tuple))
+        self.assertTrue(isinstance(first, tuple))
+        self.assertTrue(isinstance(second, np.ndarray))
+        self.assertTrue(isinstance(third, np.ndarray))
+        self.assertTrue(isinstance(fourth, np.ndarray))
+        self.assertTrue(isinstance(fifth, tuple))
 
     def test_VT_BSTR(self):
         t = _midlSAFEARRAY(BSTR)
 
         sa = t.from_param(["a", "b", "c"])
-        self.failUnlessEqual(sa[0], ("a", "b", "c"))
-        self.failUnlessEqual(SafeArrayGetVartype(sa), VT_BSTR)
+        self.assertEqual(sa[0], ("a", "b", "c"))
+        self.assertEqual(SafeArrayGetVartype(sa), VT_BSTR)
 
     def test_VT_BSTR_ndarray(self):
         np = get_numpy()
@@ -127,10 +127,10 @@ class SafeArrayTestCase(unittest.TestCase):
         sa = t.from_param(["a", "b", "c"])
         arr = get_array(sa)
 
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnlessEqual(np.dtype('<U1'), arr.dtype)
-        self.failUnless((arr == ("a", "b", "c")).all())
-        self.failUnlessEqual(SafeArrayGetVartype(sa), VT_BSTR)
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertEqual(np.dtype('<U1'), arr.dtype)
+        self.assertTrue((arr == ("a", "b", "c")).all())
+        self.assertEqual(SafeArrayGetVartype(sa), VT_BSTR)
 
     def test_VT_BSTR_leaks(self):
         sb = _midlSAFEARRAY(BSTR)
@@ -139,7 +139,7 @@ class SafeArrayTestCase(unittest.TestCase):
             sb.from_param(["foo", "bar"])
 
         bytes = find_memleak(doit)
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_VT_I4_leaks(self):
         sa = _midlSAFEARRAY(c_long)
@@ -148,16 +148,16 @@ class SafeArrayTestCase(unittest.TestCase):
             sa.from_param([1, 2, 3, 4, 5, 6])
 
         bytes = find_memleak(doit)
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_VT_I4(self):
         t = _midlSAFEARRAY(c_long)
 
         sa = t.from_param([11, 22, 33])
 
-        self.failUnlessEqual(sa[0], (11, 22, 33))
+        self.assertEqual(sa[0], (11, 22, 33))
 
-        self.failUnlessEqual(SafeArrayGetVartype(sa), VT_I4)
+        self.assertEqual(SafeArrayGetVartype(sa), VT_I4)
 
         # TypeError: len() of unsized object
         self.assertRaises(TypeError, lambda: t.from_param(object()))
@@ -174,10 +174,10 @@ class SafeArrayTestCase(unittest.TestCase):
 
         arr = get_array(sa)
 
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnlessEqual(np.dtype(np.int), arr.dtype)
-        self.failUnless((arr == inarr).all())
-        self.failUnlessEqual(SafeArrayGetVartype(sa), VT_I4)
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertEqual(np.dtype(np.int), arr.dtype)
+        self.assertTrue((arr == inarr).all())
+        self.assertEqual(SafeArrayGetVartype(sa), VT_I4)
 
     def test_array(self):
         np = get_numpy()
@@ -189,9 +189,9 @@ class SafeArrayTestCase(unittest.TestCase):
 
         pat[0] = np.zeros(32, dtype=np.float)
         arr = get_array(pat[0])
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnlessEqual(np.dtype(np.double), arr.dtype)
-        self.failUnless((arr == (0.0,) * 32).all())
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertEqual(np.dtype(np.double), arr.dtype)
+        self.assertTrue((arr == (0.0,) * 32).all())
 
         data = ((1.0, 2.0, 3.0),
                 (4.0, 5.0, 6.0),
@@ -199,9 +199,9 @@ class SafeArrayTestCase(unittest.TestCase):
         a = np.array(data, dtype=np.double)
         pat[0] = a
         arr = get_array(pat[0])
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnlessEqual(np.dtype(np.double), arr.dtype)
-        self.failUnless((arr == data).all())
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertEqual(np.dtype(np.double), arr.dtype)
+        self.assertTrue((arr == data).all())
 
         data = ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
         a = np.array(data,
@@ -209,18 +209,18 @@ class SafeArrayTestCase(unittest.TestCase):
                         order="F")
         pat[0] = a
         arr = get_array(pat[0])
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnlessEqual(np.dtype(np.double), arr.dtype)
-        self.failUnlessEqual(pat[0][0], data)
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertEqual(np.dtype(np.double), arr.dtype)
+        self.assertEqual(pat[0][0], data)
 
     def test_VT_VARIANT(self):
         t = _midlSAFEARRAY(VARIANT)
 
         now = datetime.datetime.now()
         sa = t.from_param([11, "22", None, True, now, Decimal("3.14")])
-        self.failUnlessEqual(sa[0], (11, "22", None, True, now, Decimal("3.14")))
+        self.assertEqual(sa[0], (11, "22", None, True, now, Decimal("3.14")))
 
-        self.failUnlessEqual(SafeArrayGetVartype(sa), VT_VARIANT)
+        self.assertEqual(SafeArrayGetVartype(sa), VT_VARIANT)
 
     def test_VT_VARIANT_ndarray(self):
         np = get_numpy()
@@ -231,20 +231,20 @@ class SafeArrayTestCase(unittest.TestCase):
 
         now = datetime.datetime.now()
         inarr = np.array(
-            [11, "22", u"33", 44.0, None, True, now, Decimal("3.14")]
+            [11, "22", "33", 44.0, None, True, now, Decimal("3.14")]
         ).reshape(2, 4)
         sa = t.from_param(inarr)
         arr = get_array(sa)
-        self.failUnlessEqual(np.dtype(object), arr.dtype)
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnless((arr == inarr).all())
-        self.failUnlessEqual(SafeArrayGetVartype(sa), VT_VARIANT)
+        self.assertEqual(np.dtype(object), arr.dtype)
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertTrue((arr == inarr).all())
+        self.assertEqual(SafeArrayGetVartype(sa), VT_VARIANT)
 
     def test_VT_BOOL(self):
         t = _midlSAFEARRAY(VARIANT_BOOL)
 
         sa = t.from_param([True, False, True, False])
-        self.failUnlessEqual(sa[0], (True, False, True, False))
+        self.assertEqual(sa[0], (True, False, True, False))
 
     def test_VT_BOOL_ndarray(self):
         np = get_numpy()
@@ -255,14 +255,14 @@ class SafeArrayTestCase(unittest.TestCase):
 
         sa = t.from_param([True, False, True, False])
         arr = get_array(sa)
-        self.failUnlessEqual(np.dtype(np.bool_), arr.dtype)
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnless((arr == (True, False, True, False)).all())
+        self.assertEqual(np.dtype(np.bool_), arr.dtype)
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertTrue((arr == (True, False, True, False)).all())
 
     def test_VT_UNKNOWN_1(self):
         a = _midlSAFEARRAY(POINTER(IUnknown))
         t = _midlSAFEARRAY(POINTER(IUnknown))
-        self.failUnless(a is t)
+        self.assertTrue(a is t)
 
         from comtypes.typeinfo import CreateTypeLib
         # will never be saved to disk
@@ -273,23 +273,23 @@ class SafeArrayTestCase(unittest.TestCase):
 
         # This should increase the refcount by 1
         sa = t.from_param([punk])
-        self.failUnlessEqual(initial + 1, com_refcnt(punk))
+        self.assertEqual(initial + 1, com_refcnt(punk))
 
         # Unpacking the array must not change the refcount, and must
         # return an equal object.
-        self.failUnlessEqual((punk,), sa[0])
-        self.failUnlessEqual(initial + 1, com_refcnt(punk))
+        self.assertEqual((punk,), sa[0])
+        self.assertEqual(initial + 1, com_refcnt(punk))
 
         del sa
-        self.failUnlessEqual(initial, com_refcnt(punk))
+        self.assertEqual(initial, com_refcnt(punk))
 
         sa = t.from_param([None])
-        self.failUnlessEqual((POINTER(IUnknown)(),), sa[0])
+        self.assertEqual((POINTER(IUnknown)(),), sa[0])
 
     def test_VT_UNKNOWN_multi(self):
         a = _midlSAFEARRAY(POINTER(IUnknown))
         t = _midlSAFEARRAY(POINTER(IUnknown))
-        self.failUnless(a is t)
+        self.assertTrue(a is t)
 
         from comtypes.typeinfo import CreateTypeLib
         # will never be saved to disk
@@ -300,25 +300,25 @@ class SafeArrayTestCase(unittest.TestCase):
 
         # This should increase the refcount by 4
         sa = t.from_param((punk,) * 4)
-        self.failUnlessEqual(initial + 4, com_refcnt(punk))
+        self.assertEqual(initial + 4, com_refcnt(punk))
 
         # Unpacking the array must not change the refcount, and must
         # return an equal object.
-        self.failUnlessEqual((punk,)*4, sa[0])
-        self.failUnlessEqual(initial + 4, com_refcnt(punk))
+        self.assertEqual((punk,)*4, sa[0])
+        self.assertEqual(initial + 4, com_refcnt(punk))
 
         del sa
-        self.failUnlessEqual(initial, com_refcnt(punk))
+        self.assertEqual(initial, com_refcnt(punk))
 
         # This should increase the refcount by 2
         sa = t.from_param((punk, None, punk, None))
-        self.failUnlessEqual(initial + 2, com_refcnt(punk))
+        self.assertEqual(initial + 2, com_refcnt(punk))
 
         null = POINTER(IUnknown)()
-        self.failUnlessEqual((punk, null, punk, null), sa[0])
+        self.assertEqual((punk, null, punk, null), sa[0])
 
         del sa
-        self.failUnlessEqual(initial, com_refcnt(punk))
+        self.assertEqual(initial, com_refcnt(punk))
 
         # repeat same test, with 2 different com pointers
 
@@ -327,10 +327,10 @@ class SafeArrayTestCase(unittest.TestCase):
         sa = t.from_param([plib, punk, plib])
 
 ####        self.failUnlessEqual((plib, punk, plib), sa[0])
-        self.failUnlessEqual((a+2, b+1), (com_refcnt(plib), com_refcnt(punk)))
+        self.assertEqual((a+2, b+1), (com_refcnt(plib), com_refcnt(punk)))
 
         del sa
-        self.failUnlessEqual((a, b), (com_refcnt(plib), com_refcnt(punk)))
+        self.assertEqual((a, b), (com_refcnt(plib), com_refcnt(punk)))
 
     def test_VT_UNKNOWN_multi_ndarray(self):
         np = get_numpy()
@@ -339,7 +339,7 @@ class SafeArrayTestCase(unittest.TestCase):
 
         a = _midlSAFEARRAY(POINTER(IUnknown))
         t = _midlSAFEARRAY(POINTER(IUnknown))
-        self.failUnless(a is t)
+        self.assertTrue(a is t)
 
         from comtypes.typeinfo import CreateTypeLib
         # will never be saved to disk
@@ -350,52 +350,52 @@ class SafeArrayTestCase(unittest.TestCase):
 
         # This should increase the refcount by 4
         sa = t.from_param((punk,) * 4)
-        self.failUnlessEqual(initial + 4, com_refcnt(punk))
+        self.assertEqual(initial + 4, com_refcnt(punk))
 
         # Unpacking the array must not change the refcount, and must
         # return an equal object. Creating an ndarray may change the
         # refcount.
         arr = get_array(sa)
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnlessEqual(np.dtype(object), arr.dtype)
-        self.failUnless((arr == (punk,)*4).all())
-        self.failUnlessEqual(initial + 8, com_refcnt(punk))
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertEqual(np.dtype(object), arr.dtype)
+        self.assertTrue((arr == (punk,)*4).all())
+        self.assertEqual(initial + 8, com_refcnt(punk))
 
         del arr
-        self.failUnlessEqual(initial + 4, com_refcnt(punk))
+        self.assertEqual(initial + 4, com_refcnt(punk))
 
         del sa
-        self.failUnlessEqual(initial, com_refcnt(punk))
+        self.assertEqual(initial, com_refcnt(punk))
 
         # This should increase the refcount by 2
         sa = t.from_param((punk, None, punk, None))
-        self.failUnlessEqual(initial + 2, com_refcnt(punk))
+        self.assertEqual(initial + 2, com_refcnt(punk))
 
         null = POINTER(IUnknown)()
         arr = get_array(sa)
-        self.failUnless(isinstance(arr, np.ndarray))
-        self.failUnlessEqual(np.dtype(object), arr.dtype)
-        self.failUnless((arr == (punk, null, punk, null)).all())
+        self.assertTrue(isinstance(arr, np.ndarray))
+        self.assertEqual(np.dtype(object), arr.dtype)
+        self.assertTrue((arr == (punk, null, punk, null)).all())
 
         del sa
         del arr
-        self.failUnlessEqual(initial, com_refcnt(punk))
+        self.assertEqual(initial, com_refcnt(punk))
 
     def test_UDT(self):
         from comtypes.gen.TestComServerLib import MYCOLOR
 
         t = _midlSAFEARRAY(MYCOLOR)
-        self.failUnless(t is _midlSAFEARRAY(MYCOLOR))
+        self.assertTrue(t is _midlSAFEARRAY(MYCOLOR))
 
         sa = t.from_param([MYCOLOR(0, 0, 0), MYCOLOR(1, 2, 3)])
 
-        self.failUnlessEqual([(x.red, x.green, x.blue) for x in sa[0]],
+        self.assertEqual([(x.red, x.green, x.blue) for x in sa[0]],
                              [(0.0, 0.0, 0.0), (1.0, 2.0, 3.0)])
 
         def doit():
             t.from_param([MYCOLOR(0, 0, 0), MYCOLOR(1, 2, 3)])
         bytes = find_memleak(doit)
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_UDT_ndarray(self):
         np = get_numpy()
@@ -405,12 +405,12 @@ class SafeArrayTestCase(unittest.TestCase):
         from comtypes.gen.TestComServerLib import MYCOLOR
 
         t = _midlSAFEARRAY(MYCOLOR)
-        self.failUnless(t is _midlSAFEARRAY(MYCOLOR))
+        self.assertTrue(t is _midlSAFEARRAY(MYCOLOR))
 
         sa = t.from_param([MYCOLOR(0, 0, 0), MYCOLOR(1, 2, 3)])
         arr = get_array(sa)
 
-        self.failUnless(isinstance(arr, np.ndarray))
+        self.assertTrue(isinstance(arr, np.ndarray))
         # The conversion code allows numpy to choose the dtype of
         # structured data.  This dtype is structured under numpy 1.5, 1.7 and
         # 1.8, and object in 1.6. Instead of assuming either of these, check
@@ -423,7 +423,7 @@ class SafeArrayTestCase(unittest.TestCase):
             self.assertIs(arr.dtype[1], float_dtype)
             self.assertIs(arr.dtype[2], float_dtype)
             data = [tuple(x) for x in arr]
-        self.failUnlessEqual(data, [(0.0, 0.0, 0.0), (1.0, 2.0, 3.0)])
+        self.assertEqual(data, [(0.0, 0.0, 0.0), (1.0, 2.0, 3.0)])
 
     def test_datetime64_ndarray(self):
         np = get_numpy()
@@ -444,7 +444,7 @@ class SafeArrayTestCase(unittest.TestCase):
         t = _midlSAFEARRAY(VARIANT)
         sa = t.from_param(dates)
         arr = get_array(sa).astype(dates.dtype)
-        self.failUnless((dates == arr).all())
+        self.assertTrue((dates == arr).all())
 
 
 if is_resource_enabled("pythoncom"):
@@ -486,21 +486,21 @@ if is_resource_enabled("pythoncom"):
             def test_1dim(self):
                 data = (1, 2, 3)
                 variant = pack(data)
-                self.failUnlessEqual(variant.value, data)
-                self.failUnlessEqual(unpack(variant), data)
+                self.assertEqual(variant.value, data)
+                self.assertEqual(unpack(variant), data)
 
             def test_2dim(self):
                 data = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
                 variant = pack(data)
-                self.failUnlessEqual(variant.value, data)
-                self.failUnlessEqual(unpack(variant), data)
+                self.assertEqual(variant.value, data)
+                self.assertEqual(unpack(variant), data)
 
             def test_3dim(self):
                 data = ( ( (1, 2), (3, 4), (5, 6) ),
                          ( (7, 8), (9, 10), (11, 12) ) )
                 variant = pack(data)
-                self.failUnlessEqual(variant.value, data)
-                self.failUnlessEqual(unpack(variant), data)
+                self.assertEqual(variant.value, data)
+                self.assertEqual(unpack(variant), data)
 
             def test_4dim(self):
                 data = ( ( ( ( 1,  2), ( 3,  4) ),
@@ -508,8 +508,8 @@ if is_resource_enabled("pythoncom"):
                          ( ( ( 9, 10), (11, 12) ),
                            ( (13, 14), (15, 16) ) ) )
                 variant = pack(data)
-                self.failUnlessEqual(variant.value, data)
-                self.failUnlessEqual(unpack(variant), data)
+                self.assertEqual(variant.value, data)
+                self.assertEqual(unpack(variant), data)
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_sapi.py
+++ b/comtypes/test/test_sapi.py
@@ -18,11 +18,11 @@ class Test(unittest.TestCase):
 
         # engine.AudioStream is a propputref property
         engine.AudioOutputStream = stream
-        self.failUnlessEqual(engine.AudioOutputStream, stream)
+        self.assertEqual(engine.AudioOutputStream, stream)
         engine.speak("Hello, World", 0)
         stream.Close()
         filesize = os.stat(fname).st_size
-        self.failUnless(filesize > 100, "filesize only %d bytes" % filesize)
+        self.assertTrue(filesize > 100, "filesize only %d bytes" % filesize)
         os.unlink(fname)
 
     def test_dyndisp(self):

--- a/comtypes/test/test_showevents.py
+++ b/comtypes/test/test_showevents.py
@@ -121,7 +121,7 @@ class EventsTest(unittest.TestCase):
             >>>
             '''
         
-    def IE_GetEvents():
+    def IE_GetEvents(self):
         """
         >>> from comtypes.client import CreateObject, GetEvents, PumpEvents
         >>>

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -20,18 +20,18 @@ if os.name == "nt":
 
             self.assertRaises(WindowsError, lambda: LoadTypeLibEx("<xxx.xx>"))
             tlib = LoadTypeLibEx(dllname)
-            self.failUnless(tlib.GetTypeInfoCount())
+            self.assertTrue(tlib.GetTypeInfoCount())
             tlib.GetDocumentation(-1)
-            self.failUnlessEqual(tlib.IsName("iwebbrowser"), "IWebBrowser")
-            self.failUnlessEqual(tlib.IsName("IWEBBROWSER"), "IWebBrowser")
-            self.failUnless(tlib.FindName("IWebBrowser"))
-            self.failUnlessEqual(tlib.IsName("Spam"), None)
+            self.assertEqual(tlib.IsName("iwebbrowser"), "IWebBrowser")
+            self.assertEqual(tlib.IsName("IWEBBROWSER"), "IWebBrowser")
+            self.assertTrue(tlib.FindName("IWebBrowser"))
+            self.assertEqual(tlib.IsName("Spam"), None)
             tlib.GetTypeComp()
 
             attr = tlib.GetLibAttr()
             info = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
             other_tlib = LoadRegTypeLib(*info)
-            self.failUnlessEqual(tlib, other_tlib)
+            self.assertEqual(tlib, other_tlib)
 
     ##         for n in dir(attr):
     ##             if not n.startswith("_"):
@@ -44,17 +44,17 @@ if os.name == "nt":
                 tlib.GetTypeInfoType(i)
 
                 c_tlib, index = ti.GetContainingTypeLib()
-                self.failUnlessEqual(c_tlib, tlib)
-                self.failUnlessEqual(index, i)
+                self.assertEqual(c_tlib, tlib)
+                self.assertEqual(index, i)
 
             guid_null = GUID()
             self.assertRaises(COMError, lambda: tlib.GetTypeInfoOfGuid(guid_null))
 
-            self.failUnless(tlib.GetTypeInfoOfGuid(GUID("{EAB22AC1-30C1-11CF-A7EB-0000C05BAE0B}")))
+            self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{EAB22AC1-30C1-11CF-A7EB-0000C05BAE0B}")))
 
             path = QueryPathOfRegTypeLib(*info)
             path = path.split("\0")[0]
-            self.failUnless(path.lower().endswith(dllname))
+            self.assertTrue(path.lower().endswith(dllname))
 
         def test_TypeInfo(self):
             tlib = LoadTypeLibEx("shdocvw.dll")

--- a/comtypes/test/test_urlhistory.py
+++ b/comtypes/test/test_urlhistory.py
@@ -30,7 +30,7 @@ from comtypes.test.find_memleak import find_memleak
 class Test(unittest.TestCase):
     def check_leaks(self, func):
         bytes = find_memleak(func, (5, 10))
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_creation(self):
         hist = CreateObject(urlhistLib.UrlHistory)

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -29,15 +29,15 @@ class VariantTestCase(unittest.TestCase):
 
     def test_constants(self):
         empty = VARIANT.empty
-        self.failUnlessEqual(empty.vt, VT_EMPTY)
-        self.failUnless(empty.value is None)
+        self.assertEqual(empty.vt, VT_EMPTY)
+        self.assertTrue(empty.value is None)
 
         null = VARIANT.null
-        self.failUnlessEqual(null.vt, VT_NULL)
-        self.failUnless(null.value is None)
+        self.assertEqual(null.vt, VT_NULL)
+        self.assertTrue(null.value is None)
 
         missing = VARIANT.missing
-        self.failUnlessEqual(missing.vt, VT_ERROR)
+        self.assertEqual(missing.vt, VT_ERROR)
         self.assertRaises(NotImplementedError, lambda: missing.value)
 
     def test_com_refcounts(self):
@@ -46,10 +46,10 @@ class VariantTestCase(unittest.TestCase):
         rc = get_refcnt(tlb)
 
         p = tlb.QueryInterface(IUnknown)
-        self.failUnlessEqual(get_refcnt(tlb), rc+1)
+        self.assertEqual(get_refcnt(tlb), rc+1)
 
         del p
-        self.failUnlessEqual(get_refcnt(tlb), rc)
+        self.assertEqual(get_refcnt(tlb), rc)
 
     def test_com_pointers(self):
         # Storing a COM interface pointer in a VARIANT increments the refcount,
@@ -58,22 +58,22 @@ class VariantTestCase(unittest.TestCase):
         rc = get_refcnt(tlb)
 
         v = VARIANT(tlb)
-        self.failUnlessEqual(get_refcnt(tlb), rc+1)
+        self.assertEqual(get_refcnt(tlb), rc+1)
 
         p = v.value
-        self.failUnlessEqual(get_refcnt(tlb), rc+2)
+        self.assertEqual(get_refcnt(tlb), rc+2)
         del p
-        self.failUnlessEqual(get_refcnt(tlb), rc+1)
+        self.assertEqual(get_refcnt(tlb), rc+1)
 
         v.value = None
-        self.failUnlessEqual(get_refcnt(tlb), rc)
+        self.assertEqual(get_refcnt(tlb), rc)
 
     def test_null_com_pointers(self):
         p = POINTER(IUnknown)()
-        self.failUnlessEqual(get_refcnt(p), 0)
+        self.assertEqual(get_refcnt(p), 0)
 
         VARIANT(p)
-        self.failUnlessEqual(get_refcnt(p), 0)
+        self.assertEqual(get_refcnt(p), 0)
 
     def test_dispparams(self):
         # DISPPARAMS is a complex structure, well worth testing.
@@ -83,38 +83,38 @@ class VariantTestCase(unittest.TestCase):
         for i, v in enumerate(values):
             d.rgvarg[i].value = v
         result = [d.rgvarg[i].value for i in range(3)]
-        self.failUnlessEqual(result, values)
+        self.assertEqual(result, values)
 
     def test_pythonobjects(self):
-        objects = [None, 42, 3.14, True, False, "abc", u"abc", 7L]
+        objects = [None, 42, 3.14, True, False, "abc", "abc", 7]
         for x in objects:
             v = VARIANT(x)
-            self.failUnlessEqual(x, v.value)
+            self.assertEqual(x, v.value)
 
     def test_integers(self):
         v = VARIANT()
 
         if (hasattr(sys, "maxint")):
             # this test doesn't work in Python 3000
-            v.value = sys.maxint
-            self.failUnlessEqual(v.value, sys.maxint)
-            self.failUnlessEqual(type(v.value), int)
+            v.value = sys.maxsize
+            self.assertEqual(v.value, sys.maxsize)
+            self.assertEqual(type(v.value), int)
 
             v.value += 1
-            self.failUnlessEqual(v.value, sys.maxint+1)
-            self.failUnlessEqual(type(v.value), long)
+            self.assertEqual(v.value, sys.maxsize+1)
+            self.assertEqual(type(v.value), int)
 
-        v.value = 1L
-        self.failUnlessEqual(v.value, 1)
-        self.failUnlessEqual(type(v.value), int)
+        v.value = 1
+        self.assertEqual(v.value, 1)
+        self.assertEqual(type(v.value), int)
 
     def test_datetime(self):
         now = datetime.datetime.now()
 
         v = VARIANT()
         v.value = now
-        self.failUnlessEqual(v.vt, VT_DATE)
-        self.failUnlessEqual(v.value, now)
+        self.assertEqual(v.vt, VT_DATE)
+        self.assertEqual(v.value, now)
 
     def test_datetime64(self):
         np = get_numpy()
@@ -134,39 +134,39 @@ class VariantTestCase(unittest.TestCase):
         for date in dates:
             v = VARIANT()
             v.value = date
-            self.failUnlessEqual(v.vt, VT_DATE)
-            self.failUnlessEqual(v.value, date.astype(datetime.datetime))
+            self.assertEqual(v.vt, VT_DATE)
+            self.assertEqual(v.value, date.astype(datetime.datetime))
 
     def test_decimal_as_currency(self):
         value = decimal.Decimal('3.14')
 
         v = VARIANT()
         v.value = value
-        self.failUnlessEqual(v.vt, VT_CY)
-        self.failUnlessEqual(v.value, value)
+        self.assertEqual(v.vt, VT_CY)
+        self.assertEqual(v.value, value)
 
     def test_decimal_as_decimal(self):
         v = VARIANT()
         v.vt = VT_DECIMAL
         v.decVal.Lo64 = 1234
         v.decVal.scale = 3
-        self.failUnlessEqual(v.value, decimal.Decimal('1.234'))
+        self.assertEqual(v.value, decimal.Decimal('1.234'))
 
         v.decVal.sign = 0x80
-        self.failUnlessEqual(v.value, decimal.Decimal('-1.234'))
+        self.assertEqual(v.value, decimal.Decimal('-1.234'))
 
         v.decVal.scale = 28
-        self.failUnlessEqual(v.value, decimal.Decimal('-1.234e-25'))
+        self.assertEqual(v.value, decimal.Decimal('-1.234e-25'))
 
         v.decVal.scale = 12
         v.decVal.Hi32 = 100
-        self.failUnlessEqual(
+        self.assertEqual(
             v.value, decimal.Decimal('-1844674407.370955162834'))
 
     def test_BSTR(self):
         v = VARIANT()
-        v.value = u"abc\x00123\x00"
-        self.failUnlessEqual(v.value, "abc\x00123\x00")
+        v.value = "abc\x00123\x00"
+        self.assertEqual(v.value, "abc\x00123\x00")
 
         v.value = None
         # manually clear the variant
@@ -174,7 +174,7 @@ class VariantTestCase(unittest.TestCase):
 
         # NULL pointer BSTR should be handled as empty string
         v.vt = VT_BSTR
-        self.failUnless(v.value in ("", None))
+        self.assertTrue(v.value in ("", None))
 
     def test_empty_BSTR(self):
         v = VARIANT()
@@ -185,7 +185,7 @@ class VariantTestCase(unittest.TestCase):
         from comtypes.gen.TestComServerLib import MYCOLOR
         v = VARIANT(MYCOLOR(red=1.0, green=2.0, blue=3.0))
         value = v.value
-        self.failUnlessEqual((1.0, 2.0, 3.0),
+        self.assertEqual((1.0, 2.0, 3.0),
                              (value.red, value.green, value.blue))
 
         def func():
@@ -193,7 +193,7 @@ class VariantTestCase(unittest.TestCase):
             return v.value
 
         bytes = find_memleak(func)
-        self.failIf(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
     def test_ctypes_in_variant(self):
         v = VARIANT()
@@ -211,22 +211,22 @@ class VariantTestCase(unittest.TestCase):
                 ]
         for value, vt in objs:
             v.value = value
-            self.failUnlessEqual(v.vt, vt)
+            self.assertEqual(v.vt, vt)
 
     def test_byref(self):
         variable = c_int(42)
         v = VARIANT(byref(variable))
-        self.failUnlessEqual(v[0], 42)
-        self.failUnlessEqual(v.vt, VT_BYREF | VT_I4)
+        self.assertEqual(v[0], 42)
+        self.assertEqual(v.vt, VT_BYREF | VT_I4)
         variable.value = 96
-        self.failUnlessEqual(v[0], 96)
+        self.assertEqual(v[0], 96)
 
         variable = c_int(42)
         v = VARIANT(pointer(variable))
-        self.failUnlessEqual(v[0], 42)
-        self.failUnlessEqual(v.vt, VT_BYREF | VT_I4)
+        self.assertEqual(v[0], 42)
+        self.assertEqual(v.vt, VT_BYREF | VT_I4)
         variable.value = 96
-        self.failUnlessEqual(v[0], 96)
+        self.assertEqual(v[0], 96)
 
 
 class NdArrayTest(unittest.TestCase):
@@ -240,7 +240,7 @@ class NdArrayTest(unittest.TestCase):
             a = np.array([1.0, 2.0, 3.0, 4.5], dtype=dtype)
             v = VARIANT()
             v.value = a
-            self.failUnless((v.value == a).all())
+            self.assertTrue((v.value == a).all())
 
     def test_int(self):
         np = get_numpy()
@@ -251,7 +251,7 @@ class NdArrayTest(unittest.TestCase):
             a = np.array((1, 1, 1, 1), dtype=dtype)
             v = VARIANT()
             v.value = a
-            self.failUnless((v.value == a).all())
+            self.assertTrue((v.value == a).all())
 
     def test_mixed(self):
         np = get_numpy()
@@ -263,7 +263,7 @@ class NdArrayTest(unittest.TestCase):
             [11, "22", None, True, now, decimal.Decimal("3.14")]).reshape(2,3)
         v = VARIANT()
         v.value = a
-        self.failUnless((v.value == a).all())
+        self.assertTrue((v.value == a).all())
 
 
 class ArrayTest(unittest.TestCase):
@@ -275,7 +275,7 @@ class ArrayTest(unittest.TestCase):
             a = array.array(typecode, (1.0, 2.0, 3.0, 4.5))
             v = VARIANT()
             v.value = a
-            self.failUnlessEqual(v.value, (1.0, 2.0, 3.0, 4.5))
+            self.assertEqual(v.value, (1.0, 2.0, 3.0, 4.5))
 
     def test_int(self):
         import array
@@ -283,7 +283,7 @@ class ArrayTest(unittest.TestCase):
             a = array.array(typecode, (1, 1, 1, 1))
             v = VARIANT()
             v.value = a
-            self.failUnlessEqual(v.value, (1, 1, 1, 1))
+            self.assertEqual(v.value, (1, 1, 1, 1))
 
 ################################################################
 def run_test(rep, msg, func=None, previous={}, results={}):
@@ -291,7 +291,7 @@ def run_test(rep, msg, func=None, previous={}, results={}):
     if func is None:
         locals = sys._getframe(1).f_locals
         func = eval("lambda: %s" % msg, locals)
-    items = xrange(rep)
+    items = range(rep)
     from time import clock
     start = clock()
     for i in items:
@@ -301,11 +301,11 @@ def run_test(rep, msg, func=None, previous={}, results={}):
     try:
         prev = previous[msg]
     except KeyError:
-        print >> sys.stderr, "%40s: %7.1f us" % (msg, duration)
+        print("%40s: %7.1f us" % (msg, duration), file=sys.stderr)
         delta = 0.0
     else:
         delta = duration / prev * 100.0
-        print >> sys.stderr, "%40s: %7.1f us, time = %5.1f%%" % (msg, duration, delta)
+        print("%40s: %7.1f us, time = %5.1f%%" % (msg, duration, delta), file=sys.stderr)
     results[msg] = duration
     return delta
 
@@ -314,14 +314,14 @@ def check_perf(rep=20000):
     from ctypes import c_int, byref
     from comtypes.automation import VARIANT
     import comtypes.automation
-    print comtypes.automation
+    print(comtypes.automation)
     variable = c_int()
     by_var = byref(variable)
     ptr_var = pointer(variable)
 
-    import cPickle
+    import pickle
     try:
-        previous = cPickle.load(open("result.pickle", "rb"))
+        previous = pickle.load(open("result.pickle", "rb"))
     except IOError:
         previous = {}
 
@@ -341,7 +341,7 @@ def check_perf(rep=20000):
     d += run_test(rep, "VARIANT((42,)).value", previous=previous, results=results)
     d += run_test(rep, "VARIANT([42,]).value", previous=previous, results=results)
 
-    print "Average duration %.1f%%" % (d / 10)
+    print("Average duration %.1f%%" % (d / 10))
 ##    cPickle.dump(results, open("result.pickle", "wb"))
 
 if __name__ == '__main__':
@@ -350,5 +350,5 @@ if __name__ == '__main__':
     except SystemExit:
         pass
     import comtypes
-    print "Running benchmark with comtypes %s/Python %s ..." % (comtypes.__version__, sys.version.split()[0],)
+    print("Running benchmark with comtypes %s/Python %s ..." % (comtypes.__version__, sys.version.split()[0],))
     check_perf()

--- a/comtypes/test/test_win32com_interop.py
+++ b/comtypes/test/test_win32com_interop.py
@@ -66,29 +66,29 @@ class Test(unittest.TestCase):
         o = MyComObject()
         p = comtypes2pywin(o, IDispatch)
         disp = win32com.client.Dispatch(p)
-        self.failUnlessEqual(repr(disp), "<COMObject <unknown>>")
+        self.assertEqual(repr(disp), "<COMObject <unknown>>")
 
     def test_ie(self):
         # Convert a comtypes COM interface pointer into a win32com COM
         # pointer.
         ie = self.ie = CreateObject("InternetExplorer.Application")
         # The COM refcount of the created object is 1:
-        self.failUnlessEqual(comtypes_get_refcount(ie), 1)
+        self.assertEqual(comtypes_get_refcount(ie), 1)
         # IE starts invisible:
-        self.failUnlessEqual(ie.Visible, False)
+        self.assertEqual(ie.Visible, False)
 
         # Create a pythoncom PyIDispatch object from it:
         p = comtypes2pywin(ie, interface=IDispatch)
-        self.failUnlessEqual(comtypes_get_refcount(ie), 2)
+        self.assertEqual(comtypes_get_refcount(ie), 2)
 
         # Make it usable...
         disp = win32com.client.Dispatch(p)
-        self.failUnlessEqual(comtypes_get_refcount(ie), 2)
-        self.failUnlessEqual(disp.Visible, False)
+        self.assertEqual(comtypes_get_refcount(ie), 2)
+        self.assertEqual(disp.Visible, False)
 
         # Cleanup and make sure that the COM refcounts are correct
         del p, disp
-        self.failUnlessEqual(comtypes_get_refcount(ie), 1)
+        self.assertEqual(comtypes_get_refcount(ie), 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_wmi.py
+++ b/comtypes/test/test_wmi.py
@@ -31,22 +31,22 @@ class Test(ut.TestCase):
             a = item.Properties_["Caption"].Value
             b = item.Properties_.Item("Caption").Value
             c = item.Properties_("Caption").Value
-            self.failUnlessEqual(a, b)
-            self.failUnlessEqual(a, c)
-            self.failUnless(isinstance(a, basestring))
-            self.failUnless(isinstance(b, basestring))
-            self.failUnless(isinstance(c, basestring))
+            self.assertEqual(a, b)
+            self.assertEqual(a, c)
+            self.assertTrue(isinstance(a, str))
+            self.assertTrue(isinstance(b, str))
+            self.assertTrue(isinstance(c, str))
             result = {}
             for prop in item.Properties_:
-                self.failUnless(isinstance(prop.Name, basestring))
+                self.assertTrue(isinstance(prop.Name, str))
                 prop.Value
                 result[prop.Name] = prop.Value
 ##                print "\t", (prop.Name, prop.Value)
-            self.failUnlessEqual(len(item.Properties_), item.Properties_.Count)
-            self.failUnlessEqual(len(item.Properties_), len(result))
-            self.failUnless(isinstance(item.Properties_["Description"].Value, unicode))
+            self.assertEqual(len(item.Properties_), item.Properties_.Count)
+            self.assertEqual(len(item.Properties_), len(result))
+            self.assertTrue(isinstance(item.Properties_["Description"].Value, str))
         # len(obj) is forwared to obj.Count
-        self.failUnlessEqual(len(disks), disks.Count)
+        self.assertEqual(len(disks), disks.Count)
 
 if __name__ == "__main__":
     ut.main()

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -130,7 +130,7 @@ class Parser(object):
         elif tdesc.vt == automation.VT_USERDEFINED:
             try:
                 ti = tinfo.GetRefTypeInfo(tdesc._.hreftype)
-            except COMError, details:
+            except COMError as details:
                 type_name = "__error_hreftype_%d__" % tdesc._.hreftype
                 tlib_name = get_tlib_filename(self.tlib)
                 if tlib_name is None:
@@ -620,7 +620,7 @@ class Parser(object):
         elif tkind == typeinfo.TKIND_UNION: # 7
             return self.ParseUnion(tinfo, ta)
         else:
-            print "NYI", tkind
+            print("NYI", tkind)
 ##            raise "NYI", tkind
 
     def parse_LibraryDescription(self):
@@ -757,12 +757,12 @@ def generate_module(tlib, ofi, pathname):
         pathname = get_tlib_filename(tlib)
     items = p.parse()
 
-    from codegenerator import Generator
+    from .codegenerator import Generator
 
     gen = Generator(ofi,
                     known_symbols=known_symbols,
                     )
 
-    gen.generate_code(items.values(), filename=pathname)
+    gen.generate_code(list(items.values()), filename=pathname)
 
 # -eof-

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -315,7 +315,7 @@ class ITypeInfo(IUnknown):
 
     def AddressOfMember(self, memid, invkind):
         "Get the address of a function in a dll"
-        raise "Check Me"
+        raise RuntimeError("Check Me")
         p = c_void_p()
         self.__com_AddressOfMember(memid, invkind, byref(p))
         # XXX Would the default impl return the value of p?


### PR DESCRIPTION
since 2.x is no longer being supported build_py_2to3 in distutils has been dropped and that is the reason why on python 3.9 and above installations there is no 2 to 3 conversion done. 

This is what the 2 to 3 conversion outputs when installing on python 3.8.