### PR TITLE
Python 3 setup support (setuptools downgrade)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.eggs/
+*.egg-info/
+build/
+dist/

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 """comtypes package install script"""
 import sys
 import os
@@ -15,6 +17,9 @@ except ImportError:
 
 with open('README') as readme_stream:
     readme = readme_stream.read()
+
+SETUPTOOLS_PY3_SUPPORT = "setuptools<=57.5.0"
+
 
 class test(Command):
     # Original version of this class posted
@@ -124,7 +129,7 @@ class post_install(install):
 
 
 setup_params = dict(
-    name="comtypes",
+    name="comtypes-fork",
     description="Pure Python COM package",
     long_description = readme,
     author="Thomas Heller",
@@ -162,6 +167,10 @@ setup_params = dict(
         "comtypes.tools",
         "comtypes.test",
     ],
+    # Preserve Python 3 compatibility during building & installation with pip.
+    setup_requires=[SETUPTOOLS_PY3_SUPPORT,],
+    # Also trick pip to put the forked package replacement on top of the official one.
+    install_requires=[SETUPTOOLS_PY3_SUPPORT, "comtypes"],
 )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ class post_install(install):
 
 
 setup_params = dict(
-    name="comtypes-fork",
+    name="comtypes",
     description="Pure Python COM package",
     long_description = readme,
     author="Thomas Heller",
@@ -169,8 +169,7 @@ setup_params = dict(
     ],
     # Preserve Python 3 compatibility during building & installation with pip.
     setup_requires=[SETUPTOOLS_PY3_SUPPORT,],
-    # Also trick pip to put the forked package replacement on top of the official one.
-    install_requires=[SETUPTOOLS_PY3_SUPPORT, "comtypes"],
+    install_requires=[SETUPTOOLS_PY3_SUPPORT],
 )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ setup_params = dict(
     ],
     # Preserve Python 3 compatibility during building & installation with pip.
     setup_requires=[SETUPTOOLS_PY3_SUPPORT,],
-    install_requires=[SETUPTOOLS_PY3_SUPPORT],
+    install_requires=[SETUPTOOLS_PY3_SUPPORT,],
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pins `setuptools<=57.5.0` in order to `pip install` with build-time Python 2 to 3 conversion support, otherwise you'll end up with the Python 2 flavor of the package under Python 3 envs.