### PR TITLE
Restore Python2.7 support without 2to3 fixer + timestamping fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,10 +3,11 @@ Comtypes CHANGELOG
 
 Release 1.1.11
 -------------
- * Fix Python 3.9+ compatibility. Thanks @kdschlosser.
+ * Fix setuptools>=60.0.0 compatibility. Thanks @kdschlosser.
  * Fix timestamping for typelib. Thanks @fusentasticus.
  * Fix 64bit inproc server.
- * Python 2.6 support is dropped.
+ * Drop Python 2.6 support.
+ * Fix IndexError for empty safearray. Thanks @BALOGHBence.
 
 Release 1.1.10
 -------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,9 +3,10 @@ Comtypes CHANGELOG
 
 Release 1.1.11
 -------------
- * Fix Python 3 compatibility. Thanks @kdschlosser.
- * Fix `tlib_mtime` in the absence of typelib.
+ * Fix Python 3.9+ compatibility. Thanks @kdschlosser.
+ * Fix timestamping for typelib. Thanks @fusentasticus.
  * Fix 64bit inproc server.
+ * Python 2.6 support is dropped.
 
 Release 1.1.10
 -------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2015
+image: Visual Studio 2022
 build: off
 max_jobs: 3
 
@@ -9,8 +9,6 @@ shallow_clone: true
  
 environment:
    matrix:
-     - py: Python26
-     - py: Python26-x64
      - py: Python27
      - py: Python27-x64
      - py: Python33
@@ -21,6 +19,10 @@ environment:
      - py: Python35-x64
      - py: Python36
      - py: Python36-x64
+     - py: Python39
+     - py: Python39-x64
+     - py: Python310
+     - py: Python310-x64
 
 test_script:
    - C:\%py%\python.exe setup.py install

--- a/comtypes/GUID.py
+++ b/comtypes/GUID.py
@@ -8,6 +8,13 @@ else:
     def binary(obj):
         return buffer(obj)
 
+if sys.version_info >= (3, 0):
+    text_type = str
+    base_text_type = str
+else:
+    text_type = unicode
+    base_text_type = basestring
+
 BYTE = c_byte
 WORD = c_ushort
 DWORD = c_ulong
@@ -32,10 +39,10 @@ class GUID(Structure):
 
     def __init__(self, name=None):
         if name is not None:
-            _CLSIDFromString(str(name), byref(self))
+            _CLSIDFromString(text_type(name), byref(self))
 
     def __repr__(self):
-        return 'GUID("%s")' % str(self)
+        return 'GUID("%s")' % text_type(self)
 
     def __unicode__(self):
         p = c_wchar_p()
@@ -62,7 +69,7 @@ class GUID(Structure):
         return hash(binary(self))
 
     def copy(self):
-        return GUID(str(self))
+        return GUID(text_type(self))
 
     def from_progid(cls, progid):
         """Get guid from progid, ...
@@ -71,11 +78,11 @@ class GUID(Structure):
             progid = progid._reg_clsid_
         if isinstance(progid, cls):
             return progid
-        elif isinstance(progid, str):
+        elif isinstance(progid, base_text_type):
             if progid.startswith("{"):
                 return cls(progid)
             inst = cls()
-            _CLSIDFromProgID(str(progid), byref(inst))
+            _CLSIDFromProgID(text_type(progid), byref(inst))
             return inst
         else:
             raise TypeError("Cannot construct guid from %r" % progid)

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -897,7 +897,27 @@ class named_property(object):
 ################################################################
 
 def add_metaclass(metaclass):
-    """Class decorator from six.py for creating a class with a metaclass."""
+    """Class decorator from six.py for creating a class with a metaclass.
+
+    Copyright (c) 2010-2020 Benjamin Peterson
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    """
     def wrapper(cls):
         orig_vars = cls.__dict__.copy()
         slots = orig_vars.get('__slots__')

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -5,6 +5,11 @@ import os
 # comtypes version numbers follow semver (http://semver.org/) and PEP 440
 __version__ = "1.1.11"
 
+if sys.version_info >= (3, 0):
+    text_type = str
+else:
+    text_type = unicode
+
 import logging
 class NullHandler(logging.Handler):
     """A Handler that does nothing."""
@@ -488,7 +493,7 @@ class _cominterface_meta(type):
                 if is_prop:
                     self.__map_case__[name[5:].lower()] = name[5:]
 
-        for (name, nargs), methods in list(properties.items()):
+        for (name, nargs), methods in properties.items():
             # methods contains [propget or None, propput or None, propputref or None]
             if methods[1] is not None and methods[2] is not None:
                 # both propput and propputref.
@@ -655,7 +660,7 @@ class _cominterface_meta(type):
                 return rescode
 
             rescode = list(rescode)
-            for outnum, o in list(outargs.items()):
+            for outnum, o in outargs.items():
                 rescode[outnum] = o.__ctypes_from_outparam__()
             return rescode
         return call_with_inout
@@ -670,7 +675,7 @@ class _cominterface_meta(type):
         except KeyError:
             raise AttributeError("this class must define an _iid_")
         else:
-            iid = str(iid)
+            iid = text_type(iid)
 ##            if iid in com_interface_registry:
 ##                # Warn when multiple interfaces are defined with identical iids.
 ##                # This would also trigger if we reload() a module that contains
@@ -779,7 +784,7 @@ class _cominterface_meta(type):
                     self.__map_case__[name[5:].lower()] = name[5:]
 
         # create public properties / attribute accessors
-        for (name, doc, nargs), methods in list(properties.items()):
+        for (name, doc, nargs), methods in properties.items():
             # methods contains [propget or None, propput or None, propputref or None]
             if methods[1] is not None and methods[2] is not None:
                 # both propput and propputref.
@@ -891,11 +896,31 @@ class named_property(object):
 
 ################################################################
 
+def add_metaclass(metaclass):
+    """Class decorator from six.py for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, text_type):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+################################################################
+
 class _compointer_meta(type(c_void_p), _cominterface_meta):
     "metaclass for COM interface pointer classes"
     # no functionality, but needed to avoid a metaclass conflict
 
-class _compointer_base(c_void_p, metaclass=_compointer_meta):
+@add_metaclass(_compointer_meta)
+class _compointer_base(c_void_p):
     "base class for COM interface pointer classes"
     def __del__(self, _debug=logger.debug):
         "Release the COM refcount we own."
@@ -1016,7 +1041,7 @@ class BSTR(_SimpleCData):
 ################################################################
 # IDL stuff
 
-class helpstring(str):
+class helpstring(text_type):
     "Specifies the helpstring for a COM method or property."
 
 class defaultvalue(object):
@@ -1122,7 +1147,8 @@ def COMMETHOD(idlflags, restype, methodname, *argspec):
 ################################################################
 # IUnknown, the root of all evil...
 
-class IUnknown(object, metaclass=_cominterface_meta):
+@add_metaclass(_cominterface_meta)
+class IUnknown(object):
     """The most basic COM interface.
 
     Each subclasses of IUnknown must define these class attributes:
@@ -1200,7 +1226,7 @@ def CoGetObject(displayname, interface):
         interface = IUnknown
     punk = POINTER(interface)()
     # Do we need a way to specify the BIND_OPTS parameter?
-    _ole32.CoGetObject(str(displayname),
+    _ole32.CoGetObject(text_type(displayname),
                        None,
                        byref(interface._iid_),
                        byref(punk))
@@ -1379,6 +1405,7 @@ from comtypes._comobject import COMObject
 
 from comtypes._meta import _coclass_meta
 
-class CoClass(COMObject, metaclass=_coclass_meta):
+@add_metaclass(_coclass_meta)
+class CoClass(COMObject):
     pass
 ################################################################

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -5,6 +5,7 @@ from ctypes import (
 from _ctypes import CopyComPointer
 import logging
 import os
+import sys
 
 from comtypes import COMError, ReturnHRESULT, instancemethod, _encode_idl
 from comtypes.errorinfo import ISupportErrorInfo, ReportException, ReportError
@@ -20,6 +21,11 @@ logger = logging.getLogger(__name__)
 _debug = logger.debug
 _warning = logger.warning
 _error = logger.error
+
+if sys.version_info >= (3, 0):
+    int_types = (int, )
+else:
+    int_types = (int, long)
 
 ################################################################
 # COM object implementation
@@ -51,7 +57,7 @@ def winerror(exc):
         return exc.hresult
     elif isinstance(exc, WindowsError):
         code = exc.winerror
-        if isinstance(code, int):
+        if isinstance(code, int_types):
             return code
         # Sometimes, a WindowsError instance has no error code.  An access
         # violation raised by ctypes has only text, for example.  In this
@@ -333,7 +339,10 @@ class LocalServer(object):
         messageloop.run()
 
     def run_mta(self):
-        import queue
+        if sys.version_info >= (3, 0):
+            import queue
+        else:
+            import Queue as queue
         self._queue = queue.Queue()
         self._queue.get()
 

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -8,6 +8,11 @@ import importlib
 import logging
 logger = logging.getLogger(__name__)
 
+if sys.version_info >= (3, 0):
+    base_text_type = str
+else:
+    base_text_type = basestring
+
 PATH = os.environ["PATH"].split(os.pathsep)
 
 def _my_import(fullname):
@@ -70,7 +75,7 @@ def GetModule(tlib):
     latter is a short stub loading the former.
     """
     pathname = None
-    if isinstance(tlib, str):
+    if isinstance(tlib, base_text_type):
         # pathname of type library
         if not os.path.isabs(tlib):
             # If a relative pathname is used, we try to interpret
@@ -93,7 +98,10 @@ def GetModule(tlib):
         clsid = str(tlib)
         
         # lookup associated typelib in registry
-        import winreg
+        if sys.version_info >= (3, 0):
+            import winreg
+        else:
+            import _winreg as winreg
         with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\TypeLib" % clsid, 0, winreg.KEY_READ) as key:
             typelib = winreg.EnumValue(key, 0)[1]
         with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\Version" % clsid, 0, winreg.KEY_READ) as key:
@@ -174,7 +182,10 @@ def _CreateWrapper(tlib, pathname=None):
     # generate the module since it doesn't exist or is out of date
     from comtypes.tools.tlbparser import generate_module
     if comtypes.client.gen_dir is None:
-        import io
+        if sys.version_info >= (3, 0):
+            import io
+        else:
+            import cStringIO as io
         ofi = io.StringIO()
     else:
         ofi = open(os.path.join(comtypes.client.gen_dir, modname + ".py"), "w")

--- a/comtypes/client/dynamic.py
+++ b/comtypes/client/dynamic.py
@@ -1,3 +1,4 @@
+import sys
 import ctypes
 import comtypes.automation
 import comtypes.typeinfo
@@ -153,11 +154,18 @@ class _Collection(object):
     def __init__(self, enum):
         self.enum = enum
 
-    def __next__(self):
-        item, fetched = self.enum.Next(1)
-        if fetched:
-            return item
-        raise StopIteration
+    if sys.version_info >= (3, 0):
+        def __next__(self):
+            item, fetched = self.enum.Next(1)
+            if fetched:
+                return item
+            raise StopIteration
+    else:
+        def next(self):
+            item, fetched = self.enum.Next(1)
+            if fetched:
+                return item
+            raise StopIteration
 
     def __iter__(self):
         return self

--- a/comtypes/connectionpoints.py
+++ b/comtypes/connectionpoints.py
@@ -1,3 +1,4 @@
+import sys
 from ctypes import *
 from comtypes import IUnknown, COMMETHOD, GUID, HRESULT, dispid
 _GUID = GUID
@@ -26,11 +27,18 @@ class IEnumConnections(IUnknown):
     def __iter__(self):
         return self
 
-    def __next__(self):
-        cp, fetched = self.Next(1)
-        if fetched == 0:
-            raise StopIteration
-        return cp
+    if sys.version_info >= (3, 0):
+        def __next__(self):
+            cp, fetched = self.Next(1)
+            if fetched == 0:
+                raise StopIteration
+            return cp
+    else:
+        def next(self):
+            cp, fetched = self.Next(1)
+            if fetched == 0:
+                raise StopIteration
+            return cp
 
 class IEnumConnectionPoints(IUnknown):
     _iid_ = GUID('{B196B285-BAB4-101A-B69C-00AA00341D07}')
@@ -39,11 +47,18 @@ class IEnumConnectionPoints(IUnknown):
     def __iter__(self):
         return self
 
-    def __next__(self):
-        cp, fetched = self.Next(1)
-        if fetched == 0:
-            raise StopIteration
-        return cp
+    if sys.version_info >= (3, 0):
+        def __next__(self):
+            cp, fetched = self.Next(1)
+            if fetched == 0:
+                raise StopIteration
+            return cp
+    else:
+        def next(self):
+            cp, fetched = self.Next(1)
+            if fetched == 0:
+                raise StopIteration
+            return cp
 
 ################################################################
 

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -6,6 +6,11 @@ from comtypes.hresult import *
 LPCOLESTR = c_wchar_p
 DWORD = c_ulong
 
+if sys.version_info >= (3, 0):
+    base_text_type = str
+else:
+    base_text_type = basestring
+
 class ICreateErrorInfo(IUnknown):
     _iid_ = GUID("{22F03340-547D-101B-8E65-08002B2BD119}")
     _methods_ = [
@@ -73,7 +78,7 @@ def ReportError(text, iid,
     if helpcontext is not None:
         ei.SetHelpContext(helpcontext)
     if clsid is not None:
-        if isinstance(clsid, str):
+        if isinstance(clsid, base_text_type):
             clsid = GUID(clsid)
         try:
             progid = clsid.as_progid()

--- a/comtypes/logutil.py
+++ b/comtypes/logutil.py
@@ -9,7 +9,7 @@ class NTDebugHandler(logging.Handler):
         if isinstance(text, str):
             writeA(text + "\n")
         else:
-            writeW(text + "\n")
+            writeW(text + u"\n")
 logging.NTDebugHandler = NTDebugHandler
 
 def setup_logging(*pathnames):

--- a/comtypes/patcher.py
+++ b/comtypes/patcher.py
@@ -52,7 +52,7 @@ class Patch(object):
         self.target = target
 
     def __call__(self, patches):
-        for name, value in list(vars(patches).items()):
+        for name, value in vars(patches).items():
             if name in vars(ReferenceEmptyClass):
                 continue
             no_replace = getattr(value, '__no_replace', False)

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -236,7 +236,12 @@ def _make_safearray_type(itemtype):
             """Unpack a POINTER(SAFEARRAY_...) into a Python tuple or ndarray."""
             dim = _safearray.SafeArrayGetDim(self)
 
-            if dim == 1:
+            if dim == 0:
+                if safearray_as_ndarray:
+                    import numpy
+                    return numpy.array()
+                return tuple()
+            elif dim == 1:
                 num_elements = self._get_size(1)
                 result = self._get_elements_raw(num_elements)
                 if safearray_as_ndarray:

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -58,7 +58,7 @@ class ConnectionPointImpl(COMObject):
         if hasattr(self._sink_interface, "Invoke"):
             # for better performance, we could cache the dispids.
             dispid = self._typeinfo.GetIDsOfNames(name)[0]
-            for key, p in list(self._connections.items()):
+            for key, p in self._connections.items():
                 try:
                     result = p.Invoke(dispid, *args, **kw)
                 except COMError as details:
@@ -76,7 +76,7 @@ class ConnectionPointImpl(COMObject):
                 else:
                     results.append(result)
         else:
-            for p in list(self._connections.values()):
+            for p in self._connections.values():
                 try:
                     result = getattr(p, name)(*args, **kw)
                 except COMError as details:

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -3,7 +3,12 @@ from comtypes import COMObject, GUID
 from comtypes.server import IClassFactory
 from comtypes.hresult import *
 
-import sys, winreg, logging
+import sys
+import logging
+if sys.version_info >= (3, 0):
+    import winreg
+else:
+    import _winreg as winreg
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug
@@ -119,7 +124,7 @@ def DllGetClassObject(rclsid, riid, ppv):
         if not cls:
             return CLASS_E_CLASSNOTAVAILABLE
 
-        result = ClassFactory(cls).IUnknown_QueryInterface(None, ctypes.pointer(iid), ppv)
+        result = ClassFactory(cls).IUnknown_QueryInterface(None, ctypes.pointer(iid), ctypes.c_void_p(ppv))
         _debug("DllGetClassObject() -> %s", result)
         return result
     except Exception:

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -1,9 +1,13 @@
+import sys
 from ctypes import *
 import comtypes
 from comtypes.hresult import *
 from comtypes.server import IClassFactory
 import logging
-import queue
+if sys.version_info >= (3, 0):
+    import queue
+else:
+    import Queue as queue
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -36,7 +36,10 @@ Now, debug the object, and when done delete logging info:
   python mycomobj.py /nodebug
 """
 import sys, os
-import winreg
+if sys.version_info >= (3, 0):
+    import winreg
+else:
+    import _winreg as winreg
 import logging
 
 import comtypes

--- a/comtypes/shelllink.py
+++ b/comtypes/shelllink.py
@@ -185,7 +185,7 @@ class IShellLinkW(IUnknown):
         return buf.value, iIcon.value
 
 class ShellLink(CoClass):
-    'ShellLink class'
+    """ShellLink class"""
     _reg_clsid_ = GUID('{00021401-0000-0000-C000-000000000046}')
     _idlflags_ = []
     _com_interfaces_ = [IShellLinkW, IShellLinkA]

--- a/comtypes/test/TestComServer.py
+++ b/comtypes/test/TestComServer.py
@@ -115,7 +115,7 @@ class TestComServer(
     def ITestComServer_Exec2(self, what):
         exec(what)
 
-    _name = "spam, spam, spam"
+    _name = u"spam, spam, spam"
 
     def _get_name(self):
         return self._name
@@ -147,4 +147,7 @@ if __name__ == "__main__":
     except Exception:
         import traceback
         traceback.print_exc()
-        input()
+        if sys.version_info >= (3, 0):
+            input()
+        else:
+            raw_input()

--- a/comtypes/test/TestDispServer.py
+++ b/comtypes/test/TestDispServer.py
@@ -82,7 +82,7 @@ class TestDispServer(
     def DTestDispServer_Exec2(self, what):
         exec(what)
 
-    _name = "spam, spam, spam"
+    _name = u"spam, spam, spam"
 
     # Implementation of the DTestDispServer::Name propget
     def DTestDispServer__get_name(self, this, pname):

--- a/comtypes/test/test_BSTR.py
+++ b/comtypes/test/test_BSTR.py
@@ -14,14 +14,14 @@ class Test(unittest.TestCase):
 
     def test_creation(self):
         def doit():
-            BSTR("abcdef" * 100)
+            BSTR(u"abcdef" * 100)
         # It seems this test is unreliable.  Sometimes it leaks 4096
         # bytes, sometimes not.  Try to workaround that...
         self.check_leaks(doit, limit=4096)
 
     def test_from_param(self):
         def doit():
-            BSTR.from_param("abcdef")
+            BSTR.from_param(u"abcdef")
         self.check_leaks(doit)
 
     def test_paramflags(self):
@@ -30,9 +30,9 @@ class Test(unittest.TestCase):
         func.restype = c_void_p
         func.argtypes = (BSTR, )
         def doit():
-            func("abcdef")
-            func("abc xyz")
-            func(BSTR("abc def"))
+            func(u"abcdef")
+            func(u"abc xyz")
+            func(BSTR(u"abc def"))
         self.check_leaks(doit)
 
     def test_inargs(self):
@@ -43,8 +43,8 @@ class Test(unittest.TestCase):
         self.assertEqual(SysStringLen("abc xyz"), 7)
         def doit():
             SysStringLen("abc xyz")
-            SysStringLen("abc xyz")
-            SysStringLen(BSTR("abc def"))
+            SysStringLen(u"abc xyz")
+            SysStringLen(BSTR(u"abc def"))
         self.check_leaks(doit)
 
 if __name__ == "__main__":

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -19,7 +19,7 @@ class BasicTest(ut.TestCase):
 
     def test_refcounts(self):
         p = POINTER(IUnknown)()
-        windll.oleaut32.CreateTypeLib2(1, "blabla", byref(p))
+        windll.oleaut32.CreateTypeLib2(1, u"blabla", byref(p))
         # initial refcount is 2
         for i in range(2, 10):
             self.assertEqual(p.AddRef(), i)
@@ -28,7 +28,7 @@ class BasicTest(ut.TestCase):
 
     def test_qi(self):
         p = POINTER(IUnknown)()
-        windll.oleaut32.CreateTypeLib2(1, "blabla", byref(p))
+        windll.oleaut32.CreateTypeLib2(1, u"blabla", byref(p))
         self.assertEqual(p.AddRef(), 2)
         self.assertEqual(p.Release(), 1)
 

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -1,3 +1,4 @@
+import sys
 import unittest as ut
 import comtypes.client
 from comtypes import COSERVERINFO
@@ -9,6 +10,11 @@ from comtypes.gen import Scripting
 
 import comtypes.test
 comtypes.test.requires("ui")
+
+if sys.version_info >= (3, 0):
+    text_type = str
+else:
+    text_type = unicode
 
 class Test(ut.TestCase):
     def test_progid(self):
@@ -23,7 +29,7 @@ class Test(ut.TestCase):
 
     def test_clsid_string(self):
         # create from string clsid
-        comtypes.client.CreateObject(str(Scripting.Dictionary._reg_clsid_))
+        comtypes.client.CreateObject(text_type(Scripting.Dictionary._reg_clsid_))
         comtypes.client.CreateObject(str(Scripting.Dictionary._reg_clsid_))
 
     def test_GetModule_clsid(self):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -59,13 +59,13 @@ class TestInproc(unittest.TestCase):
         def test_set_name(self):
             obj = self.create_object()
             def func():
-                obj.name = "abcde"
+                obj.name = u"abcde"
             self._find_memleak(func)
 
         def test_SetName(self):
             obj = self.create_object()
             def func():
-                obj.SetName("abcde")
+                obj.SetName(u"abcde")
             self._find_memleak(func)
 
 

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -1,3 +1,4 @@
+import sys
 from ctypes import *
 import unittest
 
@@ -5,6 +6,12 @@ import comtypes.test
 comtypes.test.requires("devel")
 
 from comtypes import BSTR, IUnknown, GUID, COMMETHOD, HRESULT
+
+if sys.version_info >= (3, 0):
+    text_type = str
+else:
+    text_type = unicode
+
 class IMalloc(IUnknown):
     _iid_ = GUID("{00000002-0000-0000-C000-000000000046}")
     _methods_ = [
@@ -37,7 +44,7 @@ def from_outparm(self):
 c_wchar_p.__ctypes_from_outparam__ = from_outparm
 
 def comstring(text, typ=c_wchar_p):
-    text = str(text)
+    text = text_type(text)
     size = (len(text) + 1) * sizeof(c_wchar)
     mem = windll.ole32.CoTaskMemAlloc(size)
     print("malloc'd 0x%x, %d bytes" % (mem, size))

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -86,7 +86,10 @@ class VariantTestCase(unittest.TestCase):
         self.assertEqual(result, values)
 
     def test_pythonobjects(self):
-        objects = [None, 42, 3.14, True, False, "abc", "abc", 7]
+        if sys.version_info >= (3, 0):
+            objects = [None, 42, 3.14, True, False, "abc", "abc", 7]
+        else:
+            objects = [None, 42, 3.14, True, False, "abc", u"abc", 7L]
         for x in objects:
             v = VARIANT(x)
             self.assertEqual(x, v.value)
@@ -102,9 +105,15 @@ class VariantTestCase(unittest.TestCase):
 
             v.value += 1
             self.assertEqual(v.value, sys.maxsize+1)
-            self.assertEqual(type(v.value), int)
+            if sys.version_info >= (3, 0):
+                self.assertEqual(type(v.value), int)
+            else:
+                self.assertEqual(type(v.value), long)
 
-        v.value = 1
+        if sys.version_info >= (3, 0):
+            v.value = 1
+        else:
+            v.value = 1L
         self.assertEqual(v.value, 1)
         self.assertEqual(type(v.value), int)
 
@@ -165,7 +174,7 @@ class VariantTestCase(unittest.TestCase):
 
     def test_BSTR(self):
         v = VARIANT()
-        v.value = "abc\x00123\x00"
+        v.value = u"abc\x00123\x00"
         self.assertEqual(v.value, "abc\x00123\x00")
 
         v.value = None
@@ -319,7 +328,10 @@ def check_perf(rep=20000):
     by_var = byref(variable)
     ptr_var = pointer(variable)
 
-    import pickle
+    if sys.version_info >= (3, 0):
+        import pickle
+    else:
+        import cPickle as pickle
     try:
         previous = pickle.load(open("result.pickle", "rb"))
     except IOError:

--- a/comtypes/test/test_wmi.py
+++ b/comtypes/test/test_wmi.py
@@ -1,9 +1,17 @@
+import sys
 import unittest as ut
 from ctypes import POINTER
 from comtypes.client import CoGetObject
 from comtypes.test import requires
 
 requires("time")
+
+if sys.version_info >= (3, 0):
+    base_text_type = str
+    text_type = str
+else:
+    base_text_type = basestring
+    text_type = unicode
 
 # WMI has dual interfaces.
 # Some methods/properties have "[out] POINTER(VARIANT)" parameters.
@@ -33,18 +41,18 @@ class Test(ut.TestCase):
             c = item.Properties_("Caption").Value
             self.assertEqual(a, b)
             self.assertEqual(a, c)
-            self.assertTrue(isinstance(a, str))
-            self.assertTrue(isinstance(b, str))
-            self.assertTrue(isinstance(c, str))
+            self.assertTrue(isinstance(a, base_text_type))
+            self.assertTrue(isinstance(b, base_text_type))
+            self.assertTrue(isinstance(c, base_text_type))
             result = {}
             for prop in item.Properties_:
-                self.assertTrue(isinstance(prop.Name, str))
+                self.assertTrue(isinstance(prop.Name, base_text_type))
                 prop.Value
                 result[prop.Name] = prop.Value
 ##                print "\t", (prop.Name, prop.Value)
             self.assertEqual(len(item.Properties_), item.Properties_.Count)
             self.assertEqual(len(item.Properties_), len(result))
-            self.assertTrue(isinstance(item.Properties_["Description"].Value, str))
+            self.assertTrue(isinstance(item.Properties_["Description"].Value, text_type))
         # len(obj) is forwared to obj.Count
         self.assertEqual(len(disks), disks.Count)
 

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1,7 +1,11 @@
 # Code generator to generate code for everything contained in COM type
 # libraries.
 import os
-import io
+import sys
+if sys.version_info >= (3, 0):
+    import io
+else:
+    import cStringIO as io
 import keyword
 import ctypes
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ classifiers = [
     'License :: OSI Approved :: MIT License',
     'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
I want to keep Python2.7 support so far. It's easy without 2to3 fixer. Of course Py2.6 support is finally dropped. So we need to set it in setup.py, PyPI tags and CHANGES.txt.

Also I've rebased PR #241 to this PR keeping author of the commit.