### PR TITLE
Removes build_py_2to3 and adds import of print_function

### DIFF
--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import ctypes
 import traceback
 import comtypes

--- a/comtypes/shelllink.py
+++ b/comtypes/shelllink.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ctypes import *
 from ctypes.wintypes import DWORD, WIN32_FIND_DATAA, WIN32_FIND_DATAW, MAX_PATH
 from comtypes import IUnknown, GUID, COMMETHOD, HRESULT, CoClass

--- a/comtypes/test/__init__.py
+++ b/comtypes/test/__init__.py
@@ -1,5 +1,6 @@
 # comtypes.test package.
 
+from __future__ import print_function
 import ctypes
 import getopt
 import os

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest, gc
 from ctypes import *
 from ctypes.wintypes import *

--- a/comtypes/test/test_agilent.py
+++ b/comtypes/test/test_agilent.py
@@ -1,6 +1,8 @@
 # This test requires that the Agilent IVI-COM Driver for Agilent546XX
 # is installed.  It is not requires to have a physical instrument
 # connected, the driver is used in simulation mode.
+
+from __future__ import print_function
 import unittest
 from comtypes.test import ResourceDenied
 from comtypes.client import CreateObject

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import glob
 import os
 import unittest

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -1,4 +1,5 @@
 # -*- coding: latin-1 -*-
+from __future__ import print_function
 import unittest
 
 import comtypes.test

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ctypes import *
 import unittest
 

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ctypes import (
     POINTER, byref, c_byte, c_char, c_double, c_float, c_int, c_int64, c_short,
     c_ubyte, c_ushort, c_uint, c_uint64, pointer,

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1,5 +1,6 @@
 # Code generator to generate code for everything contained in COM type
 # libraries.
+from __future__ import print_function
 import os
 import io
 import keyword

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 from ctypes import windll

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,7 @@ from distutils.core import Command
 from distutils.command.install import install
 from setuptools import setup
 
-try:
-    from distutils.command.build_py import build_py_2to3 as build_py
-except ImportError:
-    from distutils.command.build_py import build_py
+from distutils.command.build_py import build_py
 
 with open('README') as readme_stream:
     readme = readme_stream.read()


### PR DESCRIPTION
`__future__.print_function` needs to be imported in order to have the `print()` statements work properly on Python 2.7.

Because the code syntax is Python 2.7 compliant there is no longer a need to use build_py_2to3 to do a code conversion. So I have removed this from setup.py
