### PR TITLE
Fix assert - reference base_text_type instead of basestring

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -47,7 +47,7 @@ def _resolve_filename(tlib_string, dirpath):
       (abspath, True) or (relpath, False), 
     
     where relpath is an unresolved path."""
-    assert isinstance(tlib_string, basestring)
+    assert isinstance(tlib_string, base_text_type)
     # pathname of type library
     if os.path.isabs(tlib_string):
         # a specific location


### PR DESCRIPTION
That should be correct? Otherwise, `basestring` is not recognized under Python 3.8 (which I tested with).