### PR TITLE
Do not use "L" suffixed integers.

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -549,10 +549,7 @@ VARIANT.null = VARIANT(None)
 VARIANT.empty = VARIANT()
 VARIANT.missing = v = VARIANT()
 v.vt = VT_ERROR
-if sys.version_info >= (3, 0):
-    v._.VT_I4 = 0x80020004
-else:
-    v._.VT_I4 = 0x80020004L
+v._.VT_I4 = 0x80020004
 del v
 
 _carg_obj = type(byref(c_int()))

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -111,10 +111,8 @@ class VariantTestCase(unittest.TestCase):
             else:
                 self.assertEqual(type(v.value), long)
 
-        if sys.version_info >= (3, 0):
-            v.value = 1
-        else:
-            v.value = 1L
+        v.value = 1
+
         self.assertEqual(v.value, 1)
         self.assertEqual(type(v.value), int)
 


### PR DESCRIPTION
They cause SyntaxError on python3 and aren't need on 2.7.

See discussion on PR #259. Closes #262.