### PR TITLE
Fix safe array Py2.7 compatibility without numpy

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,10 +3,10 @@ Comtypes CHANGELOG
 
 Release 1.1.11
 -------------
- * Fix setuptools>=60.0.0 compatibility. Thanks @kdschlosser.
+ * Fix setuptools>=57.5.0 compatibility. Thanks @kdschlosser.
  * Fix timestamping for typelib. Thanks @fusentasticus.
- * Fix 64bit inproc server.
- * Drop Python 2.6 support.
+ * Fix 64bit inproc server. Thanks @klusidy.
+ * Drop Python 2.6 support (Python 2.7 is still supported).
  * Fix IndexError for empty safearray. Thanks @BALOGHBence.
 
 Release 1.1.10

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -41,6 +41,8 @@ class _SafeArrayAsNdArrayContextManager(object):
         '''
         return bool(getattr(self.thread_local, 'count', 0))
 
+    __nonzero__ = __bool__ # for Py2.7 compatibility
+
 
 # Global _SafeArrayAsNdArrayContextManager
 safearray_as_ndarray = _SafeArrayAsNdArrayContextManager()


### PR DESCRIPTION
Hope this is final fix before release 1.1.11. When this PR will pass automatic tests of pywinauto, I gonna merge and release it ASAP.

This PR reverts PR #249 after testing pywinauto with non-released master branch of comtypes. See this log: https://ci.appveyor.com/project/pywinauto/pywinauto-8b7t7/builds/42465094/job/0hm3n1w13k33fd2j (scroll down to the very bottom to see tracebacks).

Example of traceback (there are 6 such failures):
```python
ERROR: Test __repr__ method for BaseWrapper with specific Unicode text (issue #594)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\projects\pywinauto-8b7t7\pywinauto\unittests\test_uiawrapper.py", line 682, in test_pretty_print_encode_error
    print(repr(wrp))
  File "C:\projects\pywinauto-8b7t7\pywinauto\base_wrapper.py", line 199, in __repr__
    return b"<{0} - '{1}', {2}, {3}>".format(type_name, title, class_name, self.__hash__())
  File "C:\projects\pywinauto-8b7t7\pywinauto\base_wrapper.py", line 590, in __hash__
    return self.element_info.__hash__()
  File "C:\projects\pywinauto-8b7t7\pywinauto\windows\uia_element_info.py", line 545, in __hash__
    return hash(self.runtime_id)
  File "C:\projects\pywinauto-8b7t7\pywinauto\windows\uia_element_info.py", line 279, in runtime_id
    return self._element.GetRuntimeId()
  File "c:\python27-x64\lib\site-packages\comtypes\safearray.py", line 223, in __ctypes_from_outparam__
    return self[0]
  File "c:\python27-x64\lib\site-packages\comtypes\safearray.py", line 214, in __getitem__
    return self.unpack()
  File "c:\python27-x64\lib\site-packages\comtypes\safearray.py", line 248, in unpack
    import numpy
ImportError: No module named numpy
```