### PR TITLE
Ignore all files in gen/ except for __init__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 comtypes/__pycache__/*.pyc
 comtypes/client/__pycache__/*.pyc
-comtypes/gen/__pycache__/*.pyc
+comtypes/gen/
+!comtypes/gen/__init__.py
 comtypes/tools/__pycache__/*.pyc
 comtypes.egg-info/*


### PR DESCRIPTION
I don't think we need anything in `gen/` to be committed...do we?