### PR TITLE
Fixes `_pack_` being returned as a float

### DIFF
--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -130,7 +130,9 @@ def calc_packing(struct, fields):
         else:
             if pack is None:
                 return None
-            return pack/8
+
+            return int(pack / 8)
+
     raise PackingError("PACKING FAILED: %s" % details)
 
 class PackingError(Exception):


### PR DESCRIPTION
This is going to require a new release to be made ASAP. When the packing is set to a  float ctypes raises an error stating that the pack value has to be a non-negative number.