### PR TITLE
Update classmethod definition and first arg name.

### DIFF
--- a/comtypes/GUID.py
+++ b/comtypes/GUID.py
@@ -71,6 +71,7 @@ class GUID(Structure):
     def copy(self):
         return GUID(text_type(self))
 
+    @classmethod
     def from_progid(cls, progid):
         """Get guid from progid, ...
         """
@@ -86,7 +87,6 @@ class GUID(Structure):
             return inst
         else:
             raise TypeError("Cannot construct guid from %r" % progid)
-    from_progid = classmethod(from_progid)
 
     def as_progid(self):
         "Convert a GUID into a progid"
@@ -96,12 +96,13 @@ class GUID(Structure):
         _CoTaskMemFree(progid)
         return result
 
+    @classmethod
     def create_new(cls):
         "Create a brand new guid"
         guid = cls()
         _CoCreateGuid(byref(guid))
         return guid
-    create_new = classmethod(create_new)
+
 
 GUID_null = GUID()
 

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -207,11 +207,11 @@ class tagVARIANT(Structure):
             return "VARIANT(vt=0x%x, byref(%r))" % (self.vt, self[0])
         return "VARIANT(vt=0x%x, %r)" % (self.vt, self.value)
 
+    @classmethod
     def from_param(cls, value):
         if isinstance(value, cls):
             return value
         return cls(value)
-    from_param = classmethod(from_param)
 
     def __setitem__(self, index, value):
         # This method allows to change the value of a
@@ -562,6 +562,7 @@ class _(object):
     # function parameters declared as POINTER(VARIANT).  See
     # InternetExplorer's Navigate2() method, or Word's Close() method, for
     # examples.
+    @classmethod
     def from_param(cls, arg):
         # accept POINTER(VARIANT) instance
         if isinstance(arg, POINTER(VARIANT)):
@@ -577,7 +578,6 @@ class _(object):
             return arg
         # anything else which can be converted to a VARIANT.
         return byref(VARIANT(arg))
-    from_param = classmethod(from_param)
 
     def __setitem__(self, index, value):
         # This is to support the same sematics as a pointer instance:


### PR DESCRIPTION
I modernized some code.

## changes `classmethod` definition from reassignment to decorating.
  - `_compointer_base.from_param`
  - `GUID.from_progid`
  - `GUID.create_new`
  - `BSTR.from_param`
  - `tagVARIANT.from_param`
  - `automation._.from_param` (`Patch` to `POINTER(VARIANT)`)

## makes some methods' args  [pep8-comliant](https://peps.python.org/pep-0008/#function-and-method-arguments).
  - `_cominterface_meta.__new__(self, ...` -> `_cominterface_meta.__new__(cls, ...`
  - `_compointer_base.from_param(klass, ...` -> `_compointer_base.from_param(cls, ...`
