### PR TITLE
Make tests runnable on AppVeyor CI and environment-specific tests be skipped

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,4 +28,4 @@ test_script:
    - C:\%py%\python.exe setup.py install
    - C:\%py%\Scripts\pip.exe uninstall comtypes -y
    - C:\%py%\python.exe test_pip_install.py
-   - C:\%py%\python.exe -m unittest discover -s ./comtypes/test -t comtypes\test
+   - C:\%py%\python.exe -m unittest discover -v -s ./comtypes/test -t comtypes\test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ max_jobs: 3
 
 init:
   - git config --global core.autocrlf input
-  
+
 shallow_clone: true
- 
+
 environment:
    matrix:
      - py: Python27
@@ -28,3 +28,4 @@ test_script:
    - C:\%py%\python.exe setup.py install
    - C:\%py%\Scripts\pip.exe uninstall comtypes -y
    - C:\%py%\python.exe test_pip_install.py
+   - C:\%py%\python.exe -m unittest discover -s ./comtypes/test -t comtypes\test

--- a/comtypes/test/README.md
+++ b/comtypes/test/README.md
@@ -1,0 +1,9 @@
+Running tests
+-------------
+From the projects root directory, run:
+
+    python -m unittest discover -s ./comtypes/test -t comtypes\test
+
+Or, from PROJECT_ROOT/comtypes/test:
+
+    python -m unittest discover

--- a/comtypes/test/README.md
+++ b/comtypes/test/README.md
@@ -7,3 +7,11 @@ From the projects root directory, run:
 Or, from PROJECT_ROOT/comtypes/test:
 
     python -m unittest discover
+
+TODO
+----
+
+- [ ] Look at every skipped test and see if it can be fixed and made runnable as a regular
+  unit test.
+- [ ] Remove the custom test runner stuff. See `comtypes/test/__init__.py`
+  and `. /settup.py` for details.

--- a/comtypes/test/README.md
+++ b/comtypes/test/README.md
@@ -15,3 +15,5 @@ TODO
   unit test.
 - [ ] Remove the custom test runner stuff. See `comtypes/test/__init__.py`
   and `. /settup.py` for details.
+- [ ] If python 2.whatever is going to be supported we need to set up tox or something 
+  to run the tests on python 3 and python 2.

--- a/comtypes/test/__init__.py
+++ b/comtypes/test/__init__.py
@@ -8,7 +8,7 @@ import sys
 import time
 import unittest
 
-use_resources = []
+use_resources = ["*"]
 
 def get_numpy():
     '''Get numpy if it is available.'''

--- a/comtypes/test/test_GUID.py
+++ b/comtypes/test/test_GUID.py
@@ -19,13 +19,6 @@ class Test(unittest.TestCase):
         self.assertRaises(WindowsError, lambda guid: guid.as_progid(),
                           GUID("{00000000-0000-0000-C000-000000000046}"))
 
-
-        if os.name == "nt":
-            self.assertEqual(GUID.from_progid("InternetExplorer.Application"),
-                                 GUID("{0002DF01-0000-0000-C000-000000000046}"))
-            self.assertEqual(GUID("{0002DF01-0000-0000-C000-000000000046}").as_progid(),
-                                 'InternetExplorer.Application.1')
-
         self.assertNotEqual(GUID.create_new(), GUID.create_new())
 
 if __name__ == "__main__":

--- a/comtypes/test/test_QueryService.py
+++ b/comtypes/test/test_QueryService.py
@@ -6,7 +6,7 @@ from comtypes.client import CreateObject, GetModule
 GetModule('oleacc.dll')
 from comtypes.gen.Accessibility import IAccessible
 
-
+@unittest.skip("This IE test is not working.  We need to move it to using some other win32 API.")
 class TestCase(unittest.TestCase):
 
     def setUp(self):

--- a/comtypes/test/test_avmc.py
+++ b/comtypes/test/test_avmc.py
@@ -1,16 +1,20 @@
 import unittest
+
 from comtypes.client import CreateObject
 from comtypes.test.find_memleak import find_memleak
 
+
+@unittest.skip("This test does not work.  Apparently it's supposed to work with the 'avmc' stuff "
+               "in comtypes/source, but it doesn't.  It's not clear to me why.")
 class Test(unittest.TestCase):
-    "Test COM records"
+    """Test COM records"""
     def test(self):
         # The ATL COM dll
         avmc = CreateObject("AvmcIfc.Avmc.1")
 
         # This returns an array (a list) of DeviceInfo records.
         devs = avmc.FindAllAvmc()
-        
+
         self.assertEqual(devs[0].Flags, 12)
         self.assertEqual(devs[0].ID, 13)
         self.assertEqual(devs[0].LocId, 14)

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -34,6 +34,10 @@ class Test(ut.TestCase):
         clsid = comtypes.GUID.from_progid("MediaPlayer.MediaPlayer")
         tlib = comtypes.client.GetModule(clsid)
 
+    @ut.skip(
+            "This test uses IE which is not available on all machines anymore. "
+            "Find another API to use."
+    )
     def test_remote(self):
         ie = comtypes.client.CreateObject("InternetExplorer.Application",
                                           machine="localhost")
@@ -44,6 +48,10 @@ class Test(ut.TestCase):
         self.assertEqual(ie.Visible, True)
         self.assertEqual(0, ie.Quit()) # 0 == S_OK
 
+    @ut.skip(
+            "This test uses IE which is not available on all machines anymore. "
+            "Find another API to use."
+    )
     def test_server_info(self):
         serverinfo = COSERVERINFO()
         serverinfo.pwszName = 'localhost'

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -8,8 +8,6 @@ from ctypes import POINTER, byref
 comtypes.client.GetModule("scrrun.dll")
 from comtypes.gen import Scripting
 
-import comtypes.test
-comtypes.test.requires("ui")
 
 if sys.version_info >= (3, 0):
     text_type = str

--- a/comtypes/test/test_collections.py
+++ b/comtypes/test/test_collections.py
@@ -64,6 +64,7 @@ class Test(unittest.TestCase):
         cv.Reset()
         self.assertRaises(ArgumentError, lambda: cv[:])
 
+    @unittest.skip("This test takes a long time.  Do we need it? Can it be rewritten?")
     def test_leaks_1(self):
         # The XP firewall manager.
         fwmgr = CreateObject('HNetCfg.FwMgr')
@@ -76,6 +77,7 @@ class Test(unittest.TestCase):
         bytes = find_memleak(doit, (20, 20))
         self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
+    @unittest.skip("This test takes a long time.  Do we need it? Can it be rewritten?")
     def test_leaks_2(self):
         # The XP firewall manager.
         fwmgr = CreateObject('HNetCfg.FwMgr')
@@ -87,6 +89,7 @@ class Test(unittest.TestCase):
         bytes = find_memleak(doit, (20, 20))
         self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
+    @unittest.skip("This test takes a long time.  Do we need it? Can it be rewritten?")
     def test_leaks_3(self):
         # The XP firewall manager.
         fwmgr = CreateObject('HNetCfg.FwMgr')

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -1,13 +1,11 @@
-import unittest, sys
-from ctypes import *
-from ctypes.wintypes import *
-from comtypes.client import CreateObject, GetEvents, ShowEvents
-from comtypes.server.register import register#, unregister
+import sys
+import unittest
+
+import comtypes.test.TestComServer
+from comtypes.client import CreateObject
+from comtypes.server.register import register  # , unregister
 from comtypes.test import is_resource_enabled
 from comtypes.test.find_memleak import find_memleak
-
-################################################################
-import comtypes.test.TestComServer
 
 
 def setUpModule():
@@ -33,7 +31,7 @@ class TestInproc(unittest.TestCase):
         self.assertEqual(o.MixedInOut(2, 4), (3, 5))
 
     def test_getname(self):
-        from ctypes import byref, pointer
+        from ctypes import pointer
         from comtypes import BSTR
 
         # This tests a tricky bug, introduced with this patch:

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -1,4 +1,6 @@
 import unittest, sys
+raise unittest.SkipTest("This test requires the tests to be run as admin since it tries to "
+                        "register the test COM server.  Is this a good idea?")
 from ctypes import *
 from ctypes.wintypes import *
 from comtypes.client import CreateObject, GetEvents, ShowEvents

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -1,6 +1,4 @@
 import unittest, sys
-raise unittest.SkipTest("This test requires the tests to be run as admin since it tries to "
-                        "register the test COM server.  Is this a good idea?")
 from ctypes import *
 from ctypes.wintypes import *
 from comtypes.client import CreateObject, GetEvents, ShowEvents
@@ -10,7 +8,15 @@ from comtypes.test.find_memleak import find_memleak
 
 ################################################################
 import comtypes.test.TestComServer
-register(comtypes.test.TestComServer.TestComServer)
+
+
+def setUpModule():
+    raise unittest.SkipTest("This test requires the tests to be run as admin since it tries to "
+                            "register the test COM server.  Is this a good idea?")
+
+    # If this test is ever NOT skipped, then this line needs to run.  Keeping it here for posterity.
+    register(comtypes.test.TestComServer.TestComServer)
+
 
 class TestInproc(unittest.TestCase):
 

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -2,13 +2,15 @@ from __future__ import print_function
 import glob
 import os
 import unittest
+raise unittest.SkipTest("I have no idea what to do with this.  It programmatically creates "
+                        "*thousands* of tests and a few dozen of them fail.")
 import warnings
 import comtypes.typeinfo
 import comtypes.client
 import comtypes.client._generate
 from comtypes.test import requires
 
-requires("typelibs")
+# requires("typelibs")
 
 # filter warnings about interfaces without a base interface; they will
 # be skipped in the code generation.

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -1,12 +1,13 @@
 from __future__ import print_function
+
 import glob
 import os
 import unittest
 import warnings
-import comtypes.typeinfo
+
 import comtypes.client
 import comtypes.client._generate
-from comtypes.test import requires
+import comtypes.typeinfo
 
 
 def setUpModule():

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -2,13 +2,17 @@ from __future__ import print_function
 import glob
 import os
 import unittest
-raise unittest.SkipTest("I have no idea what to do with this.  It programmatically creates "
-                        "*thousands* of tests and a few dozen of them fail.")
 import warnings
 import comtypes.typeinfo
 import comtypes.client
 import comtypes.client._generate
 from comtypes.test import requires
+
+
+def setUpModule():
+    raise unittest.SkipTest("I have no idea what to do with this.  It programmatically creates "
+                            "*thousands* of tests and a few dozen of them fail.")
+
 
 # requires("typelibs")
 

--- a/comtypes/test/test_dict.py
+++ b/comtypes/test/test_dict.py
@@ -6,6 +6,11 @@ from comtypes.client import CreateObject
 from comtypes.client.lazybind import Dispatch
 from comtypes.automation import VARIANT
 
+
+def setUpModule():
+    raise unittest.SkipTest("Depends on `comtypes.safearray` which depends on numpy which isn't "
+                            "listed in project dependencies.")
+
 class Test(unittest.TestCase):
     def test_dict(self):
         d = CreateObject("Scripting.Dictionary", dynamic=True)
@@ -72,7 +77,7 @@ class Test(unittest.TestCase):
         d.Item["value"] = s.CompareMode
 
         a = d.Item["object"]
- 
+
         self.assertEqual(d.Item["object"], s)
         self.assertEqual(d.Item["object"].CompareMode, 42)
         self.assertEqual(d.Item["value"], 42)

--- a/comtypes/test/test_dict.py
+++ b/comtypes/test/test_dict.py
@@ -1,10 +1,10 @@
 """Use Scripting.Dictionary to test the lazybind module."""
 
 import unittest
-from comtypes import COMError
+
+from comtypes.automation import VARIANT
 from comtypes.client import CreateObject
 from comtypes.client.lazybind import Dispatch
-from comtypes.automation import VARIANT
 
 
 def setUpModule():

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -1,5 +1,7 @@
 import unittest
 
+raise unittest.SkipTest("This test requires the tests to be run as admin since it tries to "
+                        "register the test COM server.  Is this a good idea?")
 from comtypes.server.register import register#, unregister
 from comtypes.test import is_resource_enabled
 

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -1,11 +1,8 @@
 import unittest
 
-
-from comtypes.server.register import register#, unregister
-from comtypes.test import is_resource_enabled
-
-################################################################
 import comtypes.test.TestDispServer
+from comtypes.server.register import register  # , unregister
+from comtypes.test import is_resource_enabled
 
 
 def setUpModule():

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -1,13 +1,20 @@
 import unittest
 
-raise unittest.SkipTest("This test requires the tests to be run as admin since it tries to "
-                        "register the test COM server.  Is this a good idea?")
+
 from comtypes.server.register import register#, unregister
 from comtypes.test import is_resource_enabled
 
 ################################################################
 import comtypes.test.TestDispServer
-register(comtypes.test.TestDispServer.TestDispServer)
+
+
+def setUpModule():
+    raise unittest.SkipTest("This test requires the tests to be run as admin since it tries to "
+                            "register the test COM server.  Is this a good idea?")
+
+    # If this test is ever NOT skipped, then this line needs to run.  Keeping it here for posterity.
+    register(comtypes.test.TestDispServer.TestDispServer)
+
 
 class Test(unittest.TestCase):
 

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -1,7 +1,8 @@
 # -*- coding: latin-1 -*-
 from __future__ import print_function
 import unittest
-
+raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
+                        "built-in win32 API to use.")
 import comtypes.test
 comtypes.test.requires("ui")
 

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -1,13 +1,13 @@
 # -*- coding: latin-1 -*-
 from __future__ import print_function
+
+import datetime
 import unittest
 
 import comtypes.test
-comtypes.test.requires("ui")
-
-import datetime
-
 from comtypes.client import CreateObject
+
+comtypes.test.requires("ui")
 
 
 def setUpModule():

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -1,14 +1,19 @@
 # -*- coding: latin-1 -*-
 from __future__ import print_function
 import unittest
-raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
-                        "built-in win32 API to use.")
+
 import comtypes.test
 comtypes.test.requires("ui")
 
 import datetime
 
 from comtypes.client import CreateObject
+
+
+def setUpModule():
+    raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
+                            "built-in win32 API to use.")
+
 
 xlRangeValueDefault = 10
 xlRangeValueXMLSpreadsheet = 11

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -8,9 +8,9 @@ import comtypes
 import comtypes.client
 import comtypes.gen
 
-if sys.version_info[0] == 3:
+if sys.version_info >= (3, 4):
     from importlib import reload
-elif sys.version_info[0] == 2:
+else:
     from imp import reload
 
 imgbase = os.path.splitext(os.path.basename(sys.executable))[0]

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -1,8 +1,10 @@
 import types, os, unittest, sys, tempfile
-import importlib
 
-if sys.version_info >= (2, 6):
+if sys.version_info[0] == 3:
+    from importlib import reload
+elif sys.version_info[0] == 2:
     from imp import reload
+
 
 import comtypes
 import comtypes.client
@@ -36,7 +38,7 @@ class Test(unittest.TestCase):
         # restore the original comtypes.gen module
         comtypes.gen = self.orig_comtypesgen
         sys.modules["comtypes.gen"] = self.orig_comtypesgen
-        importlib.reload(comtypes.gen)
+        reload(comtypes.gen)
 
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -1,16 +1,17 @@
-import types, os, unittest, sys, tempfile
-
-if sys.version_info[0] == 3:
-    from importlib import reload
-elif sys.version_info[0] == 2:
-    from imp import reload
-
+import os
+import sys
+import tempfile
+import types
+import unittest
 
 import comtypes
 import comtypes.client
 import comtypes.gen
 
-from comtypes.client._code_cache import _get_appdata_dir
+if sys.version_info[0] == 3:
+    from importlib import reload
+elif sys.version_info[0] == 2:
+    from imp import reload
 
 imgbase = os.path.splitext(os.path.basename(sys.executable))[0]
 

--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -1,13 +1,18 @@
 import unittest
 
-raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
-                        "built-in win32 API to use.")
+
 
 import comtypes
 import comtypes.client
 
 import comtypes.test
 comtypes.test.requires("ui")
+
+
+def setUpModule():
+    raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
+                            "built-in win32 API to use.")
+
 
 class Test(unittest.TestCase):
     def tearDown(self):

--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -1,11 +1,9 @@
 import unittest
 
-
-
 import comtypes
 import comtypes.client
-
 import comtypes.test
+
 comtypes.test.requires("ui")
 
 

--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -1,5 +1,8 @@
 import unittest
 
+raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
+                        "built-in win32 API to use.")
+
 import comtypes
 import comtypes.client
 

--- a/comtypes/test/test_ie.py
+++ b/comtypes/test/test_ie.py
@@ -1,10 +1,9 @@
 import unittest as ut
-
-
 from ctypes import *
-from comtypes.client import CreateObject, GetEvents
 
 import comtypes.test
+from comtypes.client import CreateObject, GetEvents
+
 comtypes.test.requires("ui")
 
 

--- a/comtypes/test/test_ie.py
+++ b/comtypes/test/test_ie.py
@@ -1,13 +1,17 @@
 import unittest as ut
 
-raise ut.SkipTest("External test dependencies like this seem bad.  Find a different built-in "
-                  "win32 API to use.")
 
 from ctypes import *
 from comtypes.client import CreateObject, GetEvents
 
 import comtypes.test
 comtypes.test.requires("ui")
+
+
+def setUpModule():
+    raise ut.SkipTest("External test dependencies like this seem bad.  Find a different built-in "
+                      "win32 API to use.")
+
 
 class EventSink:
     def __init__(self):

--- a/comtypes/test/test_ie.py
+++ b/comtypes/test/test_ie.py
@@ -1,4 +1,8 @@
 import unittest as ut
+
+raise ut.SkipTest("External test dependencies like this seem bad.  Find a different built-in "
+                  "win32 API to use.")
+
 from ctypes import *
 from comtypes.client import CreateObject, GetEvents
 

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -53,6 +53,7 @@ def comstring(text, typ=c_wchar_p):
     return ptr
 
 class Test(unittest.TestCase):
+    @unittest.skip("This fails for reasons I don't understand yet")
     def test_c_char(self):
 ##        ptr = c_wchar_p("abc")
 ##        self.failUnlessEqual(ptr.__ctypes_from_outparam__(),

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -1,11 +1,12 @@
-from ctypes import *
 import sys
 import unittest
+from ctypes import *
 
 import comtypes.test
+
 comtypes.test.requires("devel")
 
-from comtypes import BSTR, IUnknown, GUID, COMMETHOD, HRESULT
+from comtypes import IUnknown, GUID, COMMETHOD
 
 if sys.version_info >= (3, 0):
     text_type = str

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -1,4 +1,5 @@
 from ctypes import *
+import sys
 import unittest
 
 import comtypes.test

--- a/comtypes/test/test_propputref.py
+++ b/comtypes/test/test_propputref.py
@@ -4,6 +4,7 @@ from comtypes.client import CreateObject
 from comtypes.automation import VARIANT
 
 class Test(unittest.TestCase):
+    @unittest.skip("Fails on creating `TestComServerLib.TestComServer`.  Figure out why.")
     def test(self, dynamic=False):
         d = CreateObject("Scripting.Dictionary", dynamic=dynamic)
         s = CreateObject("TestComServerLib.TestComServer", dynamic=dynamic)

--- a/comtypes/test/test_safearray.py
+++ b/comtypes/test/test_safearray.py
@@ -31,6 +31,7 @@ def com_refcnt(o):
 
 
 class VariantTestCase(unittest.TestCase):
+    @unittest.skip("This fails with a memory leak.  Figure out if false positive.")
     def test_VARIANT_array(self):
         v = VARIANT()
         v.value = ((1, 2, 3), ("foo", "bar", None))
@@ -43,6 +44,7 @@ class VariantTestCase(unittest.TestCase):
         bytes = find_memleak(func)
         self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
+    @unittest.skip("This fails with a memory leak.  Figure out if false positive.")
     def test_double_array(self):
         a = array.array("d", (3.14, 2.78))
         v = VARIANT(a)
@@ -132,6 +134,7 @@ class SafeArrayTestCase(unittest.TestCase):
         self.assertTrue((arr == ("a", "b", "c")).all())
         self.assertEqual(SafeArrayGetVartype(sa), VT_BSTR)
 
+    @unittest.skip("This fails with a memory leak.  Figure out if false positive.")
     def test_VT_BSTR_leaks(self):
         sb = _midlSAFEARRAY(BSTR)
 
@@ -141,6 +144,7 @@ class SafeArrayTestCase(unittest.TestCase):
         bytes = find_memleak(doit)
         self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
+    @unittest.skip("This fails with a memory leak.  Figure out if false positive.")
     def test_VT_I4_leaks(self):
         sa = _midlSAFEARRAY(c_long)
 

--- a/comtypes/test/test_safearray.py
+++ b/comtypes/test/test_safearray.py
@@ -385,6 +385,8 @@ class SafeArrayTestCase(unittest.TestCase):
         del arr
         self.assertEqual(initial, com_refcnt(punk))
 
+    @unittest.skip("This fails with a 'library not registered' error.  Need to figure out how to "
+                   "register TestComServerLib (without admin if possible).")
     def test_UDT(self):
         from comtypes.gen.TestComServerLib import MYCOLOR
 

--- a/comtypes/test/test_safearray.py
+++ b/comtypes/test/test_safearray.py
@@ -57,12 +57,16 @@ class VariantTestCase(unittest.TestCase):
         bytes = find_memleak(func)
         self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_float_array(self):
         a = array.array("f", (3.14, 2.78))
         v = VARIANT(a)
         self.assertEqual(v.vt, VT_ARRAY | VT_R4)
         self.assertEqual(tuple(a.tolist()), v.value)
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_2dim_array(self):
         data = ((1, 2, 3, 4),
                 (5, 6, 7, 8),
@@ -112,6 +116,8 @@ class SafeArrayTestCase(unittest.TestCase):
         self.assertTrue(isinstance(fourth, np.ndarray))
         self.assertTrue(isinstance(fifth, tuple))
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_VT_BSTR(self):
         t = _midlSAFEARRAY(BSTR)
 
@@ -154,6 +160,8 @@ class SafeArrayTestCase(unittest.TestCase):
         bytes = find_memleak(doit)
         self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_VT_I4(self):
         t = _midlSAFEARRAY(c_long)
 
@@ -217,6 +225,8 @@ class SafeArrayTestCase(unittest.TestCase):
         self.assertEqual(np.dtype(np.double), arr.dtype)
         self.assertEqual(pat[0][0], data)
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_VT_VARIANT(self):
         t = _midlSAFEARRAY(VARIANT)
 
@@ -244,6 +254,8 @@ class SafeArrayTestCase(unittest.TestCase):
         self.assertTrue((arr == inarr).all())
         self.assertEqual(SafeArrayGetVartype(sa), VT_VARIANT)
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_VT_BOOL(self):
         t = _midlSAFEARRAY(VARIANT_BOOL)
 
@@ -263,6 +275,8 @@ class SafeArrayTestCase(unittest.TestCase):
         self.assertTrue(isinstance(arr, np.ndarray))
         self.assertTrue((arr == (True, False, True, False)).all())
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_VT_UNKNOWN_1(self):
         a = _midlSAFEARRAY(POINTER(IUnknown))
         t = _midlSAFEARRAY(POINTER(IUnknown))
@@ -290,6 +304,8 @@ class SafeArrayTestCase(unittest.TestCase):
         sa = t.from_param([None])
         self.assertEqual((POINTER(IUnknown)(),), sa[0])
 
+    @unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+                   "the project dependencies.")
     def test_VT_UNKNOWN_multi(self):
         a = _midlSAFEARRAY(POINTER(IUnknown))
         t = _midlSAFEARRAY(POINTER(IUnknown))

--- a/comtypes/test/test_safearray.py
+++ b/comtypes/test/test_safearray.py
@@ -1,18 +1,16 @@
 import array
-from comtypes import BSTR, IUnknown
-from comtypes.test import is_resource_enabled, get_numpy
-from comtypes.test.find_memleak import find_memleak
+import datetime
+import unittest
 from ctypes import POINTER, PyDLL, byref, c_double, c_long, pointer, py_object
 from ctypes.wintypes import BOOL
-import datetime
 from decimal import Decimal
-import unittest
 
-from comtypes.automation import (
-    VARIANT, VT_ARRAY, VT_VARIANT, VT_I4, VT_R4, VT_R8, VT_BSTR, VARIANT_BOOL)
-from comtypes.automation import _midlSAFEARRAY
-from comtypes.safearray import safearray_as_ndarray
+from comtypes import BSTR, IUnknown
 from comtypes._safearray import SafeArrayGetVartype
+from comtypes.automation import VARIANT, VARIANT_BOOL, VT_ARRAY, VT_BSTR, VT_I4, VT_R4, VT_R8, VT_VARIANT, _midlSAFEARRAY
+from comtypes.safearray import safearray_as_ndarray
+from comtypes.test import get_numpy, is_resource_enabled
+from comtypes.test.find_memleak import find_memleak
 
 
 def get_array(sa):

--- a/comtypes/test/test_server.py
+++ b/comtypes/test/test_server.py
@@ -1,4 +1,6 @@
 import atexit, os, unittest
+# TODO: Make this file work.
+raise unittest.SkipTest("test_server.py causes the whole test suite to fail. Skipping until fixed.")
 ##import comtypes
 import comtypes.typeinfo, comtypes.client
 
@@ -50,7 +52,7 @@ class TypeLib(object):
 ##        atexit.register(comtypes.typeinfo.UnRegisterTypeLib,
 ##                        guid, major, minor)
         return tlb_path
-    
+
 class Interface(object):
     def __init__(self, header):
         self.header = header

--- a/comtypes/test/test_server.py
+++ b/comtypes/test/test_server.py
@@ -1,293 +1,303 @@
-import atexit, os, unittest
-# TODO: Make this file work.
-raise unittest.SkipTest("test_server.py causes the whole test suite to fail. Skipping until fixed.")
-##import comtypes
-import comtypes.typeinfo, comtypes.client
+try:
+    # Force module to raise.  We catch this error later.  Yes, a dirty hack for python2.7.
+    raise WindowsError("This test module cannot run as-is.  Investigate why")
+    import atexit, os, unittest
 
-class TypeLib(object):
-    """This class collects IDL code fragments and eventually writes
-    them into a .IDL file.  The compile() method compiles the IDL file
-    into a typelibrary and registers it.  A function is also
-    registered with atexit that will unregister the typelib at program
-    exit.
-    """
-    def __init__(self, lib):
-        self.lib = lib
-        self.interfaces = []
-        self.coclasses = []
+    import comtypes.typeinfo, comtypes.client
 
-    def interface(self, header):
-        itf = Interface(header)
-        self.interfaces.append(itf)
-        return itf
 
-    def coclass(self, definition):
-        self.coclasses.append(definition)
 
-    def __str__(self):
-        header = '''import "oaidl.idl";
-                    import "ocidl.idl";
-                    %s {''' % self.lib
-        body = "\n".join([str(itf) for itf in self.interfaces])
-        footer = "\n".join(self.coclasses) + "}"
-        return "\n".join((header, body, footer))
 
-    def compile(self):
-        """Compile and register the typelib"""
-        code = str(self)
-        curdir = os.path.dirname(__file__)
-        idl_path = os.path.join(curdir, "mylib.idl")
-        tlb_path = os.path.join(curdir, "mylib.tlb")
-        if not os.path.isfile(idl_path) or open(idl_path, "r").read() != code:
-            open(idl_path, "w").write(code)
-            os.system(r'call "%%VS71COMNTOOLS%%vsvars32.bat" && '
-                      r'midl /nologo %s /tlb %s' % (idl_path, tlb_path))
-        # Register the typelib...
-        tlib = comtypes.typeinfo.LoadTypeLib(tlb_path)
-        # create the wrapper module...
-        comtypes.client.GetModule(tlb_path)
-        # Unregister the typelib at interpreter exit...
-        attr = tlib.GetLibAttr()
-        guid, major, minor = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
-##        atexit.register(comtypes.typeinfo.UnRegisterTypeLib,
-##                        guid, major, minor)
-        return tlb_path
+    class TypeLib(object):
+        """This class collects IDL code fragments and eventually writes
+        them into a .IDL file.  The compile() method compiles the IDL file
+        into a typelibrary and registers it.  A function is also
+        registered with atexit that will unregister the typelib at program
+        exit.
+        """
+        def __init__(self, lib):
+            self.lib = lib
+            self.interfaces = []
+            self.coclasses = []
 
-class Interface(object):
-    def __init__(self, header):
-        self.header = header
-        self.code = ""
+        def interface(self, header):
+            itf = Interface(header)
+            self.interfaces.append(itf)
+            return itf
 
-    def add(self, text):
-        self.code += text + "\n"
-        return self
+        def coclass(self, definition):
+            self.coclasses.append(definition)
 
-    def __str__(self):
-        return self.header + " {\n" + self.code + "}\n"
+        def __str__(self):
+            header = '''import "oaidl.idl";
+                        import "ocidl.idl";
+                        %s {''' % self.lib
+            body = "\n".join([str(itf) for itf in self.interfaces])
+            footer = "\n".join(self.coclasses) + "}"
+            return "\n".join((header, body, footer))
 
-################################################################
-import comtypes
-from comtypes.client import wrap
+        def compile(self):
+            """Compile and register the typelib"""
+            code = str(self)
+            curdir = os.path.dirname(__file__)
+            idl_path = os.path.join(curdir, "mylib.idl")
+            tlb_path = os.path.join(curdir, "mylib.tlb")
+            if not os.path.isfile(idl_path) or open(idl_path, "r").read() != code:
+                open(idl_path, "w").write(code)
+                os.system(r'call "%%VS71COMNTOOLS%%vsvars32.bat" && '
+                          r'midl /nologo %s /tlb %s' % (idl_path, tlb_path))
+            # Register the typelib...
+            tlib = comtypes.typeinfo.LoadTypeLib(tlb_path)
+            # create the wrapper module...
+            comtypes.client.GetModule(tlb_path)
+            # Unregister the typelib at interpreter exit...
+            attr = tlib.GetLibAttr()
+            guid, major, minor = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
+    ##        atexit.register(comtypes.typeinfo.UnRegisterTypeLib,
+    ##                        guid, major, minor)
+            return tlb_path
 
-tlb = TypeLib("[uuid(f4f74946-4546-44bd-a073-9ea6f9fe78cb)] library TestLib")
+    class Interface(object):
+        def __init__(self, header):
+            self.header = header
+            self.code = ""
 
-itf = tlb.interface("""[object,
-                        oleautomation,
-                        dual,
-                        uuid(ed978f5f-cc45-4fcc-a7a6-751ffa8dfedd)]
-                        interface IMyInterface : IDispatch""")
+        def add(self, text):
+            self.code += text + "\n"
+            return self
 
-outgoing = tlb.interface("""[object,
-                             oleautomation,
-                             dual,
-                             uuid(f7c48a90-64ea-4bb8-abf1-b3a3aa996848)]
-                             interface IMyEventInterface : IDispatch""")
+        def __str__(self):
+            return self.header + " {\n" + self.code + "}\n"
 
-tlb.coclass("""
-[uuid(fa9de8f4-20de-45fc-b079-648572428817)]
-coclass MyServer {
-    [default] interface IMyInterface;
-    [default, source] interface IMyEventInterface;
-};
-""")
+    ################################################################
+    import comtypes
+    from comtypes.client import wrap
 
-# The purpose of the MyServer class is to locate three separate code
-# section snippets closely together:
-#
-# 1. The IDL method definition for a COM interface method
-# 2. The Python implementation of the COM method
-# 3. The unittest(s) for the COM method.
-#
-from comtypes.server.connectionpoints import ConnectableObjectMixin
-class MyServer(comtypes.CoClass, ConnectableObjectMixin):
-    _reg_typelib_ = ('{f4f74946-4546-44bd-a073-9ea6f9fe78cb}', 0, 0)
-    _reg_clsid_ = comtypes.GUID('{fa9de8f4-20de-45fc-b079-648572428817}')
+    tlb = TypeLib("[uuid(f4f74946-4546-44bd-a073-9ea6f9fe78cb)] library TestLib")
 
-    ################
-    # definition
-    itf.add("""[id(100), propget] HRESULT Name([out, retval] BSTR *pname);
-               [id(100), propput] HRESULT Name([in] BSTR name);""")
-    # implementation
-    Name = "foo"
-    # test
-    def test_Name(self):
-        p = wrap(self.create())
-        self.assertEqual((p.Name, p.name, p.nAME), ("foo",) * 3)
-        p.NAME = "spam"
-        self.assertEqual((p.Name, p.name, p.nAME), ("spam",) * 3)
+    itf = tlb.interface("""[object,
+                            oleautomation,
+                            dual,
+                            uuid(ed978f5f-cc45-4fcc-a7a6-751ffa8dfedd)]
+                            interface IMyInterface : IDispatch""")
 
-    ################
-    # definition
-    itf.add("[id(101)] HRESULT MixedInOut([in] int a, [out] int *b, [in] int c, [out] int *d);")
-    # implementation
-    def MixedInOut(self, a, c):
-        return a+1, c+1
-    #test
-    def test_MixedInOut(self):
-        p = wrap(self.create())
-        self.assertEqual(p.MixedInOut(1, 2), (2, 3))
+    outgoing = tlb.interface("""[object,
+                                 oleautomation,
+                                 dual,
+                                 uuid(f7c48a90-64ea-4bb8-abf1-b3a3aa996848)]
+                                 interface IMyEventInterface : IDispatch""")
 
-    ################
-    # definition
-    itf.add("[id(102)] HRESULT MultiInOutArgs([in, out] int *pa, [in, out] int *pb);")
-    # implementation
-    def MultiInOutArgs(self, pa, pb):
-        return pa[0] * 3, pb[0] * 4
-    # test
-    def test_MultiInOutArgs(self):
-        p = wrap(self.create())
-        self.assertEqual(p.MultiInOutArgs(1, 2), (3, 8))
+    tlb.coclass("""
+    [uuid(fa9de8f4-20de-45fc-b079-648572428817)]
+    coclass MyServer {
+        [default] interface IMyInterface;
+        [default, source] interface IMyEventInterface;
+    };
+    """)
 
-    ################
-    # definition
-    itf.add("HRESULT MultiInOutArgs2([in, out] int *pa, [out] int *pb);")
-##    # implementation
-##    def MultiInOutArgs2(self, pa):
-##        return pa[0] * 3, pa[0] * 4
-##    # test
-##    def test_MultiInOutArgs2(self):
-##        p = wrap(self.create())
-##        self.assertEqual(p.MultiInOutArgs2(42), (126, 168))
-
-    ################
-    # definition
-    itf.add("HRESULT MultiInOutArgs3([out] int *pa, [out] int *pb);")
-    # implementation
-    def MultiInOutArgs3(self):
-        return 42, 43
-    # test
-    def test_MultiInOutArgs3(self):
-        p = wrap(self.create())
-        self.assertEqual(p.MultiInOutArgs3(), (42, 43))
-
-    ################
-    # definition
-    itf.add("HRESULT MultiInOutArgs4([out] int *pa, [in, out] int *pb);")
-    # implementation
-    def MultiInOutArgs4(self, pb):
-        return pb[0] + 3, pb[0] + 4
-    # test
-    def test_MultiInOutArgs4(self):
-        p = wrap(self.create())
-        res = p.MultiInOutArgs4(pb=32)
-##        print "MultiInOutArgs4", res
-
-    itf.add("""HRESULT GetStackTrace([in] ULONG FrameOffset,
-                                     [in, out] INT *Frames,
-                                     [in] ULONG FramesSize,
-                                     [out, optional] ULONG *FramesFilled);""")
-    def GetStackTrace(self, this, *args):
-##        print "GetStackTrace", args
-        return 0
-    def test_GetStackTrace(self):
-        p = wrap(self.create())
-        from ctypes import c_int, POINTER, pointer
-        frames = (c_int * 5)()
-        res = p.GetStackTrace(42, frames, 5)
-##        print "RES_1", res
-
-        frames = pointer(c_int(5))
-        res = p.GetStackTrace(42, frames, 0)
-##        print "RES_2", res
-
-    # It is unlear to me if this is allowed or not.  Apparently there
-    # are typelibs that define such an argument type, but it may be
-    # that these are buggy.
+    # The purpose of the MyServer class is to locate three separate code
+    # section snippets closely together:
     #
-    # Point is that SafeArrayCreateEx(VT_VARIANT|VT_BYREF, ..) fails.
-    # The MSDN docs for SafeArrayCreate() have a notice that neither
-    # VT_ARRAY not VT_BYREF may be set, this notice is missing however
-    # for SafeArrayCreateEx().
+    # 1. The IDL method definition for a COM interface method
+    # 2. The Python implementation of the COM method
+    # 3. The unittest(s) for the COM method.
     #
-    # We have this code here to make sure that comtypes can import
-    # such a typelib, although calling ths method will fail because
-    # such an array cannot be created.
-    itf.add("""HRESULT dummy([in] SAFEARRAY(VARIANT *) foo);""")
+    from comtypes.server.connectionpoints import ConnectableObjectMixin
+    class MyServer(comtypes.CoClass, ConnectableObjectMixin):
+        _reg_typelib_ = ('{f4f74946-4546-44bd-a073-9ea6f9fe78cb}', 0, 0)
+        _reg_clsid_ = comtypes.GUID('{fa9de8f4-20de-45fc-b079-648572428817}')
+
+        ################
+        # definition
+        itf.add("""[id(100), propget] HRESULT Name([out, retval] BSTR *pname);
+                   [id(100), propput] HRESULT Name([in] BSTR name);""")
+        # implementation
+        Name = "foo"
+        # test
+        def test_Name(self):
+            p = wrap(self.create())
+            self.assertEqual((p.Name, p.name, p.nAME), ("foo",) * 3)
+            p.NAME = "spam"
+            self.assertEqual((p.Name, p.name, p.nAME), ("spam",) * 3)
+
+        ################
+        # definition
+        itf.add("[id(101)] HRESULT MixedInOut([in] int a, [out] int *b, [in] int c, [out] int *d);")
+        # implementation
+        def MixedInOut(self, a, c):
+            return a+1, c+1
+        #test
+        def test_MixedInOut(self):
+            p = wrap(self.create())
+            self.assertEqual(p.MixedInOut(1, 2), (2, 3))
+
+        ################
+        # definition
+        itf.add("[id(102)] HRESULT MultiInOutArgs([in, out] int *pa, [in, out] int *pb);")
+        # implementation
+        def MultiInOutArgs(self, pa, pb):
+            return pa[0] * 3, pb[0] * 4
+        # test
+        def test_MultiInOutArgs(self):
+            p = wrap(self.create())
+            self.assertEqual(p.MultiInOutArgs(1, 2), (3, 8))
+
+        ################
+        # definition
+        itf.add("HRESULT MultiInOutArgs2([in, out] int *pa, [out] int *pb);")
+    ##    # implementation
+    ##    def MultiInOutArgs2(self, pa):
+    ##        return pa[0] * 3, pa[0] * 4
+    ##    # test
+    ##    def test_MultiInOutArgs2(self):
+    ##        p = wrap(self.create())
+    ##        self.assertEqual(p.MultiInOutArgs2(42), (126, 168))
+
+        ################
+        # definition
+        itf.add("HRESULT MultiInOutArgs3([out] int *pa, [out] int *pb);")
+        # implementation
+        def MultiInOutArgs3(self):
+            return 42, 43
+        # test
+        def test_MultiInOutArgs3(self):
+            p = wrap(self.create())
+            self.assertEqual(p.MultiInOutArgs3(), (42, 43))
+
+        ################
+        # definition
+        itf.add("HRESULT MultiInOutArgs4([out] int *pa, [in, out] int *pb);")
+        # implementation
+        def MultiInOutArgs4(self, pb):
+            return pb[0] + 3, pb[0] + 4
+        # test
+        def test_MultiInOutArgs4(self):
+            p = wrap(self.create())
+            res = p.MultiInOutArgs4(pb=32)
+    ##        print "MultiInOutArgs4", res
+
+        itf.add("""HRESULT GetStackTrace([in] ULONG FrameOffset,
+                                         [in, out] INT *Frames,
+                                         [in] ULONG FramesSize,
+                                         [out, optional] ULONG *FramesFilled);""")
+        def GetStackTrace(self, this, *args):
+    ##        print "GetStackTrace", args
+            return 0
+        def test_GetStackTrace(self):
+            p = wrap(self.create())
+            from ctypes import c_int, POINTER, pointer
+            frames = (c_int * 5)()
+            res = p.GetStackTrace(42, frames, 5)
+    ##        print "RES_1", res
+
+            frames = pointer(c_int(5))
+            res = p.GetStackTrace(42, frames, 0)
+    ##        print "RES_2", res
+
+        # It is unlear to me if this is allowed or not.  Apparently there
+        # are typelibs that define such an argument type, but it may be
+        # that these are buggy.
+        #
+        # Point is that SafeArrayCreateEx(VT_VARIANT|VT_BYREF, ..) fails.
+        # The MSDN docs for SafeArrayCreate() have a notice that neither
+        # VT_ARRAY not VT_BYREF may be set, this notice is missing however
+        # for SafeArrayCreateEx().
+        #
+        # We have this code here to make sure that comtypes can import
+        # such a typelib, although calling ths method will fail because
+        # such an array cannot be created.
+        itf.add("""HRESULT dummy([in] SAFEARRAY(VARIANT *) foo);""")
 
 
-    # Test events.
-    itf.add("""HRESULT DoSomething();""")
-    outgoing.add("""[id(103)] HRESULT OnSomething();""")
-    # implementation
-    def DoSomething(self):
-        "Implement the DoSomething method"
-        self.Fire_Event(0, "OnSomething")
-    # test
-    def test_events(self):
-        p = wrap(self.create())
-        class Handler(object):
-            called = 0
-            def OnSomething(self, this):
-                "Handles the OnSomething event"
-                self.called += 1
-        handler = Handler()
-        ev = comtypes.client.GetEvents(p, handler)
-        p.DoSomething()
-        self.assertEqual(handler.called, 1)
+        # Test events.
+        itf.add("""HRESULT DoSomething();""")
+        outgoing.add("""[id(103)] HRESULT OnSomething();""")
+        # implementation
+        def DoSomething(self):
+            "Implement the DoSomething method"
+            self.Fire_Event(0, "OnSomething")
+        # test
+        def test_events(self):
+            p = wrap(self.create())
+            class Handler(object):
+                called = 0
+                def OnSomething(self, this):
+                    "Handles the OnSomething event"
+                    self.called += 1
+            handler = Handler()
+            ev = comtypes.client.GetEvents(p, handler)
+            p.DoSomething()
+            self.assertEqual(handler.called, 1)
 
-        class Handler(object):
-            called = 0
-            def IMyEventInterface_OnSomething(self):
-                "Handles the OnSomething event"
-                self.called += 1
-        handler = Handler()
-        ev = comtypes.client.GetEvents(p, handler)
-        p.DoSomething()
-        self.assertEqual(handler.called, 1)
+            class Handler(object):
+                called = 0
+                def IMyEventInterface_OnSomething(self):
+                    "Handles the OnSomething event"
+                    self.called += 1
+            handler = Handler()
+            ev = comtypes.client.GetEvents(p, handler)
+            p.DoSomething()
+            self.assertEqual(handler.called, 1)
 
-    # events with out-parameters (these are probably very unlikely...)
-    itf.add("""HRESULT DoSomethingElse();""")
-    outgoing.add("""[id(104)] HRESULT OnSomethingElse([out, retval] int *px);""")
-    def DoSomethingElse(self):
-        "Implement the DoSomething method"
-        self.Fire_Event(0, "OnSomethingElse")
-    def test_DoSomethingElse(self):
-        p = wrap(self.create())
-        class Handler(object):
-            called = 0
-            def OnSomethingElse(self):
-                "Handles the OnSomething event"
-                self.called += 1
-                return 42
-        handler = Handler()
-        ev = comtypes.client.GetEvents(p, handler)
-        p.DoSomethingElse()
-        self.assertEqual(handler.called, 1)
+        # events with out-parameters (these are probably very unlikely...)
+        itf.add("""HRESULT DoSomethingElse();""")
+        outgoing.add("""[id(104)] HRESULT OnSomethingElse([out, retval] int *px);""")
+        def DoSomethingElse(self):
+            "Implement the DoSomething method"
+            self.Fire_Event(0, "OnSomethingElse")
+        def test_DoSomethingElse(self):
+            p = wrap(self.create())
+            class Handler(object):
+                called = 0
+                def OnSomethingElse(self):
+                    "Handles the OnSomething event"
+                    self.called += 1
+                    return 42
+            handler = Handler()
+            ev = comtypes.client.GetEvents(p, handler)
+            p.DoSomethingElse()
+            self.assertEqual(handler.called, 1)
 
-        class Handler(object):
-            called = 0
-            def OnSomethingElse(self, this, presult):
-                "Handles the OnSomething event"
-                self.called += 1
-                presult[0] = 42
-        handler = Handler()
-        ev = comtypes.client.GetEvents(p, handler)
-        p.DoSomethingElse()
-        self.assertEqual(handler.called, 1)
+            class Handler(object):
+                called = 0
+                def OnSomethingElse(self, this, presult):
+                    "Handles the OnSomething event"
+                    self.called += 1
+                    presult[0] = 42
+            handler = Handler()
+            ev = comtypes.client.GetEvents(p, handler)
+            p.DoSomethingElse()
+            self.assertEqual(handler.called, 1)
 
-################################################################
+    ################################################################
 
-path = tlb.compile()
-from comtypes.gen import TestLib
-from comtypes.typeinfo import IProvideClassInfo, IProvideClassInfo2
-from comtypes.connectionpoints import IConnectionPointContainer
+    path = tlb.compile()
+    from comtypes.gen import TestLib
+    from comtypes.typeinfo import IProvideClassInfo, IProvideClassInfo2
+    from comtypes.connectionpoints import IConnectionPointContainer
 
-MyServer._com_interfaces_ = [TestLib.IMyInterface,
-                             IProvideClassInfo2,
-                             IConnectionPointContainer]
-MyServer._outgoing_interfaces_ = [TestLib.IMyEventInterface]
+    MyServer._com_interfaces_ = [TestLib.IMyInterface,
+                                 IProvideClassInfo2,
+                                 IConnectionPointContainer]
+    MyServer._outgoing_interfaces_ = [TestLib.IMyEventInterface]
 
-################################################################
+    ################################################################
 
-class Test(unittest.TestCase, MyServer):
-    def __init__(self, *args):
-        unittest.TestCase.__init__(self, *args)
-        MyServer.__init__(self)
+    class Test(unittest.TestCase, MyServer):
+        def __init__(self, *args):
+            unittest.TestCase.__init__(self, *args)
+            MyServer.__init__(self)
 
-    def create(self):
-        obj = MyServer()
-        return obj.QueryInterface(comtypes.IUnknown)
+        def create(self):
+            obj = MyServer()
+            return obj.QueryInterface(comtypes.IUnknown)
+except:
+    import unittest
 
+    class TestSkipped(unittest.TestCase):
+        @unittest.skip("This file causes a WindowsError.  Needs investigated and fixed.")
+        def test_server_module_skipped(self):
+            pass
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_showevents.py
+++ b/comtypes/test/test_showevents.py
@@ -9,6 +9,8 @@ requires("events")
 
 class EventsTest(unittest.TestCase):
 
+    @unittest.skip("This test depends on Internet Explorer and Excel.  Need to use something "
+                   "built-in to Windows for sure.")
     def test(self):
         import comtypes.test.test_showevents
         doctest.testmod(comtypes.test.test_showevents, optionflags=doctest.ELLIPSIS)
@@ -120,7 +122,7 @@ class EventsTest(unittest.TestCase):
             Event DWebBrowserEvents2_OnQuit(None)
             >>>
             '''
-        
+
     def IE_GetEvents(self):
         """
         >>> from comtypes.client import CreateObject, GetEvents, PumpEvents

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -31,7 +31,14 @@ if os.name == "nt":
             attr = tlib.GetLibAttr()
             info = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
             other_tlib = LoadRegTypeLib(*info)
-            self.assertEqual(tlib, other_tlib)
+            other_attr = other_tlib.GetLibAttr()
+            # `assert tlib == other_tlib` will fail in some environments.
+            # But their attributes are equal even if difference of environments.
+            self.assertEqual(attr.guid, other_attr.guid)
+            self.assertEqual(attr.wMajorVerNum, other_attr.wMajorVerNum)
+            self.assertEqual(attr.wMinorVerNum, other_attr.wMinorVerNum)
+            self.assertEqual(attr.lcid, other_attr.lcid)
+            self.assertEqual(attr.wLibFlags, other_attr.wLibFlags)
 
     ##         for n in dir(attr):
     ##             if not n.startswith("_"):

--- a/comtypes/test/test_urlhistory.py
+++ b/comtypes/test/test_urlhistory.py
@@ -13,7 +13,7 @@ from comtypes.gen import urlhistLib
 # freed by the caller.  The only way to do this without patching the
 # generated code directly is to monkey-patch the
 # _STATURL.__ctypes_from_outparam__ method like this.
-@Patch(urlhistlib._STATURL)
+@Patch(urlhistLib._STATURL)
 class _(object):
     def __ctypes_from_outparam__(self):
         from comtypes.util import cast_field

--- a/comtypes/test/test_urlhistory.py
+++ b/comtypes/test/test_urlhistory.py
@@ -32,6 +32,7 @@ class Test(unittest.TestCase):
         bytes = find_memleak(func, (5, 10))
         self.assertFalse(bytes, "Leaks %d bytes" % bytes)
 
+    @unittest.skip("This fails with: `TypeError: iter() returned non-iterator of type 'POINTER(IEnumSTATURL)'`")
     def test_creation(self):
         hist = CreateObject(urlhistLib.UrlHistory)
         for x in hist.EnumURLS():

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -208,7 +208,7 @@ class VariantTestCase(unittest.TestCase):
     def test_ctypes_in_variant(self):
         v = VARIANT()
         objs = [(c_ubyte(3), VT_UI1),
-                (c_char("x"), VT_UI1),
+                (c_char(b"x"), VT_UI1),
                 (c_byte(3), VT_I1),
                 (c_ushort(3), VT_UI2),
                 (c_short(3), VT_I2),

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -274,7 +274,8 @@ class NdArrayTest(unittest.TestCase):
         v.value = a
         self.assertTrue((v.value == a).all())
 
-
+@unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
+               "the project dependencies.")
 class ArrayTest(unittest.TestCase):
     def test_double(self):
         import array

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -1,21 +1,22 @@
 from __future__ import print_function
-from ctypes import (
-    POINTER, byref, c_byte, c_char, c_double, c_float, c_int, c_int64, c_short,
-    c_ubyte, c_ushort, c_uint, c_uint64, pointer,
-)
+
 import datetime
 import decimal
 import sys
 import unittest
+from ctypes import (
+    POINTER, byref, c_byte, c_char, c_double, c_float, c_int, c_int64, c_short, c_ubyte, c_uint,
+    c_uint64, c_ushort, pointer,
+)
 
-from comtypes import IUnknown, GUID
+from comtypes import GUID, IUnknown
 from comtypes.automation import (
-    VARIANT, DISPPARAMS, VT_NULL, VT_EMPTY, VT_ERROR, VT_I1, VT_I2, VT_I4,
-    VT_I8, VT_UI1, VT_UI2, VT_UI4, VT_UI8, VT_R4, VT_R8, VT_BYREF, VT_BSTR,
-    VT_DATE, VT_DECIMAL, VT_CY,)
-from comtypes.typeinfo import LoadRegTypeLib
+    DISPPARAMS, VARIANT, VT_BSTR, VT_BYREF, VT_CY, VT_DATE, VT_DECIMAL, VT_EMPTY, VT_ERROR, VT_I1,
+    VT_I2, VT_I4, VT_I8, VT_NULL, VT_R4, VT_R8, VT_UI1, VT_UI2, VT_UI4, VT_UI8,
+)
 from comtypes.test import get_numpy
 from comtypes.test.find_memleak import find_memleak
+from comtypes.typeinfo import LoadRegTypeLib
 
 
 def get_refcnt(comptr):

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -98,23 +98,22 @@ class VariantTestCase(unittest.TestCase):
     def test_integers(self):
         v = VARIANT()
 
+        int_type = int if sys.version_info >= (3,0) else (int, long)
+
         if (hasattr(sys, "maxint")):
             # this test doesn't work in Python 3000
             v.value = sys.maxsize
             self.assertEqual(v.value, sys.maxsize)
-            self.assertEqual(type(v.value), int)
+            self.assertIsInstance(v.value, int_type)
 
             v.value += 1
             self.assertEqual(v.value, sys.maxsize+1)
-            if sys.version_info >= (3, 0):
-                self.assertEqual(type(v.value), int)
-            else:
-                self.assertEqual(type(v.value), long)
+            self.assertIsInstance(v.value, int_type)
 
         v.value = 1
 
         self.assertEqual(v.value, 1)
-        self.assertEqual(type(v.value), int)
+        self.assertIsInstance(v.value, int_type)
 
     def test_datetime(self):
         now = datetime.datetime.now()
@@ -171,7 +170,7 @@ class VariantTestCase(unittest.TestCase):
         self.assertEqual(
             v.value, decimal.Decimal('-1844674407.370955162834'))
 
-    @unittest.skip("This test causes python to crash.")
+    @unittest.skip("This test causes python(3?) to crash.")
     def test_BSTR(self):
         v = VARIANT()
         v.value = u"abc\x00123\x00"

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -190,6 +190,7 @@ class VariantTestCase(unittest.TestCase):
         v.value = ""
         self.assertEqual(v.vt, VT_BSTR)
 
+    @unittest.skip("Fails on creating `TestComServerLib.TestComServer`.  Library not registered.")
     def test_UDT(self):
         from comtypes.gen.TestComServerLib import MYCOLOR
         v = VARIANT(MYCOLOR(red=1.0, green=2.0, blue=3.0))

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -90,7 +90,7 @@ class VariantTestCase(unittest.TestCase):
         if sys.version_info >= (3, 0):
             objects = [None, 42, 3.14, True, False, "abc", "abc", 7]
         else:
-            objects = [None, 42, 3.14, True, False, "abc", u"abc", 7L]
+            objects = [None, 42, 3.14, True, False, "abc", u"abc", 7]
         for x in objects:
             v = VARIANT(x)
             self.assertEqual(x, v.value)

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -171,6 +171,7 @@ class VariantTestCase(unittest.TestCase):
         self.assertEqual(
             v.value, decimal.Decimal('-1844674407.370955162834'))
 
+    @unittest.skip("This test causes python to crash.")
     def test_BSTR(self):
         v = VARIANT()
         v.value = u"abc\x00123\x00"

--- a/comtypes/test/test_win32com_interop.py
+++ b/comtypes/test/test_win32com_interop.py
@@ -1,5 +1,6 @@
 import unittest
-
+raise unittest.SkipTest("This test requires the pythoncom library installed.  If this is "
+                        "important tests then we need to add dev dependencies to the project that include pythoncom.")
 from ctypes import PyDLL, py_object, c_void_p, byref, POINTER
 from ctypes.wintypes import BOOL
 

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -1,6 +1,5 @@
-import unittest
-
 import time
+import unittest
 
 import comtypes.client
 import comtypes.test

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -1,4 +1,7 @@
 import unittest
+
+raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
+                        "built-in win32 API to use.")
 import time
 import comtypes.client
 

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -1,14 +1,17 @@
 import unittest
 
-raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
-                        "built-in win32 API to use.")
 import time
+
 import comtypes.client
+import comtypes.test
 
 # XXX leaks references.
 
-import comtypes.test
 comtypes.test.requires("ui")
+
+def setUpModule():
+    raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
+                            "built-in win32 API to use.")
 
 
 class Test(unittest.TestCase):

--- a/test_pip_install.py
+++ b/test_pip_install.py
@@ -9,10 +9,11 @@ def read_version():
     # Determine the version number by reading it from the file
     # 'comtypes\__init__.py'.  We cannot import this file (with py3,
     # at least) because it is in py2.x syntax.
-    for line in open("comtypes/__init__.py"):
-        if line.startswith("__version__ = "):
-            var, value = line.split('=')
-            return value.strip().strip('"').strip("'")
+    with open("comtypes/__init__.py") as ofi:
+        for line in ofi:
+            if line.startswith("__version__ = "):
+                var, value = line.split('=')
+                return value.strip().strip('"').strip("'")
     raise NotImplementedError("__version__ is not found in __init__.py")
 
 


### PR DESCRIPTION
related to #267

This PR has taken over from #271 by @dmwyatt.
- participants are @vasily-v-ryabov, @kdschlosser

With this change, tests can run on AppVeyor CI(and perhaps on developer machines).

The goal of this PR as is @dmwyatt's comment,
> It seems like it'd be better to have a test suite that runs but doesn't cover everything than a test suite that doesn't run but hypothetically covers more.
https://github.com/enthought/comtypes/issues/267#issuecomment-1029305670

## Overview of changes
links to issue/PR comments.

### Skips environment-specific tests
- [failed with `OSError: ... Invalid class string`](https://github.com/enthought/comtypes/issues/267#issue-1122368686)
- [failed with assertion in `test_leaks_x`](https://github.com/enthought/comtypes/issues/267#issue-1122368686)
- [failed with `ResourceDenied`](https://github.com/enthought/comtypes/issues/267#issue-1122368686)
- [depends upon IE and MS Office](https://github.com/enthought/comtypes/pull/271#issue-1125294924)
- [depends upon `comtypes/test/TestComServer.tlb` or `comtypes/test/TestDispServer.tlb`](https://github.com/enthought/comtypes/pull/271#issue-1125294924)
- [causes the whole test suite to fail for some reason](https://github.com/enthought/comtypes/pull/271#issue-1125294924)

### Fixes failed or warned tests
- [adds import conditional branch](https://github.com/enthought/comtypes/pull/295#issuecomment-1148740706)
- [replaces to non-environment-specific dll and asserts attributes' value instead of object](https://github.com/enthought/comtypes/pull/295#issuecomment-1148737128)
- [prevents `ResourceWarning`](https://github.com/enthought/comtypes/pull/295#issuecomment-1148720256)