### PR TITLE
update (bound_)named_property args and attributes names to be similar to builtin property

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -834,36 +834,36 @@ _all_slice = slice(None, None, None)
 
 
 class bound_named_property(object):
-    def __init__(self, name, getter, setter, im_inst):
+    def __init__(self, name, fget, fset, instance):
         self.name = name
-        self.im_inst = im_inst
-        self.getter = getter
-        self.setter = setter
+        self.instance = instance
+        self.fget = fget
+        self.fset = fset
 
     def __getitem__(self, index):
-        if self.getter is None:
+        if self.fget is None:
             raise TypeError("unsubscriptable object")
         if isinstance(index, tuple):
-            return self.getter(self.im_inst, *index)
+            return self.fget(self.instance, *index)
         elif index == _all_slice:
-            return self.getter(self.im_inst)
+            return self.fget(self.instance)
         else:
-            return self.getter(self.im_inst, index)
+            return self.fget(self.instance, index)
 
     def __call__(self, *args):
-        if self.getter is None:
+        if self.fget is None:
             raise TypeError("object is not callable")
-        return self.getter(self.im_inst, *args)
+        return self.fget(self.instance, *args)
 
     def __setitem__(self, index, value):
-        if self.setter is None:
+        if self.fset is None:
             raise TypeError("object does not support item assignment")
         if isinstance(index, tuple):
-            self.setter(self.im_inst, *(index + (value,)))
+            self.fset(self.instance, *(index + (value,)))
         elif index == _all_slice:
-            self.setter(self.im_inst, value)
+            self.fset(self.instance, value)
         else:
-            self.setter(self.im_inst, index, value)
+            self.fset(self.instance, index, value)
 
     def __repr__(self):
         return "<bound_named_property %r at %x>" % (self.name, id(self))
@@ -874,21 +874,20 @@ class bound_named_property(object):
         raise TypeError(msg)
 
 
-
 class named_property(object):
     def __init__(self, name, fget=None, fset=None, doc=None):
         self.name = name
-        self.getter = fget
-        self.setter = fset
+        self.fget = fget
+        self.fset = fset
         self.__doc__ = doc
 
-    def __get__(self, im_inst, im_class=None):
-        if im_inst is None:
+    def __get__(self, instance, owner=None):
+        if instance is None:
             return self
-        return bound_named_property(self.name, self.getter, self.setter, im_inst)
+        return bound_named_property(self.name, self.fget, self.fset, instance)
 
     # Make this a data descriptor
-    def __set__(self, obj):
+    def __set__(self, instance):
         raise AttributeError("Unsettable attribute")
 
     def __repr__(self):


### PR DESCRIPTION
Re-submitted of #297

`comtypes.named_property` and `comtypes.bound_named_property` are [descriptor](https://docs.python.org/3/library/functions.html#property), behave like builtin [`property`](https://docs.python.org/3/library/functions.html#property).

They have same names args and attributes, but there are differences in their roles.

For example, `getter` is
- an instance attribute of `named_property`.
- a method of builtin `property`.

It is very complicated, so this PR changes `(bound_)named_property` to match the `property`.

## Changes
- `getter` -> `fget`
- `setter` -> `fset`
- `im_inst` -> `instance`
- `im_class` -> `owner`

## FYI
- In python 3.10, `inspect`ed result of builtin `property` is below.
```py
>>> import inspect
>>> inspect.signature(property)
<Signature (fget=None, fset=None, fdel=None, doc=None)>
>>> inspect.signature(property.__get__)
<Signature (self, instance, owner, /)>
>>> inspect.signature(property.__set__)
<Signature (self, instance, value, /)>
>>> property.getter
<method 'getter' of 'property' objects>
>>> property.setter
<method 'setter' of 'property' objects>
```

- https://docs.python.org/3/howto/descriptor.html#properties