### PR TITLE
Refactor `comtypes.client._generate.GetModule`

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -19,7 +19,9 @@ else:
     import _winreg as winreg
     import cStringIO as io
 
+
 PATH = os.environ["PATH"].split(os.pathsep)
+
 
 def _my_import(fullname):
     # helper function to import dotted modules
@@ -28,6 +30,7 @@ def _my_import(fullname):
            and comtypes.client.gen_dir not in comtypes.gen.__path__:
         comtypes.gen.__path__.append(comtypes.client.gen_dir)
     return __import__(fullname, globals(), locals(), ['DUMMY'])
+
 
 def _name_module(tlib):
     # Determine the name of a typelib wrapper module.
@@ -38,6 +41,7 @@ def _name_module(tlib):
                libattr.wMajorVerNum,
                libattr.wMinorVerNum)
     return "comtypes.gen." + modname
+
 
 def _resolve_filename(tlib_string, dirpath):
     """Tries to make sense of a type library specified as a string.
@@ -195,6 +199,7 @@ def GetModule(tlib):
     if hasattr(importlib, "invalidate_caches"):
         importlib.invalidate_caches()
     return _my_import("comtypes.gen." + modulename)
+
 
 def _CreateWrapper(tlib, pathname):
     # helper which creates and imports the real typelib wrapper module.

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -210,9 +210,8 @@ def _create_friendly_module(tlib, modulename):
         setattr(comtypes.gen, modulename, mod)
         return mod
     # create in file system, and import it
-    ofi = open(os.path.join(comtypes.client.gen_dir, modulename + ".py"), "w")
-    ofi.write(code)
-    ofi.close()
+    with open(os.path.join(comtypes.client.gen_dir, modulename + ".py"), "w") as ofi:
+        ofi.write(code)
     _invalidate_import_caches()
     return _my_import("comtypes.gen." + modulename)
 
@@ -242,9 +241,8 @@ def _create_wrapper_module(tlib, pathname):
         sys.modules[fullname] = mod
         setattr(comtypes.gen, modname, mod)
     else:
-        ofi = open(os.path.join(comtypes.client.gen_dir, modname + ".py"), "w")
-        ofi.write(stream.getvalue())
-        ofi.close()
+        with open(os.path.join(comtypes.client.gen_dir, modname + ".py"), "w") as ofi:
+            ofi.write(stream.getvalue())
         _invalidate_import_caches()
         mod = _my_import(fullname)
     return mod

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -121,10 +121,10 @@ def GetModule(tlib):
         # directory of the calling module (if not from command line)
         frame = sys._getframe(1)
         _file_ = frame.f_globals.get("__file__", None)
-        pathname, path_exists = _resolve_filename(tlib, _file_ and os.path.dirname(_file_))
-        logger.debug("GetModule(%s), resolved: %s", pathname, path_exists)
+        pathname, is_abs = _resolve_filename(tlib_string, _file_ and os.path.dirname(_file_))
+        logger.debug("GetModule(%s), resolved: %s", pathname, is_abs)
         tlib = _load_tlib(pathname)  # don't register
-        if not path_exists:
+        if not is_abs:
             # try to get path after loading, but this only works if already registered            
             pathname = comtypes.tools.tlbparser.get_tlib_filename(tlib)
             if pathname is None:

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -207,10 +207,8 @@ def _invalidate_import_caches():
 def _create_wrapper_module(tlib, pathname):
     """helper which creates and imports the friendly-named module."""
     fullname = _name_module(tlib)
-    try:
+    if fullname in sys.modules:
         return sys.modules[fullname]
-    except KeyError:
-        pass
 
     modname = fullname.split(".")[-1]
 

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -123,7 +123,7 @@ def GetModule(tlib):
         # directory of the calling module (if not from command line)
         frame = sys._getframe(1)
         _file_ = frame.f_globals.get("__file__", None)
-        pathname, is_abs = _resolve_filename(tlib_string, _file_)
+        pathname, is_abs = _resolve_filename(tlib_string, _file_ and os.path.dirname(_file_))
         logger.debug("GetModule(%s), resolved: %s", pathname, is_abs)
         tlib = _load_tlib(pathname)  # don't register
         if not is_abs:

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -157,7 +157,7 @@ def GetModule(tlib):
         # an ITypeLib pointer
         logger.debug("GetModule(%s)", tlib.GetLibAttr())
 
-    # create and import the module
+    # create and import the real typelib wrapper module
     mod = _create_wrapper_module(tlib, pathname)
     try:
         modulename = tlib.GetDocumentation(-1)[0]
@@ -167,8 +167,18 @@ def GetModule(tlib):
         return mod
     if sys.version_info < (3, 0):
         modulename = modulename.encode("mbcs")
-
     # create and import the friendly-named module
+    return _create_friendly_module(tlib, modulename)
+
+
+def _invalidate_import_caches():
+    """clear the import cache to make sure Python sees newly created modules"""
+    if hasattr(importlib, "invalidate_caches"):
+        importlib.invalidate_caches()
+
+
+def _create_friendly_module(tlib, modulename):
+    """helper which creates and imports the friendly-named module."""
     try:
         mod = _my_import("comtypes.gen." + modulename)
     except Exception as details:
@@ -196,12 +206,6 @@ def GetModule(tlib):
     ofi.close()
     _invalidate_import_caches()
     return _my_import("comtypes.gen." + modulename)
-
-
-def _invalidate_import_caches():
-    """clear the import cache to make sure Python sees newly created modules"""
-    if hasattr(importlib, "invalidate_caches"):
-        importlib.invalidate_caches()
 
 
 def _create_wrapper_module(tlib, pathname):

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -24,7 +24,7 @@ PATH = os.environ["PATH"].split(os.pathsep)
 
 
 def _my_import(fullname):
-    # helper function to import dotted modules
+    """helper function to import dotted modules"""
     import comtypes.gen
     if comtypes.client.gen_dir \
            and comtypes.client.gen_dir not in comtypes.gen.__path__:
@@ -33,7 +33,7 @@ def _my_import(fullname):
 
 
 def _name_module(tlib):
-    # Determine the name of a typelib wrapper module.
+    """Determine the name of a typelib wrapper module"""
     libattr = tlib.GetLibAttr()
     modname = "_%s_%s_%s_%s" % \
               (str(libattr.guid)[1:-1].replace("-", "_"),
@@ -51,10 +51,9 @@ def _resolve_filename(tlib_string, dirpath):
         dirpath: a directory to relativize the location
 
     Returns:
-
-      (abspath, True) or (relpath, False), 
-    
-    where relpath is an unresolved path."""
+        (abspath, True) or (relpath, False):
+            where relpath is an unresolved path.
+    """
     assert isinstance(tlib_string, base_text_type)
     # pathname of type library
     if os.path.isabs(tlib_string):
@@ -202,7 +201,7 @@ def GetModule(tlib):
 
 
 def _CreateWrapper(tlib, pathname):
-    # helper which creates and imports the real typelib wrapper module.
+    """helper which creates and imports the friendly-named module."""
     fullname = _name_module(tlib)
     try:
         return sys.modules[fullname]

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -12,8 +12,12 @@ logger = logging.getLogger(__name__)
 
 if sys.version_info >= (3, 0):
     base_text_type = str
+    import winreg
+    import io
 else:
     base_text_type = basestring
+    import _winreg as winreg
+    import cStringIO as io
 
 PATH = os.environ["PATH"].split(os.pathsep)
 
@@ -129,12 +133,7 @@ def GetModule(tlib):
     elif isinstance(tlib, comtypes.GUID):
         # tlib contain a clsid
         clsid = str(tlib)
-        
         # lookup associated typelib in registry
-        if sys.version_info >= (3, 0):
-            import winreg
-        else:
-            import _winreg as winreg
         with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\TypeLib" % clsid, 0, winreg.KEY_READ) as key:
             typelib = winreg.EnumValue(key, 0)[1]
         with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\Version" % clsid, 0, winreg.KEY_READ) as key:
@@ -215,10 +214,6 @@ def _CreateWrapper(tlib, pathname):
     # generate the module since it doesn't exist or is out of date
     from comtypes.tools.tlbparser import generate_module
     if comtypes.client.gen_dir is None:
-        if sys.version_info >= (3, 0):
-            import io
-        else:
-            import cStringIO as io
         ofi = io.StringIO()
     else:
         ofi = open(os.path.join(comtypes.client.gen_dir, modname + ".py"), "w")

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -194,10 +194,14 @@ def GetModule(tlib):
     ofi = open(os.path.join(comtypes.client.gen_dir, modulename + ".py"), "w")
     ofi.write(code)
     ofi.close()
-    # clear the import cache to make sure Python sees newly created modules
+    _invalidate_import_caches()
+    return _my_import("comtypes.gen." + modulename)
+
+
+def _invalidate_import_caches():
+    """clear the import cache to make sure Python sees newly created modules"""
     if hasattr(importlib, "invalidate_caches"):
         importlib.invalidate_caches()
-    return _my_import("comtypes.gen." + modulename)
 
 
 def _create_wrapper_module(tlib, pathname):
@@ -235,9 +239,7 @@ def _create_wrapper_module(tlib, pathname):
         setattr(comtypes.gen, modname, mod)
     else:
         ofi.close()
-        # clear the import cache to make sure Python sees newly created modules
-        if hasattr(importlib, "invalidate_caches"):
-            importlib.invalidate_caches()
+        _invalidate_import_caches()
         mod = _my_import(fullname)
     return mod
 

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -158,7 +158,7 @@ def GetModule(tlib):
         logger.debug("GetModule(%s)", tlib.GetLibAttr())
 
     # create and import the module
-    mod = _CreateWrapper(tlib, pathname)
+    mod = _create_wrapper_module(tlib, pathname)
     try:
         modulename = tlib.GetDocumentation(-1)[0]
     except comtypes.COMError:
@@ -200,7 +200,7 @@ def GetModule(tlib):
     return _my_import("comtypes.gen." + modulename)
 
 
-def _CreateWrapper(tlib, pathname):
+def _create_wrapper_module(tlib, pathname):
     """helper which creates and imports the friendly-named module."""
     fullname = _name_module(tlib)
     try:

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -211,7 +211,7 @@ def _create_friendly_module(tlib, modulename):
         return mod
     # create in file system, and import it
     with open(os.path.join(comtypes.client.gen_dir, modulename + ".py"), "w") as ofi:
-        ofi.write(code)
+        print(code, file=ofi)
     _invalidate_import_caches()
     return _my_import("comtypes.gen." + modulename)
 
@@ -242,7 +242,7 @@ def _create_wrapper_module(tlib, pathname):
         setattr(comtypes.gen, modname, mod)
     else:
         with open(os.path.join(comtypes.client.gen_dir, modname + ".py"), "w") as ofi:
-            ofi.write(stream.getvalue())
+            print(stream.getvalue(), file=ofi)
         _invalidate_import_caches()
         mod = _my_import(fullname)
     return mod

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -14,7 +14,15 @@ if sys.version_info >= (3, 0):
 else:
     text_type = unicode
 
-class Test(ut.TestCase):
+
+class Test_GetModule(ut.TestCase):
+    def test_clsid(self):
+        clsid = comtypes.GUID.from_progid("MediaPlayer.MediaPlayer")
+        mod = comtypes.client.GetModule(clsid)
+        self.assertEqual(mod.MediaPlayer._reg_clsid_, clsid)
+
+
+class Test_CreateObject(ut.TestCase):
     def test_progid(self):
         # create from ProgID
         obj = comtypes.client.CreateObject("Scripting.Dictionary")
@@ -29,10 +37,6 @@ class Test(ut.TestCase):
         # create from string clsid
         comtypes.client.CreateObject(text_type(Scripting.Dictionary._reg_clsid_))
         comtypes.client.CreateObject(str(Scripting.Dictionary._reg_clsid_))
-
-    def test_GetModule_clsid(self):
-        clsid = comtypes.GUID.from_progid("MediaPlayer.MediaPlayer")
-        tlib = comtypes.client.GetModule(clsid)
 
     @ut.skip(
             "This test uses IE which is not available on all machines anymore. "

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -20,7 +20,7 @@ else:
 class Test_GetModule(ut.TestCase):
     def test_tlib_string(self):
         mod = comtypes.client.GetModule("scrrun.dll")
-        self.assertIs(mod, comtypes.client.GetModule(mod.Library._reg_typelib_))
+        self.assertIs(mod, Scripting)
 
     def test_abspath(self):
         mod = comtypes.client.GetModule(Scripting.typelib_path)

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -69,9 +69,6 @@ class Test(ut.TestCase):
         self.assertEqual(ie.Visible, True)
         self.assertEqual(0, ie.Quit()) # 0 == S_OK
 
-def test_main():
-    from test import test_support
-    test_support.run_unittest(Test)
 
 if __name__ == "__main__":
     ut.main()

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -1,9 +1,10 @@
+from ctypes import POINTER, byref
 import os
 import sys
 import unittest as ut
+
 import comtypes.client
 from comtypes import COSERVERINFO
-from ctypes import POINTER, byref
 
 # create the typelib wrapper and import it
 comtypes.client.GetModule("scrrun.dll")


### PR DESCRIPTION
`client.GetModule` is one of the most used functions in `comtypes`, but the implemented code is quite a lot of lines.

Therefore, I have refactored it by splitting functions according to their roles.

And from the point of view of #114 by @vijairaj,
> the code is buffered in to StringIO before making it to the file and if there's an interruption in between, it would not make it to the file and result in an incomplete file
https://github.com/enthought/comtypes/issues/114#issuecomment-284348343

so I fixed the timing of when the generated code is written to the file.