### PR TITLE
`test_typeinfo.py` quits using `shdocvw.dll` and `ieframe.dll`

### DIFF
--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -32,9 +32,9 @@ class Test(unittest.TestCase):
         self.assertEqual(attr.lcid, other_attr.lcid)
         self.assertEqual(attr.wLibFlags, other_attr.wLibFlags)
 
-##         for n in dir(attr):
-##             if not n.startswith("_"):
-##                 print "\t", n, getattr(attr, n)
+        # for n in dir(attr):
+        #     if not n.startswith("_"):
+        #         print "\t", n, getattr(attr, n)
 
         for i in range(tlib.GetTypeInfoCount()):
             ti = tlib.GetTypeInfo(i)

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -39,12 +39,6 @@ class Test(unittest.TestCase):
         #     if not n.startswith("_"):
         #         print "\t", n, getattr(attr, n)
 
-        guid_null = GUID()
-        with self.assertRaises(COMError):
-            tlib.GetTypeInfoOfGuid(guid_null)
-
-        self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{C7C3F5A4-88A3-11D0-ABCB-00A0C90FFFC0}")))
-
     def test_QueryPathOfRegTypeLib(self):
         dllname = "scrrun.dll"
         tlib = LoadTypeLibEx(dllname)
@@ -77,6 +71,12 @@ class Test(unittest.TestCase):
 
             for v in range(ta.cVars):
                 ti.GetVarDesc(v)
+
+        guid_null = GUID()
+        with self.assertRaises(COMError):
+            tlib.GetTypeInfoOfGuid(guid_null)
+
+        self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{C7C3F5A4-88A3-11D0-ABCB-00A0C90FFFC0}")))
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -58,7 +58,7 @@ class Test(unittest.TestCase):
             ta = ti.GetTypeAttr()
             ti.GetDocumentation(-1)
             c_tlib, c_index = ti.GetContainingTypeLib()
-            self.assertEqual(c_tlib, tlib)
+            self.assert_tlibattr_equal(c_tlib, tlib)
             self.assertEqual(c_index, index)
             if ta.typekind in (TKIND_INTERFACE, TKIND_DISPATCH):
                 if ta.cImplTypes:

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -9,20 +9,14 @@ from comtypes.typeinfo import LoadTypeLibEx, LoadRegTypeLib, \
 
 class Test(unittest.TestCase):
     def test_LoadTypeLibEx(self):
-        # IE 6 uses shdocvw.dll, IE 7 uses ieframe.dll
-        if os.path.exists(os.path.join(os.environ["SystemRoot"],
-                                        "system32", "ieframe.dll")):
-            dllname = "ieframe.dll"
-        else:
-            dllname = "shdocvw.dll"
-
+        dllname = "scrrun.dll"
         self.assertRaises(WindowsError, lambda: LoadTypeLibEx("<xxx.xx>"))
         tlib = LoadTypeLibEx(dllname)
         self.assertTrue(tlib.GetTypeInfoCount())
         tlib.GetDocumentation(-1)
-        self.assertEqual(tlib.IsName("iwebbrowser"), "IWebBrowser")
-        self.assertEqual(tlib.IsName("IWEBBROWSER"), "IWebBrowser")
-        self.assertTrue(tlib.FindName("IWebBrowser"))
+        self.assertEqual(tlib.IsName("ifile"), "IFile")
+        self.assertEqual(tlib.IsName("IFILE"), "IFile")
+        self.assertTrue(tlib.FindName("IFile"))
         self.assertEqual(tlib.IsName("Spam"), None)
         tlib.GetTypeComp()
 
@@ -55,14 +49,14 @@ class Test(unittest.TestCase):
         guid_null = GUID()
         self.assertRaises(COMError, lambda: tlib.GetTypeInfoOfGuid(guid_null))
 
-        self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{EAB22AC1-30C1-11CF-A7EB-0000C05BAE0B}")))
+        self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{C7C3F5A4-88A3-11D0-ABCB-00A0C90FFFC0}")))
 
         path = QueryPathOfRegTypeLib(*info)
         path = path.split("\0")[0]
         self.assertTrue(path.lower().endswith(dllname))
 
     def test_TypeInfo(self):
-        tlib = LoadTypeLibEx("shdocvw.dll")
+        tlib = LoadTypeLibEx("scrrun.dll")
         for index in range(tlib.GetTypeInfoCount()):
             ti = tlib.GetTypeInfo(index)
             ta = ti.GetTypeAttr()

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -43,10 +43,6 @@ class Test(unittest.TestCase):
             tlib.GetDocumentation(i)
             tlib.GetTypeInfoType(i)
 
-            c_tlib, index = ti.GetContainingTypeLib()
-            self.assertEqual(c_tlib, tlib)
-            self.assertEqual(index, i)
-
         guid_null = GUID()
         with self.assertRaises(COMError):
             tlib.GetTypeInfoOfGuid(guid_null)
@@ -68,6 +64,9 @@ class Test(unittest.TestCase):
             ti = tlib.GetTypeInfo(index)
             ta = ti.GetTypeAttr()
             ti.GetDocumentation(-1)
+            c_tlib, index = ti.GetContainingTypeLib()
+            self.assertEqual(c_tlib, tlib)
+            self.assertEqual(index, i)
             if ta.typekind in (TKIND_INTERFACE, TKIND_DISPATCH):
                 if ta.cImplTypes:
                     href = ti.GetRefTypeOfImplType(0)

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -21,6 +21,8 @@ class Test(unittest.TestCase):
         self.assertEqual(tlib.IsName("Spam"), None)
         tlib.GetTypeComp()
 
+    def test_LoadRegTypeLib(self):
+        tlib = LoadTypeLibEx("scrrun.dll")
         attr = tlib.GetLibAttr()
         info = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
         other_tlib = LoadRegTypeLib(*info)

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -53,6 +53,11 @@ class Test(unittest.TestCase):
 
         self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{C7C3F5A4-88A3-11D0-ABCB-00A0C90FFFC0}")))
 
+    def test_QueryPathOfRegTypeLib(self):
+        dllname = "scrrun.dll"
+        tlib = LoadTypeLibEx(dllname)
+        attr = tlib.GetLibAttr()
+        info = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
         path = QueryPathOfRegTypeLib(*info)
         path = path.split("\0")[0]
         self.assertTrue(path.lower().endswith(dllname))

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -10,7 +10,8 @@ from comtypes.typeinfo import LoadTypeLibEx, LoadRegTypeLib, \
 class Test(unittest.TestCase):
     def test_LoadTypeLibEx(self):
         dllname = "scrrun.dll"
-        self.assertRaises(WindowsError, lambda: LoadTypeLibEx("<xxx.xx>"))
+        with self.assertRaises(WindowsError):
+            LoadTypeLibEx("<xxx.xx>")
         tlib = LoadTypeLibEx(dllname)
         self.assertTrue(tlib.GetTypeInfoCount())
         tlib.GetDocumentation(-1)
@@ -47,7 +48,8 @@ class Test(unittest.TestCase):
             self.assertEqual(index, i)
 
         guid_null = GUID()
-        self.assertRaises(COMError, lambda: tlib.GetTypeInfoOfGuid(guid_null))
+        with self.assertRaises(COMError):
+            tlib.GetTypeInfoOfGuid(guid_null)
 
         self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{C7C3F5A4-88A3-11D0-ABCB-00A0C90FFFC0}")))
 

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -37,12 +37,6 @@ class Test(unittest.TestCase):
         #     if not n.startswith("_"):
         #         print "\t", n, getattr(attr, n)
 
-        for i in range(tlib.GetTypeInfoCount()):
-            ti = tlib.GetTypeInfo(i)
-            ti.GetTypeAttr()
-            tlib.GetDocumentation(i)
-            tlib.GetTypeInfoType(i)
-
         guid_null = GUID()
         with self.assertRaises(COMError):
             tlib.GetTypeInfoOfGuid(guid_null)

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -64,9 +64,9 @@ class Test(unittest.TestCase):
             ti = tlib.GetTypeInfo(index)
             ta = ti.GetTypeAttr()
             ti.GetDocumentation(-1)
-            c_tlib, index = ti.GetContainingTypeLib()
+            c_tlib, c_index = ti.GetContainingTypeLib()
             self.assertEqual(c_tlib, tlib)
-            self.assertEqual(index, i)
+            self.assertEqual(c_index, index)
             if ta.typekind in (TKIND_INTERFACE, TKIND_DISPATCH):
                 if ta.cImplTypes:
                     href = ti.GetRefTypeOfImplType(0)

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -26,10 +26,10 @@ class Test(unittest.TestCase):
         attr = tlib.GetLibAttr()
         info = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
         other_tlib = LoadRegTypeLib(*info)
-        other_attr = other_tlib.GetLibAttr()
-        self.assert_tlibattr_equal(attr, other_attr)
+        self.assert_tlibattr_equal(tlib, other_tlib)
     
-    def assert_tlibattr_equal(self, attr, other_attr):
+    def assert_tlibattr_equal(self, tlib, other_tlib):
+        attr, other_attr = tlib.GetLibAttr(), other_tlib.GetLibAttr()
         # `assert tlib == other_tlib` will fail in some environments.
         # But their attributes are equal even if difference of environments.
         self.assertEqual(attr.guid, other_attr.guid)
@@ -83,7 +83,7 @@ class Test(unittest.TestCase):
         ti = tlib.GetTypeInfoOfGuid(guid)
         c_tlib, c_index = ti.GetContainingTypeLib()
         c_ti = c_tlib.GetTypeInfo(c_index)
-        self.assert_tlibattr_equal(c_tlib.GetLibAttr(), tlib.GetLibAttr())
+        self.assert_tlibattr_equal(c_tlib, tlib)
         self.assertEqual(c_ti, ti)
         self.assertEqual(guid, ti.GetTypeAttr().guid)
 

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -27,6 +27,9 @@ class Test(unittest.TestCase):
         info = attr.guid, attr.wMajorVerNum, attr.wMinorVerNum
         other_tlib = LoadRegTypeLib(*info)
         other_attr = other_tlib.GetLibAttr()
+        self.assert_tlibattr_equal(attr, other_attr)
+    
+    def assert_tlibattr_equal(self, attr, other_attr):
         # `assert tlib == other_tlib` will fail in some environments.
         # But their attributes are equal even if difference of environments.
         self.assertEqual(attr.guid, other_attr.guid)
@@ -76,7 +79,13 @@ class Test(unittest.TestCase):
         with self.assertRaises(COMError):
             tlib.GetTypeInfoOfGuid(guid_null)
 
-        self.assertTrue(tlib.GetTypeInfoOfGuid(GUID("{C7C3F5A4-88A3-11D0-ABCB-00A0C90FFFC0}")))
+        guid = GUID("{C7C3F5A4-88A3-11D0-ABCB-00A0C90FFFC0}")
+        ti = tlib.GetTypeInfoOfGuid(guid)
+        c_tlib, c_index = ti.GetContainingTypeLib()
+        c_ti = c_tlib.GetTypeInfo(c_index)
+        self.assert_tlibattr_equal(c_tlib.GetLibAttr(), tlib.GetLibAttr())
+        self.assertEqual(c_ti, ti)
+        self.assertEqual(guid, ti.GetTypeAttr().guid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
see #302 for the reason for changes.
- To be honest, I thought I had replaced the dll in #298 but missed it.

And I did below;
- added some assertions to `test_TypeInfo`.(previously, there is no assertion!)
- split some test cases and move assertions.
