### PR TITLE
Split `Constants` into a separate module.

### DIFF
--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -18,6 +18,7 @@ import comtypes.automation
 import comtypes.typeinfo
 import comtypes.client.dynamic
 
+from comtypes.client._constants import Constants
 from comtypes.client._events import GetEvents, ShowEvents, PumpEvents
 from comtypes.client._generate import GetModule
 
@@ -131,30 +132,6 @@ wrap = GetBestInterface
 
 # Should we do this for POINTER(IUnknown) also?
 ctypes.POINTER(comtypes.automation.IDispatch).__ctypes_from_outparam__ = wrap_outparam
-
-################################################################
-#
-# Typelib constants
-#
-class Constants(object):
-    """This class loads the type library from the supplied object,
-    then exposes constants in the type library as attributes."""
-    def __init__(self, obj):
-        obj = obj.QueryInterface(comtypes.automation.IDispatch)
-        tlib, index = obj.GetTypeInfo(0).GetContainingTypeLib()
-        self.tcomp = tlib.GetTypeComp()
-
-    def __getattr__(self, name):
-        try:
-            kind, desc = self.tcomp.Bind(name)
-        except (WindowsError, comtypes.COMError):
-            raise AttributeError(name)
-        if kind != "variable":
-            raise AttributeError(name)
-        return desc._.lpvarValue[0].value
-
-    def _bind_type(self, name):
-        return self.tcomp.BindType(name)
 
 ################################################################
 #

--- a/comtypes/client/_constants.py
+++ b/comtypes/client/_constants.py
@@ -1,0 +1,28 @@
+################################################################
+#
+# Typelib constants
+#
+################################################################
+import comtypes
+import comtypes.automation
+
+
+class Constants(object):
+    """This class loads the type library from the supplied object,
+    then exposes constants in the type library as attributes."""
+    def __init__(self, obj):
+        obj = obj.QueryInterface(comtypes.automation.IDispatch)
+        tlib, index = obj.GetTypeInfo(0).GetContainingTypeLib()
+        self.tcomp = tlib.GetTypeComp()
+
+    def __getattr__(self, name):
+        try:
+            kind, desc = self.tcomp.Bind(name)
+        except (WindowsError, comtypes.COMError):
+            raise AttributeError(name)
+        if kind != "variable":
+            raise AttributeError(name)
+        return desc._.lpvarValue[0].value
+
+    def _bind_type(self, name):
+        return self.tcomp.BindType(name)


### PR DESCRIPTION
The reason for change is in #301, and see below;
https://github.com/enthought/comtypes/blob/4c97398ac142f7fcd4d9ef9c2dcb47f2b7972fdf/comtypes/client/__init__.py#L4-L10

I just moved `Constants` to a different module, and import to `comtypes.client`.