### PR TITLE
`client.GetModule` can take a just one-length sequence containing libUUID

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -169,9 +169,12 @@ def _load_tlib(obj):
         with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\Version" % clsid) as key:
             version = winreg.EnumValue(key, 0)[1].split(".")
         return LoadRegTypeLib(GUID(libid), int(version[0]), int(version[1]), 0)
-    # obj is a sequence containing libid and version numbers
+    # obj is a sequence containing libid
     elif isinstance(obj, (tuple, list)):
         libid, version = obj[0], obj[1:]
+        if not version:  # case of version numbers are not containing
+            with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"TypeLib\%s" % libid) as key:
+                version = [int(v, base=16) for v in winreg.EnumKey(key, 0).split(".")]
         return LoadRegTypeLib(GUID(libid), *version)
     # obj is a COMObject implementation
     elif hasattr(obj, "_reg_libid_"):

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -38,6 +38,11 @@ class Test_GetModule(ut.TestCase):
         mod = comtypes.client.GetModule(Scripting.Library._reg_typelib_)
         self.assertIs(mod, Scripting)
 
+    def test_one_length_sequence_containing_libid(self):
+        libid, _, _ = Scripting.Library._reg_typelib_
+        mod = comtypes.client.GetModule((libid,))
+        self.assertIs(mod, Scripting)
+
     def test_obj_has_reg_libid_and_reg_version(self):
         typelib = Scripting.Library._reg_typelib_
         libid, version = typelib[0], typelib[1:]


### PR DESCRIPTION
see #309

With this change, for example, `GetModule(("{00020813-0000-0000-C000-000000000046}",))` will generate `comtypes.gen.Excel` module.