### PR TITLE
Update `test_excel`

### DIFF
--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -24,7 +24,7 @@ except (ImportError, OSError):
     IMPORT_FAILED = True
 
 
-class Base(object):
+class BaseBindTest(object):
     # `dynamic = True/False` must be defined in subclasses!
 
     def setUp(self):
@@ -117,12 +117,12 @@ class Base(object):
 @unittest.skipIf(IMPORT_FAILED, "This depends on Excel.")
 @unittest.skip("There is difference of `Range.Value` behavior "
     "between Python >= 3.8.x and Python <= 3.7.x.")
-class Test_EarlyBind(Base, unittest.TestCase):
+class Test_EarlyBind(BaseBindTest, unittest.TestCase):
     dynamic = False
 
 
 @unittest.skipIf(IMPORT_FAILED, "This depends on Excel.")
-class Test_LateBind(Base, unittest.TestCase):
+class Test_LateBind(BaseBindTest, unittest.TestCase):
     dynamic = True
 
 

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -24,10 +24,7 @@ except (ImportError, OSError):
     IMPORT_FAILED = True
 
 
-@unittest.skipIf(IMPORT_FAILED, "This depends on Excel.")
-@unittest.skip("There is difference of `Range.Value` behavior "
-    "between Python >= 3.8.x and Python <= 3.7.x.")
-class BaseTest(unittest.TestCase):
+class Base(object):
     # `dynamic = True/False` must be defined in subclasses!
 
     def setUp(self):
@@ -43,9 +40,9 @@ class BaseTest(unittest.TestCase):
     def test(self):
         xl = self.xl
         xl.Visible = 0
-        self.assertEqual(xl.Visible, False)
+        self.assertEqual(xl.Visible, False)  # type: ignore
         xl.Visible = 1
-        self.assertEqual(xl.Visible, True)
+        self.assertEqual(xl.Visible, True)  # type: ignore
 
         wb = xl.Workbooks.Add()
 
@@ -117,15 +114,16 @@ class BaseTest(unittest.TestCase):
         sh.Range[sh.Cells.Item[4,1],sh.Cells.Item[6,3]].Select()
 
 
-class Test_EarlyBind(BaseTest):
+@unittest.skipIf(IMPORT_FAILED, "This depends on Excel.")
+@unittest.skip("There is difference of `Range.Value` behavior "
+    "between Python >= 3.8.x and Python <= 3.7.x.")
+class Test_EarlyBind(Base, unittest.TestCase):
     dynamic = False
 
 
-class Test_LateBind(BaseTest):
+@unittest.skipIf(IMPORT_FAILED, "This depends on Excel.")
+class Test_LateBind(Base, unittest.TestCase):
     dynamic = True
-
-
-del BaseTest  # to avoid running `BaseTest`
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -4,32 +4,43 @@ from __future__ import print_function
 import datetime
 import unittest
 
-import comtypes.test
-from comtypes.client import CreateObject
+from comtypes.client import CreateObject, GetModule
 
-comtypes.test.requires("ui")
+################################################################
+#
+# TODO:
+#
+# It seems bad that only external test like this
+# can verify the behavior of `comtypes` implementation.
+# Find a different built-in win32 API to use.
+#
+################################################################
+
+try:
+    GetModule(("{00020813-0000-0000-C000-000000000046}",))  # Excel libUUID
+    from comtypes.gen.Excel import xlRangeValueDefault
+    IMPORT_FAILED = False
+except (ImportError, OSError):
+    IMPORT_FAILED = True
 
 
-def setUpModule():
-    raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
-                            "built-in win32 API to use.")
+@unittest.skipIf(IMPORT_FAILED, "This depends on Excel.")
+@unittest.skip("There is difference of `Range.Value` behavior "
+    "between Python >= 3.8.x and Python <= 3.7.x.")
+class BaseTest(unittest.TestCase):
+    # `dynamic = True/False` must be defined in subclasses!
 
+    def setUp(self):
+        self.xl = CreateObject("Excel.Application", dynamic=self.dynamic)
 
-xlRangeValueDefault = 10
-xlRangeValueXMLSpreadsheet = 11
-xlRangeValueMSPersistXML = 12
+    def tearDown(self):
+        # Close all open workbooks without saving, then quit excel.
+        for wb in self.xl.Workbooks:
+            wb.Close(0)
+        self.xl.Quit()
+        del self.xl
 
-class Test(unittest.TestCase):
-
-    def test_earlybound(self):
-        self._doit(False)
-
-    def test_latebound(self):
-        self._doit(True)
-
-    def _doit(self, dynamic):
-        self.xl = CreateObject("Excel.Application", dynamic=dynamic)
-
+    def test(self):
         xl = self.xl
         xl.Visible = 0
         self.assertEqual(xl.Visible, False)
@@ -39,41 +50,33 @@ class Test(unittest.TestCase):
         wb = xl.Workbooks.Add()
 
         # Test with empty-tuple argument
-        xl.Range["A1", "C1"].Value[()] = (10,"20",31.4)
+        xl.Range["A1", "C1"].Value[()] = (10,"20",31.4)  # XXX: in Python >= 3.8.x, cannot set values to A1:C1
         xl.Range["A2:C2"].Value[()] = ('x','y','z')
         # Test with empty slice argument
         xl.Range["A3:C3"].Value[:] = ('3','2','1')
-## not (yet?) implemented:
-##        xl.Range["A4:C4"].Value = ('3','2','1')
+        # not implemented:
+        #     xl.Range["A4:C4"].Value = ("3", "2" ,"1")
 
         # call property to retrieve value
+        expected_values = ((10.0, 20.0, 31.4),
+                           ("x", "y", "z"),
+                           (3.0, 2.0, 1.0))
+        # XXX: in Python >= 3.8.x, fails below
         self.assertEqual(xl.Range["A1:C3"].Value(),
-                             ((10.0, 20.0, 31.4),
-                              ("x", "y", "z"),
-                              (3.0, 2.0, 1.0)))
+                         expected_values)
         # index with empty tuple
         self.assertEqual(xl.Range["A1:C3"].Value[()],
-                             ((10.0, 20.0, 31.4),
-                              ("x", "y", "z"),
-                              (3.0, 2.0, 1.0)))
+                         expected_values)
         # index with empty slice
         self.assertEqual(xl.Range["A1:C3"].Value[:],
-                             ((10.0, 20.0, 31.4),
-                              ("x", "y", "z"),
-                              (3.0, 2.0, 1.0)))
+                         expected_values)
         self.assertEqual(xl.Range["A1:C3"].Value[xlRangeValueDefault],
-                             ((10.0, 20.0, 31.4),
-                              ("x", "y", "z"),
-                              (3.0, 2.0, 1.0)))
+                         expected_values)
         self.assertEqual(xl.Range["A1", "C3"].Value[()],
-                             ((10.0, 20.0, 31.4),
-                              ("x", "y", "z"),
-                              (3.0, 2.0, 1.0)))
+                         expected_values)
 
-        r = xl.Range["A1:C3"]
-        i = iter(r)
-
-        # Test for iteration support in 'Range' interface
+        # Test for iteration support in "Range" interface
+        iter(xl.Range["A1:C3"])
         self.assertEqual([c.Value() for c in xl.Range["A1:C3"]],
                              [10.0, 20.0, 31.4,
                               "x", "y", "z",
@@ -83,12 +86,14 @@ class Test(unittest.TestCase):
         # With comtypes, one must write xl.Cells.Item(1, b)
 
         for i in range(20):
-            xl.Cells.Item[i+1,i+1].Value[()] = "Hi %d" % i
-            print(xl.Cells.Item[i+1, i+1].Value[()])
+            val = "Hi %d" % i
+            xl.Cells.Item[i+1,i+1].Value[()] = val
+            self.assertEqual(xl.Cells.Item[i+1, i+1].Value[()], val)
 
         for i in range(20):
-            xl.Cells(i+1,i+1).Value[()] = "Hi %d" % i
-            print(xl.Cells(i+1, i+1).Value[()])
+            val = "Hi %d" % i
+            xl.Cells(i+1,i+1).Value[()] = val
+            self.assertEqual(xl.Cells(i+1, i+1).Value[()], val)
 
         # test dates out with Excel
         xl.Range["A5"].Value[()] = "Excel time"
@@ -111,11 +116,17 @@ class Test(unittest.TestCase):
         sh.Range[sh.Cells.Item[1,1],sh.Cells.Item[3,3]].Copy(sh.Cells.Item[4,1])
         sh.Range[sh.Cells.Item[4,1],sh.Cells.Item[6,3]].Select()
 
-    def tearDown(self):
-        # Close all open workbooks without saving, then quit excel.
-        for wb in self.xl.Workbooks:
-            wb.Close(0)
-        self.xl.Quit()
+
+class Test_EarlyBind(BaseTest):
+    dynamic = False
+
+
+class Test_LateBind(BaseTest):
+    dynamic = True
+
+
+del BaseTest  # to avoid running `BaseTest`
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In #298, environment-specific-tests are skipped.

But there are `def setUpModule;raise SkipTest(...` in some modules.
In this way, skipped testcase names are not displayed even if using `-v` option.

With this change, in `test_excel`, skipped testcase name and reasons are displayed in console.

for example:
```
# with non-excel-installed environment
test (test_excel.Test_EarlyBind) ... skipped 'This depends on Excel.'
test (test_excel.Test_LateBind) ... skipped 'This depends on Excel.'
```

```
# with excel-installed environment
test (test_excel.Test_EarlyBind) ... skipped 'There is difference of `Range.Value` behavior between Python >= 3.8.x and Python <= 3.7.x.'
test (test_excel.Test_LateBind) ... ok
```

See https://github.com/enthought/comtypes/issues/212#issuecomment-1163176126 for details of `@unittest.skip("There is difference of  ...`