### PR TITLE
Update `test_word`

### DIFF
--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -1,6 +1,7 @@
 import time
 import unittest
 
+from comtypes import COMError
 import comtypes.client
 import comtypes.test
 
@@ -32,7 +33,6 @@ class Test(unittest.TestCase):
         del self.word
 
     def test(self):
-        # create a word instance
         word = self.word
         from comtypes.gen import Word
 
@@ -70,11 +70,9 @@ class Test(unittest.TestCase):
         tb = word.CommandBars("Standard")
         btn = tb.Controls[1]
 
-        if 0: # word does not allow programmatic access, so this does fail
-            evt = word.VBE.Events.CommandBarEvents(btn)
-            from comtypes.gen import Word, VBIDE
-            comtypes.client.ShowEvents(evt, interface=VBIDE._dispCommandBarControlEvents)
-            comtypes.client.ShowEvents(evt)
+        # word does not allow programmatic access, so this does fail
+        with self.assertRaises(COMError):
+            word.VBE.Events.CommandBarEvents(btn)
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -14,6 +14,14 @@ def setUpModule():
                             "built-in win32 API to use.")
 
 
+try:
+    comtypes.client.GetModule(('{00020905-0000-0000-C000-000000000046}',))  # Word libUUID
+    from comtypes.gen import Word
+    IMPORT_FAILED = False
+except (ImportError, OSError):
+    IMPORT_FAILED = True
+
+
 class _Sink(object):
     def __init__(self):
         self.events = []
@@ -34,8 +42,6 @@ class Test(unittest.TestCase):
 
     def test(self):
         word = self.word
-        from comtypes.gen import Word
-
         # Get the instance again, and receive events from that
         w2 = comtypes.client.GetActiveObject("Word.Application")
         sink = _Sink()

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -13,16 +13,16 @@ def setUpModule():
                             "built-in win32 API to use.")
 
 
-class Test(unittest.TestCase):
-
-    def setUp(self):
-        self._events = []
+class _Sink(object):
+    def __init__(self):
+        self.events = []
 
     # Word Application Event
     def DocumentChange(self, this, *args):
-##        print "DocumentChange", args
-        self._events.append("DocumentChange")
+        self.events.append("DocumentChange")
 
+
+class Test(unittest.TestCase):
     def test(self):
         # create a word instance
         word = comtypes.client.CreateObject("Word.Application")
@@ -30,7 +30,8 @@ class Test(unittest.TestCase):
 
         # Get the instance again, and receive events from that
         w2 = comtypes.client.GetActiveObject("Word.Application")
-        conn = comtypes.client.GetEvents(w2, sink=self)
+        sink = _Sink()
+        conn = comtypes.client.GetEvents(w2, sink=sink)
 
         word.Visible = 1
 
@@ -53,7 +54,7 @@ class Test(unittest.TestCase):
 
         time.sleep(0.5)
 
-##        self.failUnlessEqual(self._events, ["DocumentChange", "DocumentChange"])
+        self.assertEqual(sink.events, ["DocumentChange", "DocumentChange"])
 
     def test_commandbar(self):
         word = comtypes.client.CreateObject("Word.Application")

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -3,16 +3,6 @@ import unittest
 
 from comtypes import COMError
 import comtypes.client
-import comtypes.test
-
-# XXX leaks references.
-
-comtypes.test.requires("ui")
-
-def setUpModule():
-    raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
-                            "built-in win32 API to use.")
-
 
 try:
     comtypes.client.GetModule(('{00020905-0000-0000-C000-000000000046}',))  # Word libUUID
@@ -20,6 +10,17 @@ try:
     IMPORT_FAILED = False
 except (ImportError, OSError):
     IMPORT_FAILED = True
+
+
+################################################################
+#
+# TODO:
+#
+# It seems bad that only external test like this
+# can verify the behavior of `comtypes` implementation.
+# Find a different built-in win32 API to use.
+#
+################################################################
 
 
 class _Sink(object):
@@ -31,6 +32,7 @@ class _Sink(object):
         self.events.append("DocumentChange")
 
 
+@unittest.skipIf(IMPORT_FAILED, "This depends on Word.")
 class Test(unittest.TestCase):
     def setUp(self):
         # create a word instance
@@ -79,6 +81,8 @@ class Test(unittest.TestCase):
         # word does not allow programmatic access, so this does fail
         with self.assertRaises(COMError):
             word.VBE.Events.CommandBarEvents(btn)
+
+        del word
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -23,9 +23,17 @@ class _Sink(object):
 
 
 class Test(unittest.TestCase):
+    def setUp(self):
+        # create a word instance
+        self.word = comtypes.client.CreateObject("Word.Application")
+
+    def tearDown(self):
+        self.word.Quit()
+        del self.word
+
     def test(self):
         # create a word instance
-        word = comtypes.client.CreateObject("Word.Application")
+        word = self.word
         from comtypes.gen import Word
 
         # Get the instance again, and receive events from that
@@ -49,7 +57,6 @@ class Test(unittest.TestCase):
 
         doc.Close(SaveChanges = Word.wdDoNotSaveChanges)
 
-        word.Quit()
         del word, w2
 
         time.sleep(0.5)
@@ -57,7 +64,7 @@ class Test(unittest.TestCase):
         self.assertEqual(sink.events, ["DocumentChange", "DocumentChange"])
 
     def test_commandbar(self):
-        word = comtypes.client.CreateObject("Word.Application")
+        word = self.word
         word.Visible = 1
         tb = word.CommandBars("Standard")
         btn = tb.Controls[1]
@@ -68,7 +75,6 @@ class Test(unittest.TestCase):
             comtypes.client.ShowEvents(evt, interface=VBIDE._dispCommandBarControlEvents)
             comtypes.client.ShowEvents(evt)
 
-        word.Quit()
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_word.py
+++ b/comtypes/test/test_word.py
@@ -60,6 +60,7 @@ class Test(unittest.TestCase):
         del word, w2
 
         time.sleep(0.5)
+        conn.disconnect()
 
         self.assertEqual(sink.events, ["DocumentChange", "DocumentChange"])
 


### PR DESCRIPTION
With this change, in `test_word`, skipped testcase name and reasons are displayed in console.

for example:
```
# with non-word-installed environment
test (test_word.Test.test) ... skipped 'This depends on Word.'
test (test_word.Test.test_commandbar) ... skipped 'This depends on Word.
```

