### PR TITLE
remove `from sets import Set` workarounds

### DIFF
--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -65,10 +65,7 @@ SHDeleteKey = windll.shlwapi.SHDeleteKeyW
 SHDeleteKey.errcheck = _non_zero
 SHDeleteKey.argtypes = c_ulong, c_wchar_p
 
-try:
-    Set = set
-except NameError:
-    from sets import Set #as set
+Set = set
 
 
 _KEYS = {winreg.HKEY_CLASSES_ROOT: "HKCR",

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -12,10 +12,6 @@ from comtypes import COMError
 from comtypes.tools import typedesc
 from comtypes.client._code_cache import _get_module_filename
 
-try:
-    set
-except NameError:
-    from sets import Set as set
 
 # Is the process 64-bit?
 is_64bits = sys.maxsize > 2**32

--- a/comtypes/tools/typedesc_base.py
+++ b/comtypes/tools/typedesc_base.py
@@ -1,8 +1,4 @@
 # typedesc.py - classes representing C type descriptions
-try:
-    set
-except NameError:
-    from sets import Set as set
 
 class Argument(object):
     "a Parameter in the argument list of a callable (Function, Method, ...)"


### PR DESCRIPTION
Currently, `comtypes` only supports Python versions where the `sets` module has been deprecated or replaced with the built-in `set` class.