### PR TITLE
refactor `tools.tlbparser.get_tlib_filename`

### DIFF
--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -706,17 +706,8 @@ def get_tlib_filename(tlib):
     la = tlib.GetLibAttr()
     name = BSTR()
     try:
-        windll.oleaut32.QueryPathOfRegTypeLib
-    except AttributeError:
-        # Windows CE doesn't have this function
-        return None
-    if 0 == windll.oleaut32.QueryPathOfRegTypeLib(byref(la.guid),
-                                                  la.wMajorVerNum,
-                                                  la.wMinorVerNum,
-                                                  0, # lcid
-                                                  byref(name)
-                                                  ):
-        full_filename = name.value.split("\0")[0]
+        full_filename = typeinfo.QueryPathOfRegTypeLib(
+            str(la.guid), la.wMajorVerNum, la.wMinorVerNum)
         if not os.path.isabs(full_filename):
             # workaround Windows 7 bug in QueryPathOfRegTypeLib returning relative path
             try:
@@ -726,6 +717,8 @@ def get_tlib_filename(tlib):
             except OSError:
                 return None
         return full_filename
+    except OSError:  # there's no way to determine the filename.
+        pass
     return None
 
 def _py2exe_hint():

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -1,10 +1,7 @@
 from __future__ import print_function
 import os
 import sys
-from ctypes import windll
-from ctypes import c_void_p
-from ctypes import sizeof
-from ctypes import alignment
+from ctypes import alignment, c_void_p, sizeof, windll
 
 from comtypes import automation
 from comtypes import typeinfo
@@ -701,10 +698,7 @@ class TypeLibParser(Parser):
 def get_tlib_filename(tlib):
     # seems if the typelib is not registered, there's no way to
     # determine the filename.
-    from ctypes import windll, byref
-    from comtypes import BSTR
     la = tlib.GetLibAttr()
-    name = BSTR()
     try:
         full_filename = typeinfo.QueryPathOfRegTypeLib(
             str(la.guid), la.wMajorVerNum, la.wMinorVerNum)


### PR DESCRIPTION
With this change,

- remove Windows CE workaround
- replace `windll.oleaut32.QueryPathOfRegTypeLib` to `typeinfo.QueryPathOfRegTypeLib`
- make the import part clean