### PR TITLE
modernize `_Struct_Union_Base` definition

### DIFF
--- a/comtypes/tools/typedesc_base.py
+++ b/comtypes/tools/typedesc_base.py
@@ -131,6 +131,10 @@ class StructureBody(object):
 
 class _Struct_Union_Base(object):
     location = None
+    def __init__(self):
+        self.struct_body = StructureBody(self)
+        self.struct_head = StructureHead(self)
+
     def get_body(self):
         return self.struct_body
 
@@ -148,8 +152,7 @@ class Structure(_Struct_Union_Base):
             self.size = int(size)
         else:
             self.size = None
-        self.struct_body = StructureBody(self)
-        self.struct_head = StructureHead(self)
+        super(Structure, self).__init__()
 
 class Union(_Struct_Union_Base):
     def __init__(self, name, align, members, bases, size, artificial=None):
@@ -162,8 +165,7 @@ class Union(_Struct_Union_Base):
             self.size = int(size)
         else:
             self.size = None
-        self.struct_body = StructureBody(self)
-        self.struct_head = StructureHead(self)
+        super(Union, self).__init__()
 
 class Field(object):
     def __init__(self, name, typ, bits, offset):


### PR DESCRIPTION
Formerly, `_Struct_Union_Base` has an incomplete constructor.

Given the role of the base class `_Struct_Union_Base`, it should be avoided to assign other than a `StructureBody` instance to the `struct_body` attribute and/or other than a `StructureHead` instance to the `struct_head` attribute.

If there is a situation where a derived class wants to assign instances of a different type to these attributes, it should not be the responsibility of the `_Struct_Union_Base`, and a suitable base class should be defined separately.