### PR TITLE
Fix `TypeError`  in `client.GetModule("msi.dll")`

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -9,7 +9,7 @@ from ctypes import _Pointer
 from _ctypes import CopyComPointer
 from comtypes import IUnknown, GUID, IID, STDMETHOD, BSTR, COMMETHOD, COMError
 from comtypes.hresult import *
-from comtypes.patcher import Patch
+import comtypes.patcher
 from comtypes import npsupport
 try:
     from comtypes import _safearray
@@ -555,7 +555,7 @@ del v
 _carg_obj = type(byref(c_int()))
 from _ctypes import Array as _CArrayType
 
-@Patch(POINTER(VARIANT))
+@comtypes.patcher.Patch(POINTER(VARIANT))
 class _(object):
     # Override the default .from_param classmethod of POINTER(VARIANT).
     # This allows to pass values which can be stored in VARIANTs as

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -56,6 +56,21 @@ class Test_GetModule(ut.TestCase):
         mod = comtypes.client.GetModule(clsid)
         self.assertEqual(mod.MediaPlayer._reg_clsid_, clsid)
 
+    def test_imports_IEnumVARIANT_from_other_generated_modules(self):
+        # NOTE: `codegenerator` generates code that contains unused imports,
+        # but removing them are attracting wierd bugs in library-wrappers
+        # which depend on externals.
+        # NOTE: `mscorlib`, which imports `IEnumVARIANT` from `stdole`.
+        comtypes.client.GetModule(("{BED7F4EA-1A96-11D2-8F08-00A0C9A6186D}",))
+
+    def test_no_replacing_Patch_namespace(self):
+        # NOTE: An object named `Patch` is defined in some dll.
+        # Depending on how the namespace is defined in the static module,
+        # `Patch` in generated modules will be replaced with
+        # `comtypes.patcher.Patch`, and generating module will fail.
+        # NOTE: `WindowsInstaller`, which has `Patch` definition in dll.
+        comtypes.client.GetModule("msi.dll")
+
 
 class Test_CreateObject(ut.TestCase):
     def test_progid(self):


### PR DESCRIPTION
see #330 and [comment](https://github.com/enthought/comtypes/issues/330#issuecomment-1195419160).

And I added test that ensure #293 was resolved.
(Unused imports in generated modules may be used from other generated modules.)