### PR TITLE
Require explicit enabling of numpy interop

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -284,9 +284,9 @@ class tagVARIANT(Structure):
             com_days = delta.days + (delta.seconds + delta.microseconds * 1e-6) / 86400.
             self.vt = VT_DATE
             self._.VT_R8 = com_days
-        elif npsupport.isdatetime64(value):
+        elif npsupport.interop.isdatetime64(value):
             com_days = value - npsupport.com_null_date64
-            com_days /= npsupport.get_numpy().timedelta64(1, 'D')
+            com_days /= npsupport.interop.numpy.timedelta64(1, 'D')
             self.vt = VT_DATE
             self._.VT_R8 = com_days
         elif decimal is not None and isinstance(value, decimal.Decimal):
@@ -308,10 +308,10 @@ class tagVARIANT(Structure):
             obj = _midlSAFEARRAY(typ).create(value)
             memmove(byref(self._), byref(obj), sizeof(obj))
             self.vt = VT_ARRAY | obj._vartype_
-        elif npsupport.isndarray(value):
+        elif npsupport.interop.isndarray(value):
             # Try to convert a simple array of basic types.
             descr = value.dtype.descr[0][1]
-            typ = npsupport.typecodes.get(descr)
+            typ = npsupport.interop.typecodes.get(descr)
             if typ is None:
                 # Try for variant
                 obj = _midlSAFEARRAY(VARIANT).create(value)

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -286,7 +286,7 @@ class tagVARIANT(Structure):
             self._.VT_R8 = com_days
         elif npsupport.isdatetime64(value):
             com_days = value - npsupport.com_null_date64
-            com_days /= npsupport.numpy.timedelta64(1, 'D')
+            com_days /= npsupport.get_numpy().timedelta64(1, 'D')
             self.vt = VT_DATE
             self._.VT_R8 = com_days
         elif decimal is not None and isinstance(value, decimal.Decimal):

--- a/comtypes/npsupport.py
+++ b/comtypes/npsupport.py
@@ -109,10 +109,13 @@ def enable_numpy_interop():
     necessary functions for comtypes to work with ndarrays.
 
     """
+    global HAVE_NUMPY
+    if HAVE_NUMPY:
+        return
+
     global numpy
     import numpy
 
-    global HAVE_NUMPY
     HAVE_NUMPY = True
     global typecodes
     typecodes = _check_ctypeslib_typecodes()

--- a/comtypes/npsupport.py
+++ b/comtypes/npsupport.py
@@ -63,10 +63,12 @@ def isndarray(value):
     if not HAVE_NUMPY:
         if hasattr(value, "__array_interface__"):
             raise ValueError(
-                f"Argument {value} appears to be a numpy.ndarray, but "
-                "comtypes numpy support has not been enabled. Please "
-                "try calling comtypes.npsupport.enable_numpy_interop() "
-                "before passing ndarrays as parameters."
+                (
+                    "Argument {0} appears to be a numpy.ndarray, but "
+                    "comtypes numpy support has not been enabled. Please "
+                    "try calling comtypes.npsupport.enable_numpy_interop() "
+                    "before passing ndarrays as parameters."
+                ).format(value)
             )
         return False
     numpy = get_numpy()

--- a/comtypes/npsupport.py
+++ b/comtypes/npsupport.py
@@ -2,157 +2,152 @@
 import sys
 
 is_64bits = sys.maxsize > 2**32
-HAVE_NUMPY = False
-com_null_date64 = None
-numpy = None
-datetime64 = None
-VARIANT_dtype = None
-typecodes = {}
 
-def _make_variant_dtype():
-    """ Create a dtype for VARIANT. This requires support for Unions, which is
-    available in numpy version 1.7 or greater.
 
-    This does not support the decimal type.
-
-    Returns None if the dtype cannot be created.
-
+class Interop:
+    """ Class encapsulating all the functionality necessary to allow interop of
+    comtypes with numpy. Needs to be enabled with the "enable()" method.
     """
-    numpy = get_numpy()
+    def __init__(self):
+        self.enabled = False
+        self.VARIANT_dtype = None
+        self.typecodes = {}
+        self.datetime64 = None
+        self.com_null_date64 = None
 
-    # pointer typecode
-    ptr_typecode = '<u8' if is_64bits else '<u4'
+    def _make_variant_dtype(self):
+        """ Create a dtype for VARIANT. This requires support for Unions, which
+        is available in numpy version 1.7 or greater.
 
-    _tagBRECORD_format = [
-        ('pvRecord', ptr_typecode),
-        ('pRecInfo', ptr_typecode),
-    ]
+        This does not support the decimal type.
 
-    # overlapping typecodes only allowed in numpy version 1.7 or greater
-    U_VARIANT_format = dict(
-        names=[
-            'VT_BOOL', 'VT_I1', 'VT_I2', 'VT_I4', 'VT_I8', 'VT_INT', 'VT_UI1',
-            'VT_UI2', 'VT_UI4', 'VT_UI8', 'VT_UINT', 'VT_R4', 'VT_R8', 'VT_CY',
-            'c_wchar_p', 'c_void_p', 'pparray', 'bstrVal', '_tagBRECORD',
-        ],
-        formats=[
-            '<i2', '<i1', '<i2', '<i4', '<i8', '<i4', '<u1', '<u2', '<u4',
-            '<u8', '<u4', '<f4', '<f8', '<i8', ptr_typecode, ptr_typecode,
-            ptr_typecode, ptr_typecode, _tagBRECORD_format,
-        ],
-        offsets=[0] * 19  # This is what makes it a union
-    )
+        Returns None if the dtype cannot be created.
+        """
+        if not self.enabled:
+            return None
+        # pointer typecode
+        ptr_typecode = '<u8' if is_64bits else '<u4'
 
-    tagVARIANT_format = [
-        ("vt", '<u2'),
-        ("wReserved1", '<u2'),
-        ("wReserved2", '<u2'),
-        ("wReserved3", '<u2'),
-        ("_", U_VARIANT_format),
-    ]
+        _tagBRECORD_format = [
+            ('pvRecord', ptr_typecode),
+            ('pRecInfo', ptr_typecode),
+        ]
 
-    return numpy.dtype(tagVARIANT_format)
+        # overlapping typecodes only allowed in numpy version 1.7 or greater
+        U_VARIANT_format = dict(
+            names=[
+                'VT_BOOL', 'VT_I1', 'VT_I2', 'VT_I4', 'VT_I8', 'VT_INT',
+                'VT_UI1', 'VT_UI2', 'VT_UI4', 'VT_UI8', 'VT_UINT', 'VT_R4',
+                'VT_R8', 'VT_CY', 'c_wchar_p', 'c_void_p', 'pparray',
+                'bstrVal', '_tagBRECORD',
+            ],
+            formats=[
+                '<i2', '<i1', '<i2', '<i4', '<i8', '<i4', '<u1', '<u2', '<u4',
+                '<u8', '<u4', '<f4', '<f8', '<i8', ptr_typecode, ptr_typecode,
+                ptr_typecode, ptr_typecode, _tagBRECORD_format,
+            ],
+            offsets=[0] * 19  # This is what makes it a union
+        )
 
+        tagVARIANT_format = [
+            ("vt", '<u2'),
+            ("wReserved1", '<u2'),
+            ("wReserved2", '<u2'),
+            ("wReserved3", '<u2'),
+            ("_", U_VARIANT_format),
+        ]
 
-def isndarray(value):
-    """ Check if a value is an ndarray.
+        return self.numpy.dtype(tagVARIANT_format)
 
-    This cannot succeed if numpy is not available.
-
-    """
-    if not HAVE_NUMPY:
-        if hasattr(value, "__array_interface__"):
-            raise ValueError(
-                (
-                    "Argument {0} appears to be a numpy.ndarray, but "
-                    "comtypes numpy support has not been enabled. Please "
-                    "try calling comtypes.npsupport.enable_numpy_interop() "
-                    "before passing ndarrays as parameters."
-                ).format(value)
-            )
-        return False
-    numpy = get_numpy()
-    return isinstance(value, numpy.ndarray)
-
-
-def isdatetime64(value):
-    """ Check if a value is a datetime64.
-
-    This cannot succeed if datetime64 is not available.
-
-    """
-    if not HAVE_NUMPY:
-        return False
-    return isinstance(value, datetime64)
-
-
-def _check_ctypeslib_typecodes():
-    import numpy as np
-    from numpy import ctypeslib
-    try:
-        from numpy.ctypeslib import _typecodes
-    except ImportError:
-        from numpy.ctypeslib import as_ctypes_type
-
-        dtypes_to_ctypes = {}
-
-        for tp in set(np.sctypeDict.values()):
-            try:
-                ctype_for = as_ctypes_type(tp)
-                dtypes_to_ctypes[np.dtype(tp).str] = ctype_for
-            except NotImplementedError:
-                continue
-        ctypeslib._typecodes = dtypes_to_ctypes
-    return ctypeslib._typecodes
-
-
-def enable_numpy_interop():
-    """ Import the numpy library (if not already imported) and set up the
-    necessary functions for comtypes to work with ndarrays.
-
-    """
-    global HAVE_NUMPY
-    if HAVE_NUMPY:
-        return
-
-    global numpy
-    import numpy
-
-    HAVE_NUMPY = True
-    global typecodes
-    typecodes = _check_ctypeslib_typecodes()
-    # dtype for VARIANT. This allows for packing of variants into an array, and
-    # subsequent conversion to a multi-dimensional safearray.
-    global VARIANT_dtype
-    try:
-        VARIANT_dtype = _make_variant_dtype()
-    except ValueError:
-        pass
-    global datetime64
-    global com_null_date64
-    # This simplifies dependent modules
-    try:
-        from numpy import datetime64
-    except ImportError:
-        pass
-    else:
+    def _check_ctypeslib_typecodes(self):
+        if not self.enabled:
+            return {}
+        import numpy as np
+        from numpy import ctypeslib
         try:
-            # This does not work on numpy 1.6
-            com_null_date64 = datetime64("1899-12-30T00:00:00", "ns")
-        except TypeError:
-            pass
+            from numpy.ctypeslib import _typecodes
+        except ImportError:
+            from numpy.ctypeslib import as_ctypes_type
+
+            dtypes_to_ctypes = {}
+
+            for tp in set(np.sctypeDict.values()):
+                try:
+                    ctype_for = as_ctypes_type(tp)
+                    dtypes_to_ctypes[np.dtype(tp).str] = ctype_for
+                except NotImplementedError:
+                    continue
+            ctypeslib._typecodes = dtypes_to_ctypes
+        return dtypes_to_ctypes
+
+    def isndarray(self, value):
+        """ Check if a value is an ndarray.
+
+        This cannot succeed if numpy is not available.
+
+        """
+        if not self.enabled:
+            if hasattr(value, "__array_interface__"):
+                raise ValueError(
+                    (
+                        "Argument {0} appears to be a numpy.ndarray, but "
+                        "comtypes numpy support has not been enabled. Please "
+                        "try calling comtypes.npsupport.enable_numpy_interop()"
+                        " before passing ndarrays as parameters."
+                    ).format(value)
+                )
+            return False
+
+        return isinstance(value, self.numpy.ndarray)
+
+    def isdatetime64(self, value):
+        """ Check if a value is a datetime64.
+
+        This cannot succeed if datetime64 is not available.
+
+        """
+        if not self.enabled:
+            return False
+        return isinstance(value, self.datetime64)
+
+    @property
+    def numpy(self):
+        """ The numpy package.
+        """
+        if self.enabled:
+            import numpy
+            return numpy
+        raise ImportError(
+            "In comtypes>=1.2.0 numpy interop must be explicitly enabled with "
+            "comtypes.npsupport.enable_numpy_interop before attempting to use "
+            "numpy features."
+        )
+
+    def enable(self):
+        """ Enables numpy/comtypes interop.
+        """
+        # don't do this twice
+        if self.enabled:
+            return
+        # first we have to be able to import numpy
+        import numpy
+        # if that succeeded we can be enabled
+        self.enabled = True
+        self.VARIANT_dtype = self._make_variant_dtype()
+        self.typecodes = self._check_ctypeslib_typecodes()
+        try:
+            from numpy import datetime64
+            self.datetime64 = datetime64
+        except ImportError:
+            self.datetime64 = None
+        if self.datetime64:
+            try:
+                # This does not work on numpy 1.6
+                self.com_null_date64 = self.datetime64("1899-12-30T00:00:00", "ns")
+            except TypeError:
+                self.com_null_date64 = None
 
 
-def get_numpy():
-    """ Returns the numpy package if numpy interop is enabled, otherwise raises
-    an import error to remind the user they need to manually enable numpy
-    interop
+interop = Interop()
 
-    """
-    if HAVE_NUMPY:
-        return numpy
-    raise ImportError(
-        "In comtypes>=1.2.0 numpy interop must be explicitly enabled with "
-        "comtypes.npsupport.enable_numpy_interop before attempting to use "
-        "numpy features."
-    )
+__all__ = ["interop"]

--- a/comtypes/npsupport.py
+++ b/comtypes/npsupport.py
@@ -61,6 +61,13 @@ def isndarray(value):
 
     """
     if not HAVE_NUMPY:
+        if hasattr(value, "__array_interface__"):
+            raise ValueError(
+                f"Argument {value} appears to be a numpy.ndarray, but "
+                "comtypes numpy support has not been enabled. Please "
+                "try calling comtypes.npsupport.enable_numpy_interop() "
+                "before passing ndarrays as parameters."
+            )
         return False
     numpy = get_numpy()
     return isinstance(value, numpy.ndarray)

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -26,6 +26,8 @@ class _SafeArrayAsNdArrayContextManager(object):
     thread_local = threading.local()
 
     def __enter__(self):
+        if not npsupport.HAVE_NUMPY:
+            npsupport.enable_numpy_interop()
         try:
             self.thread_local.count += 1
         except AttributeError:

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -5,7 +5,6 @@ from ctypes import (POINTER, Structure, byref, cast, c_long, memmove, pointer,
 from comtypes import _safearray, IUnknown, com_interface_registry, npsupport
 from comtypes.patcher import Patch
 
-numpy = npsupport.numpy
 _safearray_type_cache = {}
 
 
@@ -167,7 +166,7 @@ def _make_safearray_type(itemtype):
 
             # SAFEARRAYs have Fortran order; convert the numpy array if needed
             if not value.flags.f_contiguous:
-                value = numpy.array(value, order="F")
+                value = npsupport.get_numpy().array(value, order="F")
 
             # For VT_UNKNOWN or VT_DISPATCH, extra must be a pointer to
             # the GUID of the interface.
@@ -240,15 +239,13 @@ def _make_safearray_type(itemtype):
 
             if dim == 0:
                 if safearray_as_ndarray:
-                    import numpy
-                    return numpy.array()
+                    return npsupport.get_numpy.array()
                 return tuple()
             elif dim == 1:
                 num_elements = self._get_size(1)
                 result = self._get_elements_raw(num_elements)
                 if safearray_as_ndarray:
-                    import numpy
-                    return numpy.asarray(result)
+                    return npsupport.get_numpy().asarray(result)
                 return tuple(result)
             elif dim == 2:
                 # get the number of elements in each dimension
@@ -258,8 +255,7 @@ def _make_safearray_type(itemtype):
                 # this must be reshaped and transposed because it is
                 # flat, and in VB order
                 if safearray_as_ndarray:
-                    import numpy
-                    return numpy.asarray(result).reshape((cols, rows)).T
+                    return npsupport.get_numpy().asarray(result).reshape((cols, rows)).T
                 result = [tuple(result[r::rows]) for r in range(rows)]
                 return tuple(result)
             else:
@@ -270,8 +266,7 @@ def _make_safearray_type(itemtype):
                                for d in range(1, dim+1)]
                 row = self._get_row(0, indexes, lowerbounds, upperbounds)
                 if safearray_as_ndarray:
-                    import numpy
-                    return numpy.asarray(row)
+                    return npsupport.get_numpy.asarray(row)
                 return row
 
         def _get_elements_raw(self, num_elements):
@@ -316,7 +311,7 @@ def _make_safearray_type(itemtype):
                         #     numpy.ctypeslib.
                         if (safearray_as_ndarray and self._itemtype_ in
                                 list(npsupport.typecodes.keys())):
-                            arr = numpy.ctypeslib.as_array(ptr,
+                            arr = npsupport.get_numpy().ctypeslib.as_array(ptr,
                                                            (num_elements,))
                             return arr.copy()
                         return ptr[:num_elements]
@@ -375,6 +370,7 @@ def _ndarray_to_variant_array(value):
     if npsupport.VARIANT_dtype is None:
         msg = "VARIANT ndarrays require NumPy 1.7 or newer."
         raise RuntimeError(msg)
+    numpy = npsupport.get_numpy()
 
     # special cases
     if numpy.issubdtype(value.dtype, npsupport.datetime64):
@@ -394,6 +390,7 @@ def _datetime64_ndarray_to_variant_array(value):
     # since midnight 30 December 1899. Hours and minutes are represented as
     # fractional days.
     from comtypes.automation import VT_DATE
+    numpy = npsupport.get_numpy()
     value = numpy.array(value, "datetime64[ns]")
     value = value - npsupport.com_null_date64
     # Convert to days

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -26,8 +26,7 @@ class _SafeArrayAsNdArrayContextManager(object):
     thread_local = threading.local()
 
     def __enter__(self):
-        if not npsupport.HAVE_NUMPY:
-            npsupport.enable_numpy_interop()
+        npsupport.interop.enable()
         try:
             self.thread_local.count += 1
         except AttributeError:
@@ -114,7 +113,7 @@ def _make_safearray_type(itemtype):
             one-dimensional arrays.  To create multidimensional arrys,
             numpy arrays must be passed.
             """
-            if npsupport.isndarray(value):
+            if npsupport.interop.isndarray(value):
                 return cls.create_from_ndarray(value, extra)
 
             # For VT_UNKNOWN or VT_DISPATCH, extra must be a pointer to
@@ -157,18 +156,18 @@ def _make_safearray_type(itemtype):
             from comtypes.automation import VARIANT
             # If processing VARIANT, makes sure the array type is correct.
             if cls._itemtype_ is VARIANT:
-                if value.dtype != npsupport.VARIANT_dtype:
+                if value.dtype != npsupport.interop.VARIANT_dtype:
                     value = _ndarray_to_variant_array(value)
             else:
                 ai = value.__array_interface__
                 if ai["version"] != 3:
                     raise TypeError("only __array_interface__ version 3 supported")
-                if cls._itemtype_ != npsupport.typecodes[ai["typestr"]]:
+                if cls._itemtype_ != npsupport.interop.typecodes[ai["typestr"]]:
                     raise TypeError("Wrong array item type")
 
             # SAFEARRAYs have Fortran order; convert the numpy array if needed
             if not value.flags.f_contiguous:
-                value = npsupport.get_numpy().array(value, order="F")
+                value = npsupport.interop.numpy.array(value, order="F")
 
             # For VT_UNKNOWN or VT_DISPATCH, extra must be a pointer to
             # the GUID of the interface.
@@ -241,13 +240,13 @@ def _make_safearray_type(itemtype):
 
             if dim == 0:
                 if safearray_as_ndarray:
-                    return npsupport.get_numpy.array()
+                    return npsupport.interop.numpy.array()
                 return tuple()
             elif dim == 1:
                 num_elements = self._get_size(1)
                 result = self._get_elements_raw(num_elements)
                 if safearray_as_ndarray:
-                    return npsupport.get_numpy().asarray(result)
+                    return npsupport.interop.numpy.asarray(result)
                 return tuple(result)
             elif dim == 2:
                 # get the number of elements in each dimension
@@ -257,7 +256,7 @@ def _make_safearray_type(itemtype):
                 # this must be reshaped and transposed because it is
                 # flat, and in VB order
                 if safearray_as_ndarray:
-                    return npsupport.get_numpy().asarray(result).reshape((cols, rows)).T
+                    return npsupport.interop.numpy.asarray(result).reshape((cols, rows)).T
                 result = [tuple(result[r::rows]) for r in range(rows)]
                 return tuple(result)
             else:
@@ -268,7 +267,7 @@ def _make_safearray_type(itemtype):
                                for d in range(1, dim+1)]
                 row = self._get_row(0, indexes, lowerbounds, upperbounds)
                 if safearray_as_ndarray:
-                    return npsupport.get_numpy.asarray(row)
+                    return npsupport.interop.numpy.asarray(row)
                 return row
 
         def _get_elements_raw(self, num_elements):
@@ -312,8 +311,8 @@ def _make_safearray_type(itemtype):
                         # XXX Only try to convert types known to
                         #     numpy.ctypeslib.
                         if (safearray_as_ndarray and self._itemtype_ in
-                                list(npsupport.typecodes.keys())):
-                            arr = npsupport.get_numpy().ctypeslib.as_array(ptr,
+                                list(npsupport.interop.typecodes.keys())):
+                            arr = npsupport.interop.numpy.ctypeslib.as_array(ptr,
                                                            (num_elements,))
                             return arr.copy()
                         return ptr[:num_elements]
@@ -369,18 +368,18 @@ def _make_safearray_type(itemtype):
 def _ndarray_to_variant_array(value):
     """ Convert an ndarray to VARIANT_dtype array """
     # Check that variant arrays are supported
-    if npsupport.VARIANT_dtype is None:
+    if npsupport.interop.VARIANT_dtype is None:
         msg = "VARIANT ndarrays require NumPy 1.7 or newer."
         raise RuntimeError(msg)
-    numpy = npsupport.get_numpy()
+    numpy = npsupport.interop.numpy
 
     # special cases
-    if numpy.issubdtype(value.dtype, npsupport.datetime64):
+    if numpy.issubdtype(value.dtype, npsupport.interop.datetime64):
         return _datetime64_ndarray_to_variant_array(value)
 
     from comtypes.automation import VARIANT
     # Empty array
-    varr = numpy.zeros(value.shape, npsupport.VARIANT_dtype, order='F')
+    varr = numpy.zeros(value.shape, npsupport.interop.VARIANT_dtype, order='F')
     # Convert each value to a variant and put it in the array.
     varr.flat = [VARIANT(v) for v in value.flat]
     return varr
@@ -392,12 +391,12 @@ def _datetime64_ndarray_to_variant_array(value):
     # since midnight 30 December 1899. Hours and minutes are represented as
     # fractional days.
     from comtypes.automation import VT_DATE
-    numpy = npsupport.get_numpy()
+    numpy = npsupport.interop.numpy
     value = numpy.array(value, "datetime64[ns]")
-    value = value - npsupport.com_null_date64
+    value = value - npsupport.interop.com_null_date64
     # Convert to days
     value = value / numpy.timedelta64(1, 'D')
-    varr = numpy.zeros(value.shape, npsupport.VARIANT_dtype, order='F')
+    varr = numpy.zeros(value.shape, npsupport.interop.VARIANT_dtype, order='F')
     varr['vt'] = VT_DATE
     varr['_']['VT_R8'].flat = value.flat
     return varr

--- a/comtypes/test/__init__.py
+++ b/comtypes/test/__init__.py
@@ -13,8 +13,9 @@ use_resources = ["*"]
 def get_numpy():
     '''Get numpy if it is available.'''
     try:
-        import numpy
-        return numpy
+        import comtypes.npsupport
+        comtypes.npsupport.enable_numpy_interop()
+        return comtypes.npsupport.get_numpy()
     except ImportError:
         return None
 

--- a/comtypes/test/__init__.py
+++ b/comtypes/test/__init__.py
@@ -10,14 +10,6 @@ import unittest
 
 use_resources = ["*"]
 
-def get_numpy():
-    '''Get numpy if it is available.'''
-    try:
-        import comtypes.npsupport
-        comtypes.npsupport.enable_numpy_interop()
-        return comtypes.npsupport.get_numpy()
-    except ImportError:
-        return None
 
 def register_server(source_dir):
     """ Register testing server appropriate for the python architecture.

--- a/comtypes/test/test_dict.py
+++ b/comtypes/test/test_dict.py
@@ -7,10 +7,6 @@ from comtypes.client import CreateObject
 from comtypes.client.lazybind import Dispatch
 
 
-def setUpModule():
-    raise unittest.SkipTest("Depends on `comtypes.safearray` which depends on numpy which isn't "
-                            "listed in project dependencies.")
-
 class Test(unittest.TestCase):
     def test_dict(self):
         d = CreateObject("Scripting.Dictionary", dynamic=True)

--- a/comtypes/test/test_npsupport.py
+++ b/comtypes/test/test_npsupport.py
@@ -1,19 +1,314 @@
-import sys
+import datetime
+import importlib
 import unittest
+from ctypes import c_long, c_double, pointer, POINTER
+from decimal import Decimal
+
+import comtypes.npsupport
+from comtypes import IUnknown
+from comtypes._safearray import SafeArrayGetVartype
+from comtypes.automation import (
+    BSTR,
+    VT_BSTR,
+    VT_DATE,
+    VT_I4,
+    _midlSAFEARRAY,
+    VARIANT,
+    VT_VARIANT,
+    VARIANT_BOOL
+)
+from comtypes.safearray import safearray_as_ndarray
+
+numpy = None
+
+
+def setUpModule():
+    """Only run the module if we can import numpy."""
+
+    try:
+        global numpy
+        import numpy
+    except ImportError:
+        raise unittest.SkipTest("Skipping test_npsupport as numpy not installed.")
+
+
+def get_ndarray(sa):
+    """Get an array from a safe array type"""
+    with safearray_as_ndarray:
+        return sa[0]
+
+
+def com_refcnt(o):
+    """Return the COM refcount of an interface pointer"""
+    import gc
+    gc.collect()
+    gc.collect()
+    o.AddRef()
+    return o.Release()
 
 
 class NumpySupportTestCase(unittest.TestCase):
-    def test_not_imported_imported(self):
-        self.assertFalse("numpy" in sys.modules)
+    def setUp(self) -> None:
+        # we reload the module in between tests to disable the previously
+        # enabled interop functionality
+        importlib.reload(comtypes.npsupport)
 
-        import comtypes.npsupport
-        self.assertFalse("numpy" in sys.modules)
+    def test_not_imported_imported(self):
         self.assertRaises(ImportError, comtypes.npsupport.get_numpy)
         comtypes.npsupport.enable_numpy_interop()
-        self.assertTrue("numpy" in sys.modules)
         import numpy
         self.assertEqual(numpy, comtypes.npsupport.get_numpy())
 
+    def test_nested_contexts(self):
+        t = _midlSAFEARRAY(BSTR)
+        sa = t.from_param(["a", "b", "c"])
 
-if __name__ == '__main__':
+        first = sa[0]
+        with safearray_as_ndarray:
+            second = sa[0]
+            with safearray_as_ndarray:
+                third = sa[0]
+            fourth = sa[0]
+        fifth = sa[0]
+
+        self.assertTrue(isinstance(first, tuple))
+        self.assertTrue(isinstance(second, numpy.ndarray))
+        self.assertTrue(isinstance(third, numpy.ndarray))
+        self.assertTrue(isinstance(fourth, numpy.ndarray))
+        self.assertTrue(isinstance(fifth, tuple))
+
+    @unittest.skipUnless(
+        hasattr(numpy, "datetime64"),
+        "Skipping because this version of numpy does not support datetime64"
+    )
+    def test_datetime64_ndarray(self):
+        comtypes.npsupport.enable_numpy_interop()
+        dates = numpy.array([
+            numpy.datetime64("2000-01-01T05:30:00", "s"),
+            numpy.datetime64("1800-01-01T05:30:00", "ms"),
+            numpy.datetime64("2014-03-07T00:12:56", "us"),
+            numpy.datetime64("2000-01-01T12:34:56", "ns"),
+        ])
+
+        t = _midlSAFEARRAY(VARIANT)
+        sa = t.from_param(dates)
+        arr = get_ndarray(sa).astype(dates.dtype)
+        self.assertTrue((dates == arr).all())
+
+    @unittest.skip(
+        "This fails with a 'library not registered' error.  Need to figure "
+        "out how to register TestComServerLib (without admin if possible)."
+    )
+    def test_UDT_ndarray(self):
+        from comtypes.gen.TestComServerLib import MYCOLOR
+
+        t = _midlSAFEARRAY(MYCOLOR)
+        self.assertTrue(t is _midlSAFEARRAY(MYCOLOR))
+
+        sa = t.from_param([MYCOLOR(0, 0, 0), MYCOLOR(1, 2, 3)])
+        arr = get_ndarray(sa)
+
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        # The conversion code allows numpy to choose the dtype of
+        # structured data.  This dtype is structured under numpy 1.5, 1.7 and
+        # 1.8, and object in 1.6. Instead of assuming either of these, check
+        # the array contents based on the chosen type.
+        if arr.dtype is numpy.dtype(object):
+            data = [(x.red, x.green, x.blue) for x in arr]
+        else:
+            float_dtype = numpy.dtype('float64')
+            self.assertIs(arr.dtype[0], float_dtype)
+            self.assertIs(arr.dtype[1], float_dtype)
+            self.assertIs(arr.dtype[2], float_dtype)
+            data = [tuple(x) for x in arr]
+        self.assertEqual(data, [(0.0, 0.0, 0.0), (1.0, 2.0, 3.0)])
+
+    def test_VT_BOOL_ndarray(self):
+        t = _midlSAFEARRAY(VARIANT_BOOL)
+
+        sa = t.from_param([True, False, True, False])
+        arr = get_ndarray(sa)
+        self.assertEqual(numpy.dtype(numpy.bool_), arr.dtype)
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertTrue((arr == (True, False, True, False)).all())
+
+    def test_VT_BSTR_ndarray(self):
+        t = _midlSAFEARRAY(BSTR)
+
+        sa = t.from_param(["a", "b", "c"])
+        arr = get_ndarray(sa)
+
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertEqual(numpy.dtype("<U1"), arr.dtype)
+        self.assertTrue((arr == ("a", "b", "c")).all())
+        self.assertEqual(SafeArrayGetVartype(sa), VT_BSTR)
+
+    def test_VT_I4_ndarray(self):
+        comtypes.npsupport.enable_numpy_interop()
+        t = _midlSAFEARRAY(c_long)
+
+        in_arr = numpy.array([11, 22, 33])
+        sa = t.from_param(in_arr)
+
+        arr = get_ndarray(sa)
+
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertEqual(numpy.dtype(int), arr.dtype)
+        self.assertTrue((arr == in_arr).all())
+        self.assertEqual(SafeArrayGetVartype(sa), VT_I4)
+
+    def test_array(self):
+        comtypes.npsupport.enable_numpy_interop()
+        t = _midlSAFEARRAY(c_double)
+        pat = pointer(t())
+
+        pat[0] = numpy.zeros(32, dtype=float)
+        arr = get_ndarray(pat[0])
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertEqual(numpy.dtype(float), arr.dtype)
+        self.assertTrue((arr == (0.0,) * 32).all())
+
+        data = ((1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0))
+        a = numpy.array(data, dtype=float)
+        pat[0] = a
+        arr = get_ndarray(pat[0])
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertEqual(numpy.dtype(float), arr.dtype)
+        self.assertTrue((arr == data).all())
+
+        data = ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+        a = numpy.array(data, dtype=float, order="F")
+        pat[0] = a
+        arr = get_ndarray(pat[0])
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertEqual(numpy.dtype(float), arr.dtype)
+        self.assertEqual(pat[0][0], data)
+
+    @unittest.skip(
+        "Skipping because creating an ndarray from ctypes pointer to c_void_p "
+        "is not currently supported."
+    )
+    def test_VT_UNKNOWN_multi_ndarray(self):
+        a = _midlSAFEARRAY(POINTER(IUnknown))
+        t = _midlSAFEARRAY(POINTER(IUnknown))
+        self.assertTrue(a is t)
+
+        from comtypes.typeinfo import CreateTypeLib
+        # will never be saved to disk
+        punk = CreateTypeLib("spam").QueryInterface(IUnknown)
+
+        # initial refcount
+        initial = com_refcnt(punk)
+
+        # This should increase the refcount by 4
+        sa = t.from_param((punk,) * 4)
+        self.assertEqual(initial + 4, com_refcnt(punk))
+
+        # Unpacking the array must not change the refcount, and must
+        # return an equal object. Creating an ndarray may change the
+        # refcount.
+        arr = get_ndarray(sa)
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertEqual(numpy.dtype(object), arr.dtype)
+        self.assertTrue((arr == (punk,)*4).all())
+        self.assertEqual(initial + 8, com_refcnt(punk))
+
+        del arr
+        self.assertEqual(initial + 4, com_refcnt(punk))
+
+        del sa
+        self.assertEqual(initial, com_refcnt(punk))
+
+        # This should increase the refcount by 2
+        sa = t.from_param((punk, None, punk, None))
+        self.assertEqual(initial + 2, com_refcnt(punk))
+
+        null = POINTER(IUnknown)()
+        arr = get_ndarray(sa)
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertEqual(numpy.dtype(object), arr.dtype)
+        self.assertTrue((arr == (punk, null, punk, null)).all())
+
+        del sa
+        del arr
+        self.assertEqual(initial, com_refcnt(punk))
+
+    @unittest.skip(
+        "Skipping because numpy cannot currently create an array of variants "
+        "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
+    )
+    def test_VT_VARIANT_ndarray(self):
+        comtypes.npsupport.enable_numpy_interop()
+        t = _midlSAFEARRAY(VARIANT)
+
+        now = datetime.datetime.now()
+        inarr = numpy.array(
+            [11, "22", "33", 44.0, None, True, now, Decimal("3.14")]
+        ).reshape(2, 4)
+        sa = t.from_param(inarr)
+        arr = get_ndarray(sa)
+        self.assertEqual(numpy.dtype(object), arr.dtype)
+        self.assertTrue(isinstance(arr, numpy.ndarray))
+        self.assertTrue((arr == inarr).all())
+        self.assertEqual(SafeArrayGetVartype(sa), VT_VARIANT)
+
+
+class NumpyVariantTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # we reload the module in between tests to disable the previously
+        # enabled interop functionality
+        importlib.reload(comtypes.npsupport)
+
+    def test_double(self):
+        comtypes.npsupport.enable_numpy_interop()
+        for dtype in ('float32', 'float64'):
+            # because of FLOAT rounding errors, whi will only work for
+            # certain values!
+            a = numpy.array([1.0, 2.0, 3.0, 4.5], dtype=dtype)
+            v = VARIANT()
+            v.value = a
+            self.assertTrue((v.value == a).all())
+
+    def test_int(self):
+        comtypes.npsupport.enable_numpy_interop()
+        for dtype in ('int8', 'int16', 'int32', 'int64', 'uint8',
+                'uint16', 'uint32', 'uint64'):
+            a = numpy.array((1, 1, 1, 1), dtype=dtype)
+            v = VARIANT()
+            v.value = a
+            self.assertTrue((v.value == a).all())
+
+    @unittest.skipUnless(
+        hasattr(numpy, "datetime64"),
+        "Skipping because this version of numpy does not support datetime64"
+    )
+    def test_datetime64(self):
+        comtypes.npsupport.enable_numpy_interop()
+        dates = [
+            numpy.datetime64("2000-01-01T05:30:00", "s"),
+            numpy.datetime64("1800-01-01T05:30:00", "ms"),
+            numpy.datetime64("2000-01-01T12:34:56", "us")
+        ]
+
+        for date in dates:
+            v = VARIANT()
+            v.value = date
+            self.assertEqual(v.vt, VT_DATE)
+            self.assertEqual(v.value, date.astype(datetime.datetime))
+
+    @unittest.skip(
+        "Skipping because numpy cannot currently create an array of variants "
+        "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
+    )
+    def test_mixed(self):
+        comtypes.npsupport.enable_numpy_interop()
+        now = datetime.datetime.now()
+        a = numpy.array(
+            [11, "22", None, True, now, Decimal("3.14")]).reshape(2, 3)
+        v = VARIANT()
+        v.value = a
+        self.assertTrue((v.value == a).all())
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_npsupport.py
+++ b/comtypes/test/test_npsupport.py
@@ -54,10 +54,11 @@ class NumpySupportTestCase(unittest.TestCase):
         importlib.reload(comtypes.npsupport)
 
     def test_not_imported_imported(self):
-        self.assertRaises(ImportError, comtypes.npsupport.get_numpy)
-        comtypes.npsupport.enable_numpy_interop()
+        with self.assertRaises(ImportError):
+            a = comtypes.npsupport.interop.numpy
+        comtypes.npsupport.interop.enable()
         import numpy
-        self.assertEqual(numpy, comtypes.npsupport.get_numpy())
+        self.assertEqual(numpy, comtypes.npsupport.interop.numpy)
 
     def test_nested_contexts(self):
         t = _midlSAFEARRAY(BSTR)
@@ -82,7 +83,7 @@ class NumpySupportTestCase(unittest.TestCase):
         "Skipping because this version of numpy does not support datetime64"
     )
     def test_datetime64_ndarray(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         dates = numpy.array([
             numpy.datetime64("2000-01-01T05:30:00", "s"),
             numpy.datetime64("1800-01-01T05:30:00", "ms"),
@@ -144,7 +145,7 @@ class NumpySupportTestCase(unittest.TestCase):
         self.assertEqual(SafeArrayGetVartype(sa), VT_BSTR)
 
     def test_VT_I4_ndarray(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         t = _midlSAFEARRAY(c_long)
 
         in_arr = numpy.array([11, 22, 33])
@@ -158,7 +159,7 @@ class NumpySupportTestCase(unittest.TestCase):
         self.assertEqual(SafeArrayGetVartype(sa), VT_I4)
 
     def test_array(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         t = _midlSAFEARRAY(c_double)
         pat = pointer(t())
 
@@ -238,7 +239,7 @@ class NumpySupportTestCase(unittest.TestCase):
         "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
     )
     def test_VT_VARIANT_ndarray(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         t = _midlSAFEARRAY(VARIANT)
 
         now = datetime.datetime.now()
@@ -260,7 +261,7 @@ class NumpyVariantTest(unittest.TestCase):
         importlib.reload(comtypes.npsupport)
 
     def test_double(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         for dtype in ('float32', 'float64'):
             # because of FLOAT rounding errors, whi will only work for
             # certain values!
@@ -270,7 +271,7 @@ class NumpyVariantTest(unittest.TestCase):
             self.assertTrue((v.value == a).all())
 
     def test_int(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         for dtype in ('int8', 'int16', 'int32', 'int64', 'uint8',
                 'uint16', 'uint32', 'uint64'):
             a = numpy.array((1, 1, 1, 1), dtype=dtype)
@@ -283,7 +284,7 @@ class NumpyVariantTest(unittest.TestCase):
         "Skipping because this version of numpy does not support datetime64"
     )
     def test_datetime64(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         dates = [
             numpy.datetime64("2000-01-01T05:30:00", "s"),
             numpy.datetime64("1800-01-01T05:30:00", "ms"),
@@ -301,7 +302,7 @@ class NumpyVariantTest(unittest.TestCase):
         "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
     )
     def test_mixed(self):
-        comtypes.npsupport.enable_numpy_interop()
+        comtypes.npsupport.interop.enable()
         now = datetime.datetime.now()
         a = numpy.array(
             [11, "22", None, True, now, Decimal("3.14")]).reshape(2, 3)

--- a/comtypes/test/test_npsupport.py
+++ b/comtypes/test/test_npsupport.py
@@ -1,0 +1,19 @@
+import sys
+import unittest
+
+
+class NumpySupportTestCase(unittest.TestCase):
+    def test_not_imported_imported(self):
+        self.assertFalse("numpy" in sys.modules)
+
+        import comtypes.npsupport
+        self.assertFalse("numpy" in sys.modules)
+        self.assertRaises(ImportError, comtypes.npsupport.get_numpy)
+        comtypes.npsupport.enable_numpy_interop()
+        self.assertTrue("numpy" in sys.modules)
+        import numpy
+        self.assertEqual(numpy, comtypes.npsupport.get_numpy())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/comtypes/test/test_npsupport.py
+++ b/comtypes/test/test_npsupport.py
@@ -48,7 +48,7 @@ def com_refcnt(o):
 
 
 class NumpySupportTestCase(unittest.TestCase):
-    def setUp(self) -> None:
+    def setUp(self):
         # we reload the module in between tests to disable the previously
         # enabled interop functionality
         importlib.reload(comtypes.npsupport)
@@ -254,7 +254,7 @@ class NumpySupportTestCase(unittest.TestCase):
 
 
 class NumpyVariantTest(unittest.TestCase):
-    def setUp(self) -> None:
+    def setUp(self):
         # we reload the module in between tests to disable the previously
         # enabled interop functionality
         importlib.reload(comtypes.npsupport)

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -14,7 +14,6 @@ from comtypes.automation import (
     DISPPARAMS, VARIANT, VT_BSTR, VT_BYREF, VT_CY, VT_DATE, VT_DECIMAL, VT_EMPTY, VT_ERROR, VT_I1,
     VT_I2, VT_I4, VT_I8, VT_NULL, VT_R4, VT_R8, VT_UI1, VT_UI2, VT_UI4, VT_UI8,
 )
-from comtypes.test import get_numpy
 from comtypes.test.find_memleak import find_memleak
 from comtypes.typeinfo import LoadRegTypeLib
 
@@ -124,27 +123,6 @@ class VariantTestCase(unittest.TestCase):
         self.assertEqual(v.vt, VT_DATE)
         self.assertEqual(v.value, now)
 
-    def test_datetime64(self):
-        np = get_numpy()
-        if np is None:
-            return
-        try:
-            np.datetime64
-        except AttributeError:
-            return
-
-        dates = [
-            np.datetime64("2000-01-01T05:30:00", "s"),
-            np.datetime64("1800-01-01T05:30:00", "ms"),
-            np.datetime64("2000-01-01T12:34:56", "us")
-        ]
-
-        for date in dates:
-            v = VARIANT()
-            v.value = date
-            self.assertEqual(v.vt, VT_DATE)
-            self.assertEqual(v.value, date.astype(datetime.datetime))
-
     def test_decimal_as_currency(self):
         value = decimal.Decimal('3.14')
 
@@ -239,44 +217,6 @@ class VariantTestCase(unittest.TestCase):
         self.assertEqual(v[0], 96)
 
 
-class NdArrayTest(unittest.TestCase):
-    def test_double(self):
-        np = get_numpy()
-        if np is None:
-            return
-        for dtype in ('float32', 'float64'):
-            # because of FLOAT rounding errors, whi will only work for
-            # certain values!
-            a = np.array([1.0, 2.0, 3.0, 4.5], dtype=dtype)
-            v = VARIANT()
-            v.value = a
-            self.assertTrue((v.value == a).all())
-
-    def test_int(self):
-        np = get_numpy()
-        if np is None:
-            return
-        for dtype in ('int8', 'int16', 'int32', 'int64', 'uint8',
-                'uint16', 'uint32', 'uint64'):
-            a = np.array((1, 1, 1, 1), dtype=dtype)
-            v = VARIANT()
-            v.value = a
-            self.assertTrue((v.value == a).all())
-
-    def test_mixed(self):
-        np = get_numpy()
-        if np is None:
-            return
-
-        now = datetime.datetime.now()
-        a = np.array(
-            [11, "22", None, True, now, decimal.Decimal("3.14")]).reshape(2,3)
-        v = VARIANT()
-        v.value = a
-        self.assertTrue((v.value == a).all())
-
-@unittest.skip("This depends on comtypes.safearray which depends on numpy, which is not in "
-               "the project dependencies.")
 class ArrayTest(unittest.TestCase):
     def test_double(self):
         import array


### PR DESCRIPTION
This PR addresses issue #333, "Delayed loading of npsupport". It does not attempt to load numpy as a library at import time, but only when explicitly requested via the new function `comtypes.npsupport.enable_numpy_interop()` (or by entering the existing context manager `safearray_as_ndarray`). This allows users to control whether (and when) numpy is imported, even if it is installed in their environment.

The current version passes all the previous tests, and has gained one checking that trying to access numpy via npsupport fails until `enable_numpy_interop()` has been called, but probably some further tests are appropriate to test that the right errors are raised at the right times when the function has not been called, so that any users who will be affected by this change get the most helpful error messages. However, best practice testing of this feature may require upgrading of the test environment to allow testing different python envs with and without numpy. There is also the possibility that all numpy interop could be replaced with the PEP3118 Buffer Protocol, removing all numpy related code from comtypes.