### PR TITLE
Fix cross imports part1

### DIFF
--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -730,36 +730,4 @@ def _py2exe_hint():
     import comtypes.typeinfo
     import comtypes.automation
 
-def generate_module(tlib, ofi, pathname):
-    known_symbols = {}
-    for name in ("comtypes.persist",
-                 "comtypes.typeinfo",
-                 "comtypes.automation",
-                 "comtypes._others",
-                 "comtypes",
-                 "ctypes.wintypes",
-                 "ctypes"):
-        try:
-            mod = __import__(name)
-        except ImportError:
-            if name == "comtypes._others":
-                continue
-            raise
-        for submodule in name.split(".")[1:]:
-            mod = getattr(mod, submodule)
-        for name in mod.__dict__:
-            known_symbols[name] = mod.__name__
-    p = TypeLibParser(tlib)
-    if pathname is None:
-        pathname = get_tlib_filename(tlib)
-    items = p.parse()
-
-    from .codegenerator import Generator
-
-    gen = Generator(ofi,
-                    known_symbols=known_symbols,
-                    )
-
-    gen.generate_code(list(items.values()), filename=pathname)
-
 # -eof-


### PR DESCRIPTION
see #329 and https://github.com/enthought/comtypes/issues/329#issuecomment-1191571085

I moved and redefine some functions for fixing cross imports.

- `tools.tlbparser.generate_module` -> `client._generate.generate_module`
- `client._generate._name_module` -> `tools.codegenerator.name_wrapper_module`
- trying `modulename = tlib.GetDocumentation(-1)[0]`  in `client._generate` -> `tools.codegenerator.name_friendly_module`

## Next action (plan)
After this PR is merged, I will remove calling `GetModule` from `tools.codegenerator.Generator.External`.
see https://github.com/enthought/comtypes/issues/329#issuecomment-1191557095