### PR TITLE
333 optin numpy v2

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -27,6 +27,7 @@ logger.addHandler(NullHandler())
 from ctypes import *
 from _ctypes import COMError
 from comtypes import patcher
+from comtypes._npsupport import interop as npsupport
 
 def _check_version(actual, tlib_cached_mtime=None):
     from comtypes.tools.codegenerator import version as required

--- a/comtypes/_npsupport.py
+++ b/comtypes/_npsupport.py
@@ -78,7 +78,7 @@ class Interop:
                 except NotImplementedError:
                     continue
             ctypeslib._typecodes = dtypes_to_ctypes
-        return dtypes_to_ctypes
+        return ctypeslib._typecodes
 
     def isndarray(self, value):
         """ Check if a value is an ndarray.
@@ -108,7 +108,7 @@ class Interop:
         """
         if not self.enabled:
             return False
-        return isinstance(value, self.datetime64)
+        return isinstance(value, self.numpy.datetime64)
 
     @property
     def numpy(self):
@@ -135,17 +135,7 @@ class Interop:
         self.enabled = True
         self.VARIANT_dtype = self._make_variant_dtype()
         self.typecodes = self._check_ctypeslib_typecodes()
-        try:
-            from numpy import datetime64
-            self.datetime64 = datetime64
-        except ImportError:
-            self.datetime64 = None
-        if self.datetime64:
-            try:
-                # This does not work on numpy 1.6
-                self.com_null_date64 = self.datetime64("1899-12-30T00:00:00", "ns")
-            except TypeError:
-                self.com_null_date64 = None
+        self.com_null_date64 = self.numpy.datetime64("1899-12-30T00:00:00", "ns")
 
 
 interop = Interop()

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -10,7 +10,7 @@ from _ctypes import CopyComPointer
 from comtypes import IUnknown, GUID, IID, STDMETHOD, BSTR, COMMETHOD, COMError
 from comtypes.hresult import *
 import comtypes.patcher
-from comtypes import npsupport
+import comtypes
 try:
     from comtypes import _safearray
 except (ImportError, AttributeError):
@@ -284,9 +284,9 @@ class tagVARIANT(Structure):
             com_days = delta.days + (delta.seconds + delta.microseconds * 1e-6) / 86400.
             self.vt = VT_DATE
             self._.VT_R8 = com_days
-        elif npsupport.interop.isdatetime64(value):
-            com_days = value - npsupport.com_null_date64
-            com_days /= npsupport.interop.numpy.timedelta64(1, 'D')
+        elif comtypes.npsupport.isdatetime64(value):
+            com_days = value - comtypes.npsupport.com_null_date64
+            com_days /= comtypes.npsupport.numpy.timedelta64(1, 'D')
             self.vt = VT_DATE
             self._.VT_R8 = com_days
         elif decimal is not None and isinstance(value, decimal.Decimal):
@@ -308,10 +308,10 @@ class tagVARIANT(Structure):
             obj = _midlSAFEARRAY(typ).create(value)
             memmove(byref(self._), byref(obj), sizeof(obj))
             self.vt = VT_ARRAY | obj._vartype_
-        elif npsupport.interop.isndarray(value):
+        elif comtypes.npsupport.isndarray(value):
             # Try to convert a simple array of basic types.
             descr = value.dtype.descr[0][1]
-            typ = npsupport.interop.typecodes.get(descr)
+            typ = comtypes.npsupport.typecodes.get(descr)
             if typ is None:
                 # Try for variant
                 obj = _midlSAFEARRAY(VARIANT).create(value)

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -1,8 +1,9 @@
 import threading
 import array
+import comtypes
 from ctypes import (POINTER, Structure, byref, cast, c_long, memmove, pointer,
                     sizeof)
-from comtypes import _safearray, IUnknown, com_interface_registry, npsupport
+from comtypes import _safearray, IUnknown, com_interface_registry
 from comtypes.patcher import Patch
 
 _safearray_type_cache = {}
@@ -26,7 +27,7 @@ class _SafeArrayAsNdArrayContextManager(object):
     thread_local = threading.local()
 
     def __enter__(self):
-        npsupport.interop.enable()
+        comtypes.npsupport.enable()
         try:
             self.thread_local.count += 1
         except AttributeError:
@@ -113,7 +114,7 @@ def _make_safearray_type(itemtype):
             one-dimensional arrays.  To create multidimensional arrys,
             numpy arrays must be passed.
             """
-            if npsupport.interop.isndarray(value):
+            if comtypes.npsupport.isndarray(value):
                 return cls.create_from_ndarray(value, extra)
 
             # For VT_UNKNOWN or VT_DISPATCH, extra must be a pointer to
@@ -156,18 +157,18 @@ def _make_safearray_type(itemtype):
             from comtypes.automation import VARIANT
             # If processing VARIANT, makes sure the array type is correct.
             if cls._itemtype_ is VARIANT:
-                if value.dtype != npsupport.interop.VARIANT_dtype:
+                if value.dtype != comtypes.npsupport.VARIANT_dtype:
                     value = _ndarray_to_variant_array(value)
             else:
                 ai = value.__array_interface__
                 if ai["version"] != 3:
                     raise TypeError("only __array_interface__ version 3 supported")
-                if cls._itemtype_ != npsupport.interop.typecodes[ai["typestr"]]:
+                if cls._itemtype_ != comtypes.npsupport.typecodes[ai["typestr"]]:
                     raise TypeError("Wrong array item type")
 
             # SAFEARRAYs have Fortran order; convert the numpy array if needed
             if not value.flags.f_contiguous:
-                value = npsupport.interop.numpy.array(value, order="F")
+                value = comtypes.npsupport.numpy.array(value, order="F")
 
             # For VT_UNKNOWN or VT_DISPATCH, extra must be a pointer to
             # the GUID of the interface.
@@ -240,13 +241,13 @@ def _make_safearray_type(itemtype):
 
             if dim == 0:
                 if safearray_as_ndarray:
-                    return npsupport.interop.numpy.array()
+                    return comtypes.npsupport.numpy.array()
                 return tuple()
             elif dim == 1:
                 num_elements = self._get_size(1)
                 result = self._get_elements_raw(num_elements)
                 if safearray_as_ndarray:
-                    return npsupport.interop.numpy.asarray(result)
+                    return comtypes.npsupport.numpy.asarray(result)
                 return tuple(result)
             elif dim == 2:
                 # get the number of elements in each dimension
@@ -256,7 +257,7 @@ def _make_safearray_type(itemtype):
                 # this must be reshaped and transposed because it is
                 # flat, and in VB order
                 if safearray_as_ndarray:
-                    return npsupport.interop.numpy.asarray(result).reshape((cols, rows)).T
+                    return comtypes.npsupport.numpy.asarray(result).reshape((cols, rows)).T
                 result = [tuple(result[r::rows]) for r in range(rows)]
                 return tuple(result)
             else:
@@ -267,7 +268,7 @@ def _make_safearray_type(itemtype):
                                for d in range(1, dim+1)]
                 row = self._get_row(0, indexes, lowerbounds, upperbounds)
                 if safearray_as_ndarray:
-                    return npsupport.interop.numpy.asarray(row)
+                    return comtypes.npsupport.numpy.asarray(row)
                 return row
 
         def _get_elements_raw(self, num_elements):
@@ -311,8 +312,8 @@ def _make_safearray_type(itemtype):
                         # XXX Only try to convert types known to
                         #     numpy.ctypeslib.
                         if (safearray_as_ndarray and self._itemtype_ in
-                                list(npsupport.interop.typecodes.keys())):
-                            arr = npsupport.interop.numpy.ctypeslib.as_array(ptr,
+                                list(comtypes.npsupport.typecodes.keys())):
+                            arr = comtypes.npsupport.numpy.ctypeslib.as_array(ptr,
                                                            (num_elements,))
                             return arr.copy()
                         return ptr[:num_elements]
@@ -368,18 +369,20 @@ def _make_safearray_type(itemtype):
 def _ndarray_to_variant_array(value):
     """ Convert an ndarray to VARIANT_dtype array """
     # Check that variant arrays are supported
-    if npsupport.interop.VARIANT_dtype is None:
+    if comtypes.npsupport.interop.VARIANT_dtype is None:
         msg = "VARIANT ndarrays require NumPy 1.7 or newer."
         raise RuntimeError(msg)
-    numpy = npsupport.interop.numpy
+    numpy = comtypes.npsupport.interop.numpy
 
     # special cases
-    if numpy.issubdtype(value.dtype, npsupport.interop.datetime64):
+    if numpy.issubdtype(value.dtype, comtypes.npsupport.interop.datetime64):
         return _datetime64_ndarray_to_variant_array(value)
 
     from comtypes.automation import VARIANT
     # Empty array
-    varr = numpy.zeros(value.shape, npsupport.interop.VARIANT_dtype, order='F')
+    varr = numpy.zeros(
+        value.shape, comtypes.npsupport.interop.VARIANT_dtype, order='F'
+    )
     # Convert each value to a variant and put it in the array.
     varr.flat = [VARIANT(v) for v in value.flat]
     return varr
@@ -391,12 +394,12 @@ def _datetime64_ndarray_to_variant_array(value):
     # since midnight 30 December 1899. Hours and minutes are represented as
     # fractional days.
     from comtypes.automation import VT_DATE
-    numpy = npsupport.interop.numpy
+    numpy = comtypes.npsupport.interop.numpy
     value = numpy.array(value, "datetime64[ns]")
-    value = value - npsupport.interop.com_null_date64
+    value = value - comtypes.npsupport.interop.com_null_date64
     # Convert to days
     value = value / numpy.timedelta64(1, 'D')
-    varr = numpy.zeros(value.shape, npsupport.interop.VARIANT_dtype, order='F')
+    varr = numpy.zeros(value.shape, comtypes.npsupport.interop.VARIANT_dtype, order='F')
     varr['vt'] = VT_DATE
     varr['_']['VT_R8'].flat = value.flat
     return varr

--- a/comtypes/test/test_npsupport.py
+++ b/comtypes/test/test_npsupport.py
@@ -1,10 +1,12 @@
 import datetime
+import functools
 import importlib
+import inspect
 import unittest
 from ctypes import c_long, c_double, pointer, POINTER
 from decimal import Decimal
 
-import comtypes.npsupport
+import comtypes._npsupport
 from comtypes import IUnknown
 from comtypes._safearray import SafeArrayGetVartype
 from comtypes.automation import (
@@ -19,16 +21,15 @@ from comtypes.automation import (
 )
 from comtypes.safearray import safearray_as_ndarray
 
-numpy = None
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 
 def setUpModule():
     """Only run the module if we can import numpy."""
-
-    try:
-        global numpy
-        import numpy
-    except ImportError:
+    if numpy is None:
         raise unittest.SkipTest("Skipping test_npsupport as numpy not installed.")
 
 
@@ -47,18 +48,48 @@ def com_refcnt(o):
     return o.Release()
 
 
+def enabled_disabled(disabled_error):
+    """Decorator for testing which will replace the original test method with
+    two new methods in the same local frame, one will be called where npsupport
+    is enabled, the other where it is disabled. For the disabled version, it is
+    expected that disabled_error will be raised by the function.
+    """
+    frame_locals = inspect.currentframe().f_back.f_locals
+
+    def decorator_enabled_disabled(func):
+        @functools.wraps(func)
+        def call_enabled(self):
+            from comtypes import npsupport
+            npsupport.enable()
+            func(self)
+
+        @functools.wraps(func)
+        def call_disabled(self):
+            from comtypes import npsupport
+            if npsupport.enabled:
+                raise EnvironmentError(
+                    "Expected numpy interop not to be enabled but it is."
+                )
+            with self.assertRaises(disabled_error):
+                func(self)
+
+        frame_locals[func.__name__ + "_enabled"] = call_enabled
+        frame_locals[func.__name__ + "_disabled"] = call_disabled
+
+    return decorator_enabled_disabled
+
+
 class NumpySupportTestCase(unittest.TestCase):
     def setUp(self):
         # we reload the module in between tests to disable the previously
         # enabled interop functionality
-        importlib.reload(comtypes.npsupport)
+        importlib.reload(comtypes._npsupport)
+        comtypes.npsupport = comtypes._npsupport.interop
 
+    @enabled_disabled(disabled_error=ImportError)
     def test_not_imported_imported(self):
-        with self.assertRaises(ImportError):
-            a = comtypes.npsupport.interop.numpy
-        comtypes.npsupport.interop.enable()
-        import numpy
-        self.assertEqual(numpy, comtypes.npsupport.interop.numpy)
+        np = comtypes.npsupport.numpy
+        self.assertEqual(np, numpy)
 
     def test_nested_contexts(self):
         t = _midlSAFEARRAY(BSTR)
@@ -78,12 +109,12 @@ class NumpySupportTestCase(unittest.TestCase):
         self.assertTrue(isinstance(fourth, numpy.ndarray))
         self.assertTrue(isinstance(fifth, tuple))
 
-    @unittest.skipUnless(
-        hasattr(numpy, "datetime64"),
-        "Skipping because this version of numpy does not support datetime64"
+    @unittest.skip(
+        "Skipping because numpy cannot currently create an array of variants "
+        "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
     )
     def test_datetime64_ndarray(self):
-        comtypes.npsupport.interop.enable()
+        comtypes.npsupport.enable()
         dates = numpy.array([
             numpy.datetime64("2000-01-01T05:30:00", "s"),
             numpy.datetime64("1800-01-01T05:30:00", "ms"),
@@ -144,8 +175,8 @@ class NumpySupportTestCase(unittest.TestCase):
         self.assertTrue((arr == ("a", "b", "c")).all())
         self.assertEqual(SafeArrayGetVartype(sa), VT_BSTR)
 
+    @enabled_disabled(disabled_error=ValueError)
     def test_VT_I4_ndarray(self):
-        comtypes.npsupport.interop.enable()
         t = _midlSAFEARRAY(c_long)
 
         in_arr = numpy.array([11, 22, 33])
@@ -158,8 +189,8 @@ class NumpySupportTestCase(unittest.TestCase):
         self.assertTrue((arr == in_arr).all())
         self.assertEqual(SafeArrayGetVartype(sa), VT_I4)
 
+    @enabled_disabled(disabled_error=ValueError)
     def test_array(self):
-        comtypes.npsupport.interop.enable()
         t = _midlSAFEARRAY(c_double)
         pat = pointer(t())
 
@@ -239,7 +270,7 @@ class NumpySupportTestCase(unittest.TestCase):
         "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
     )
     def test_VT_VARIANT_ndarray(self):
-        comtypes.npsupport.interop.enable()
+        comtypes.npsupport.enable()
         t = _midlSAFEARRAY(VARIANT)
 
         now = datetime.datetime.now()
@@ -258,10 +289,11 @@ class NumpyVariantTest(unittest.TestCase):
     def setUp(self):
         # we reload the module in between tests to disable the previously
         # enabled interop functionality
-        importlib.reload(comtypes.npsupport)
+        importlib.reload(comtypes._npsupport)
+        comtypes.npsupport = comtypes._npsupport.interop
 
+    @enabled_disabled(disabled_error=ValueError)
     def test_double(self):
-        comtypes.npsupport.interop.enable()
         for dtype in ('float32', 'float64'):
             # because of FLOAT rounding errors, whi will only work for
             # certain values!
@@ -270,8 +302,8 @@ class NumpyVariantTest(unittest.TestCase):
             v.value = a
             self.assertTrue((v.value == a).all())
 
+    @enabled_disabled(disabled_error=ValueError)
     def test_int(self):
-        comtypes.npsupport.interop.enable()
         for dtype in ('int8', 'int16', 'int32', 'int64', 'uint8',
                 'uint16', 'uint32', 'uint64'):
             a = numpy.array((1, 1, 1, 1), dtype=dtype)
@@ -279,12 +311,8 @@ class NumpyVariantTest(unittest.TestCase):
             v.value = a
             self.assertTrue((v.value == a).all())
 
-    @unittest.skipUnless(
-        hasattr(numpy, "datetime64"),
-        "Skipping because this version of numpy does not support datetime64"
-    )
+    @enabled_disabled(disabled_error=ValueError)
     def test_datetime64(self):
-        comtypes.npsupport.interop.enable()
         dates = [
             numpy.datetime64("2000-01-01T05:30:00", "s"),
             numpy.datetime64("1800-01-01T05:30:00", "ms"),
@@ -302,7 +330,7 @@ class NumpyVariantTest(unittest.TestCase):
         "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
     )
     def test_mixed(self):
-        comtypes.npsupport.interop.enable()
+        comtypes.npsupport.enable()
         now = datetime.datetime.now()
         a = numpy.array(
             [11, "22", None, True, now, Decimal("3.14")]).reshape(2, 3)


### PR DESCRIPTION
As promised, here are the improvements to the optin numpy PR that didn't quite make it in before the last PR was merged.
`npsupport` has been moved to `_npsupport` so that `_npsupport.interop` can be imported in `__init__.py` as `comtypes.npsupport`. That also means that e.g. `from comtypes import npsupport` is valid. Interop is then enabled via `comtypes.npsupport.enable()`. 

Testing has been improved - tests that should fail with an error if interop is not enabled now have a decorator which calls them twice, once with and once without enabling interop, checking for the error in the disabled branch. I managed to do this without needing a 3rd party library in the end, although it is a little bit hacky.

Numpy support pre 1.7 is now dropped as well.