### PR TITLE
refactor creating `__all__` part in `codegenerator.Generator.generate_code`

### DIFF
--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -291,12 +291,12 @@ class Generator(object):
         print(self.declarations.getvalue(), file=self.output)
         print(file=self.output)
         print(self.stream.getvalue(), file=self.output)
-        dunder_all = "__all__ = [%s]" % ", ".join(repr(str(n)) for n in self.names)
+        names = ", ".join(repr(str(n)) for n in self.names)
+        dunder_all = "__all__ = [%s]" % names
         if len(dunder_all) > 80:
             wrapper = textwrap.TextWrapper(subsequent_indent="    ",
                                            initial_indent="    ",
                                            break_long_words=False)
-            names = ", ".join(repr(str(n)) for n in self.names)
             dunder_all = "__all__ = [\n%s\n]" % "\n".join(wrapper.wrap(names))
         print(dunder_all, file=self.output)
         print(file=self.output)


### PR DESCRIPTION
The position of variable declarations has been changed, so that processing (joining names) is no longer duplicated.