### PR TITLE
Shorten the lifetime of `io.StringIO` used for code generation

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -224,9 +224,9 @@ def _create_wrapper_module(tlib, pathname):
     p = tlbparser.TypeLibParser(tlib)
     if pathname is None:
         pathname = tlbparser.get_tlib_filename(tlib)
-    items = p.parse()
-    gen = codegenerator.Generator(known_symbols=_get_known_symbols())
-    code = gen.generate_code(list(items.values()), filename=pathname)
+    items = list(p.parse().values())
+    gen = codegenerator.Generator(_get_known_symbols())
+    code = gen.generate_code(items, filename=pathname)
     for ext_tlib in gen.externals:  # generating dependency COM-lib modules
         GetModule(ext_tlib)
     if comtypes.client.gen_dir is None:

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -225,9 +225,9 @@ def _create_wrapper_module(tlib, pathname):
     if pathname is None:
         pathname = tlbparser.get_tlib_filename(tlib)
     items = list(p.parse().values())
-    gen = codegenerator.Generator(_get_known_symbols())
-    code = gen.generate_code(items, filename=pathname)
-    for ext_tlib in gen.externals:  # generating dependency COM-lib modules
+    codegen = codegenerator.CodeGenerator(_get_known_symbols())
+    code = codegen.generate_code(items, filename=pathname)
+    for ext_tlib in codegen.externals:  # generates dependency COM-lib modules
         GetModule(ext_tlib)
     if comtypes.client.gen_dir is None:
         return _create_module_in_memory(modulename, code)

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -180,7 +180,7 @@ def name_friendly_module(tlib):
 
 ################################################################
 
-class Generator(object):
+class CodeGenerator(object):
 
     def __init__(self, known_symbols=None):
         self.stream = io.StringIO()

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -182,8 +182,7 @@ def name_friendly_module(tlib):
 
 class Generator(object):
 
-    def __init__(self, ofi, known_symbols=None):
-        self.output = ofi
+    def __init__(self, known_symbols=None):
         self.stream = io.StringIO()
         self.imports = ImportedNamespaces()
         self.declarations = DeclaredNamespaces()
@@ -304,16 +303,16 @@ class Generator(object):
         if tlib_mtime is not None:
             logger.debug("filename: \"%s\": tlib_mtime: %s", filename, tlib_mtime)
             self.imports.add('comtypes', '_check_version')
-
+        output = io.StringIO()
         if filename is not None:
             # Hm, what is the CORRECT encoding?
-            print("# -*- coding: mbcs -*-", file=self.output)
-            print(file=self.output)
-        print(self.imports.getvalue(), file=self.output)
-        print(file=self.output)
-        print(self.declarations.getvalue(), file=self.output)
-        print(file=self.output)
-        print(self.stream.getvalue(), file=self.output)
+            print("# -*- coding: mbcs -*-", file=output)
+            print(file=output)
+        print(self.imports.getvalue(), file=output)
+        print(file=output)
+        print(self.declarations.getvalue(), file=output)
+        print(file=output)
+        print(self.stream.getvalue(), file=output)
         names = ", ".join(repr(str(n)) for n in self.names)
         dunder_all = "__all__ = [%s]" % names
         if len(dunder_all) > 80:
@@ -321,13 +320,12 @@ class Generator(object):
                                            initial_indent="    ",
                                            break_long_words=False)
             dunder_all = "__all__ = [\n%s\n]" % "\n".join(wrapper.wrap(names))
-        print(dunder_all, file=self.output)
-        print(file=self.output)
+        print(dunder_all, file=output)
+        print(file=output)
         if tlib_mtime is not None:
             print("_check_version(%r, %f)" % (version, tlib_mtime),
-                    file=self.output)
-
-        return loops
+                    file=output)
+        return output.getvalue()
 
     def type_name(self, t):
         # Return a string, containing an expression which can be used


### PR DESCRIPTION
Previously, it was necessary to pass `io.StringIO` instantiated in `client._generate` to `codegenerator.Generator`.
Such implementation makes the lifetime of a variable inadvertently longer.

This change removes `ofi: io.StringIO` from the constructor arguments of `codegenerator.Generator`.
The `Generator.generate_code` method now returns a code string.

Also, I plan to add stuffs to the `codegenerator` to generate type stubs in the future as suggested in #327.
In consideration with the addition of `FooGenerator` in the future, This change renames `codegenerator.Generator` to `codegenerator.CodeGenerator`.