### PR TITLE
add `Python311` to environment matrix of `appveyor.yml`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ environment:
      - py: Python39-x64
      - py: Python310
      - py: Python310-x64
+     - py: Python311
+     - py: Python311-x64
 
 test_script:
    - C:\%py%\python.exe setup.py install


### PR DESCRIPTION
Appveyor will be start to support stable Python 3.11(appveyor/ci#3844).

Let's add it to ci's environment matrix.

I will open this PR when Appveyor started to support Py311.