### PR TITLE
add type hints to `comtypes/__init__.py`

### DIFF
--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -1,0 +1,21 @@
+from typing import (
+    Any, Callable, Generic, NoReturn, Optional, overload, SupportsIndex,
+    Type, TypeVar, Union as _UnionT,
+)
+
+
+def AnnoField() -> Any:
+    """**THIS IS `TYPE_CHECKING` ONLY SYMBOL.
+
+    This is workaround for class field type annotations for old
+    python versions.
+
+    Examples:
+        # instead of class field annotation, like below
+
+        class Foo:
+            # spam: int  # <- not available in old versions.
+            if TYPE_CHECKING:
+                spam = AnnoField()  # type: int  # <- available in old versions.
+    """
+    ...


### PR DESCRIPTION
related to #327 

This PR introduces type hints into statically defined modules.

- Scattered `import`s are now grouped together at the beginning of the code.
  - As for `add_metaclass`, it was moved where "if it was imported from `six`, it would be about here."
- Annotation-only symbols are imported from `typing` using `TYPE_CHECKING`, so `List`, `Tuple` and others are not in the runtime namespace.
- In the case of `_IUnknown_Base`, whose definition exists in runtime, is prevented from being used in `gen` by #360.
- For field annotations, defining `AnnoField` in `hints.pyi`. This can be used only under `if TYPE_CHECKING`.

In order to add more type annotations in the future, there are more symbols imported from `typing` than I use this time.
- I think it is better than having changes in the `import` part over and over.