### PR TITLE
Add typehints to codegen and typedesc

### DIFF
--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -2,10 +2,17 @@
 # in typedesc_base
 
 import ctypes
+from comtypes import TYPE_CHECKING
+from comtypes.typeinfo import ITypeLib, TLIBATTR
 from comtypes.tools.typedesc_base import *
+
+if TYPE_CHECKING:
+    from typing import Any, List, Optional, Tuple, Union as _UnionT
+
 
 class TypeLib(object):
     def __init__(self, name, guid, major, minor, doc=None):
+        # type: (str, str, int, int, Optional[str]) -> None
         self.name = name
         self.guid = guid
         self.major = major
@@ -17,12 +24,14 @@ class TypeLib(object):
 
 class Constant(object):
     def __init__(self, name, typ, value):
+        # type: (str, _UnionT[Typedef, FundamentalType], Any) -> None
         self.name = name
         self.typ = typ
         self.value = value
 
 class External(object):
     def __init__(self, tlib, name, size, align, docs=None):
+        # type: (ITypeLib, str, int, int, Optional[Tuple[str, str]]) -> None
         # the type library containing the symbol
         self.tlib = tlib
         # name of symbol
@@ -33,45 +42,52 @@ class External(object):
         self.docs = docs
 
     def get_head(self):
+        # type: () -> External
         # codegen might call this
         return self
 
 class SAFEARRAYType(object):
     def __init__(self, typ):
+        # type: (Any) -> None
         self.typ = typ
         self.align = self.size = ctypes.sizeof(ctypes.c_void_p) * 8
 
 class ComMethod(object):
     # custom COM method, parsed from typelib
     def __init__(self, invkind, memid, name, returns, idlflags, doc):
+        # type: (int, int, str, Typedef, List[str], Optional[str]) -> None
         self.invkind = invkind
         self.name = name
         self.returns = returns
         self.idlflags = idlflags
         self.memid = memid
         self.doc = doc
-        self.arguments = []
+        self.arguments = []  # type: List[Tuple[Any, str, List[str], Optional[Any]]]
 
     def add_argument(self, typ, name, idlflags, default):
+        # type: (Any, str, List[str], Optional[Any]) -> None
         self.arguments.append((typ, name, idlflags, default))
 
 class DispMethod(object):
     # dispatchable COM method, parsed from typelib
     def __init__(self, dispid, invkind, name, returns, idlflags, doc):
+        # type: (int, int, str, Typedef, List[str], Optional[str]) -> None
         self.dispid = dispid
         self.invkind = invkind
         self.name = name
         self.returns = returns
         self.idlflags = idlflags
         self.doc = doc
-        self.arguments = []
+        self.arguments = []  # type: List[Tuple[Any, str, List[str], Optional[Any]]]
 
     def add_argument(self, typ, name, idlflags, default):
+        # type: (Any, str, List[str], Optional[Any]) -> None
         self.arguments.append((typ, name, idlflags, default))
 
 class DispProperty(object):
     # dispatchable COM property, parsed from typelib
     def __init__(self, dispid, name, typ, idlflags, doc):
+        # type: (int, str, Any, List[str], Optional[Any]) -> None
         self.dispid = dispid
         self.name = name
         self.typ = typ
@@ -80,14 +96,17 @@ class DispProperty(object):
 
 class DispInterfaceHead(object):
     def __init__(self, itf):
+        # type: (DispInterface) -> None
         self.itf = itf
 
 class DispInterfaceBody(object):
     def __init__(self, itf):
+        # type: (DispInterface) -> None
         self.itf = itf
 
 class DispInterface(object):
     def __init__(self, name, members, base, iid, idlflags):
+        # type: (str, List[_UnionT[DispMethod, DispProperty]], Any, str, List[str]) -> None
         self.name = name
         self.members = members
         self.base = base
@@ -97,21 +116,26 @@ class DispInterface(object):
         self.itf_body = DispInterfaceBody(self)
 
     def get_body(self):
+        # type: () -> DispInterfaceBody
         return self.itf_body
 
     def get_head(self):
+        # type: () -> DispInterfaceHead
         return self.itf_head
 
 class ComInterfaceHead(object):
     def __init__(self, itf):
+        # type: (ComInterface) -> None
         self.itf = itf
 
 class ComInterfaceBody(object):
     def __init__(self, itf):
+        # type: (ComInterface) -> None
         self.itf = itf
 
 class ComInterface(object):
     def __init__(self, name, members, base, iid, idlflags):
+        # type: (str, List[ComMethod], Any, str, List[str]) -> None
         self.name = name
         self.members = members
         self.base = base
@@ -121,18 +145,22 @@ class ComInterface(object):
         self.itf_body = ComInterfaceBody(self)
 
     def get_body(self):
+        # type: () -> ComInterfaceBody
         return self.itf_body
 
     def get_head(self):
+        # type: () -> ComInterfaceHead
         return self.itf_head
 
 class CoClass(object):
     def __init__(self, name, clsid, idlflags, tlibattr):
+        # type: (str, str, List[str], TLIBATTR) -> None
         self.name = name
         self.clsid = clsid
         self.idlflags = idlflags
         self.tlibattr = tlibattr
-        self.interfaces = []
+        self.interfaces = []  # type: List[Tuple[Any, int]]
 
     def add_interface(self, itf, idlflags):
+        # type: (Any, int) -> None
         self.interfaces.append((itf, idlflags))

--- a/comtypes/tools/typedesc_base.py
+++ b/comtypes/tools/typedesc_base.py
@@ -1,5 +1,12 @@
 # typedesc.py - classes representing C type descriptions
 
+import comtypes
+from comtypes import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List, Optional, Tuple, Union as _UnionT, SupportsInt
+
+
 class Argument(object):
     "a Parameter in the argument list of a callable (Function, Method, ...)"
     def __init__(self, atype, name):
@@ -111,6 +118,7 @@ class Typedef(object):
 class ArrayType(object):
     location = None
     def __init__(self, typ, min, max):
+        # type: (Any, int, int) -> None
         self.typ = typ
         self.min = min
         self.max = max
@@ -118,27 +126,41 @@ class ArrayType(object):
 class StructureHead(object):
     location = None
     def __init__(self, struct):
+        # type: (_Struct_Union_Base) -> None
         self.struct = struct
 
 class StructureBody(object):
     location = None
     def __init__(self, struct):
+        # type: (_Struct_Union_Base) -> None
         self.struct = struct
 
 class _Struct_Union_Base(object):
+    if TYPE_CHECKING:
+        name = comtypes.hints.AnnoField()  # type: str
+        align = comtypes.hints.AnnoField()  # type: int
+        members = comtypes.hints.AnnoField()  # type: List[_UnionT[Field, Method, Constructor]]
+        bases = comtypes.hints.AnnoField()  # type: List[_Struct_Union_Base]
+        artificial = comtypes.hints.AnnoField()  # type: Optional[Any]
+        size = comtypes.hints.AnnoField()  # type: Optional[int]
+        _recordinfo_ = comtypes.hints.AnnoField()  # type: Tuple[str, int, int, int, str]
+
     location = None
     def __init__(self):
         self.struct_body = StructureBody(self)
         self.struct_head = StructureHead(self)
 
     def get_body(self):
+        # type: () -> StructureBody
         return self.struct_body
 
     def get_head(self):
+        # type: () -> StructureHead
         return self.struct_head
 
 class Structure(_Struct_Union_Base):
     def __init__(self, name, align, members, bases, size, artificial=None):
+        # type: (str, SupportsInt, List[Field], List[Any], Optional[SupportsInt], Optional[Any]) -> None
         self.name = name
         self.align = int(align)
         self.members = members
@@ -152,6 +174,7 @@ class Structure(_Struct_Union_Base):
 
 class Union(_Struct_Union_Base):
     def __init__(self, name, align, members, bases, size, artificial=None):
+        # type: (str, SupportsInt, List[Field], List[Any], Optional[SupportsInt], Optional[Any]) -> None
         self.name = name
         self.align = int(align)
         self.members = members
@@ -165,6 +188,7 @@ class Union(_Struct_Union_Base):
 
 class Field(object):
     def __init__(self, name, typ, bits, offset):
+        # type: (str, Any, Optional[Any], SupportsInt) -> None
         self.name = name
         self.typ = typ
         self.bits = bits
@@ -179,16 +203,19 @@ class CvQualifiedType(object):
 class Enumeration(object):
     location = None
     def __init__(self, name, size, align):
+        # type: (str, SupportsInt, SupportsInt) -> None
         self.name = name
         self.size = int(size)
         self.align = int(align)
-        self.values = []
+        self.values = []  # type: List[EnumValue]
 
     def add_value(self, v):
+        # type: (EnumValue) -> None
         self.values.append(v)
 
 class EnumValue(object):
     def __init__(self, name, value, enumeration):
+        # type: (str, int, Enumeration) -> None
         self.name = name
         self.value = value
         self.enumeration = enumeration


### PR DESCRIPTION
related to #327 

To facilitate code modification for the addition of type stub generating feature, I first added type annotations to `typedesc` and `codegenerator`.

There are a few things I noticed.
- It is better to use `isinstance(t, T)` rather than `type(t) is T` for type-narrowing.
- `typedesc` objects and the `tlbparser` processes are tightly coupled. There are rewriting attributes and manipulating mutable objects directly.