### PR TITLE
Removed extra space in typeinfo.IRecordInfo._methods_

### DIFF
--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -439,7 +439,7 @@ class IRecordInfo(IUnknown):
         # XXX Should SysFreeString the array contents. How to?
         return result
 
-IRecordInfo. _methods_ = [
+IRecordInfo._methods_ = [
         COMMETHOD([], HRESULT, 'RecordInit',
                   (['in'], c_void_p, 'pvNew')),
         COMMETHOD([], HRESULT, 'RecordClear',


### PR DESCRIPTION
[Issue] #381
[Problem] There is a strange, perhaps unnecessary space in typeinfo.IRecordInfo._methods_
[Solution] Removed the extra space