### PR TITLE
Prevent .whl installation (OOTB) on non Win

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to `comtypes`
+
+Welcome! :smile:
+
+`comtypes` is a community project for developing a lightweight COM client and server framework coded by **pure** `Python` on Windows environments.
+
+We appreciate all contributions, from reporting bugs to implementing new features.
+
+## Table of contents
+- [To keep the community healthy and sustainable :busts_in_silhouette:](#to-keep-the-community-healthy-and-sustainable-busts_in_silhouette)
+- [Reporting bugs :bug:](#reporting-bugs-bug)
+- [Breaking troubles down :flashlight:](#breaking-troubles-down-flashlight)
+- [Suggesting enhancements :sparkles:](#suggesting-enhancements-sparkles)
+- [Contributing to the codebase :open_file_folder:](#contributing-to-the-codebase-open_file_folder)
+- [Contributing to documentation :books:](#contributing-to-documentation-books)
+- [Final words :green_heart:](#final-words-green_heart)
+
+## To keep the community healthy and sustainable :busts_in_silhouette:
+
+If you have to understand all that this package has to offer, it would require an enormous amount of knowledge.
+
+- `Python`:snake:
+- `C`-lang:computer:
+- COM interface, implementation, client and server:door:
+- COM type library functionalities:wrench:
+
+However, there is **no means to say** that you must understand all of these things to be a contributor.
+
+The purpose of this document is to provide a pathway for you to contribute to this community even if you only know a small portion of this package.
+
+Please keep the followings in your mind:
+- :point_right:Please follow the following guidelines when posting a [GitHub Pull Request](https://github.com/enthought/comtypes/pulls) or filing a [GitHub Issue](https://github.com/enthought/comtypes/issues) on this project.
+- :bow:The community may not be able to process and reply to your issue or PR right-away. Participants in the community have a lot of work to do besides `comtypes`, but they would try their best.
+- :book:For code of conduct, please read [Contributor Covenant](https://www.contributor-covenant.org/).
+
+## Reporting bugs :bug:
+
+We use [GitHub issues](https://github.com/enthought/comtypes/issues) to track bugs and suggested enhancements. You can report a bug by opening a [new issue](https://github.com/enthought/comtypes/issues/new/choose).
+
+We need several infomations for breaking troubles down.
+
+This package handles functionalities of COM libraries in the user's environment.  
+Therefore, even if a community participant would like to work on a solution to a problem, the COM library may not be available in their development environments.  
+Also, it is possible that you can only reproduce this in your own environment.  
+If the community requests you to "try do-something", please respond to them.
+
+At least, please write the following.
+
+### Environment data
+- OS: 
+- `Python` version: 
+- `comtypes` version: 
+- what COM type libraries you want to use: 
+### Code snippet
+- Please provide a minimal, self-contained code snippet that reproduces the issue.
+- GitHub permalink is very useful as references.
+### Situation reproducing steps
+- Please provide a minimal description of conditions and steps needed to reproduce the situation.
+### Expected behavior
+- The results what you wanted.
+### Actual behavior
+- The results what you got.
+
+## Suggesting enhancements :sparkles:
+
+We use [GitHub issues](https://github.com/enthought/comtypes/issues) to track bugs and suggested enhancements. You can suggest an enhancement by opening a [new issue](https://github.com/enthought/comtypes/issues/new/choose). Before creating an enhancement suggestion, please check that a similar issue does not already exist.
+
+Please describe the behavior you want and why, and provide examples of how `comtypes` would be used if your feature were added.
+
+## Contributing to the codebase :open_file_folder:
+
+### Picking an issue
+Pick an issue by going through the [issue tracker](https://github.com/enthought/comtypes/issues) and finding an issue you would like to work on. Feel free to pick any issue that is not already assigned. We use the [`help wanted` label](https://github.com/enthought/comtypes/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) to indicate issues that are high on our wishlist.
+
+If you are a first time contributor, you might want to look for [issues labeled `good first issue`](https://github.com/enthought/comtypes/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).  
+The `comtypes` code base is quite complex, so starting with a small issue will help you find your way around!
+
+If you would like to take on an issue, please comment on the issue to let others know. You may use the issue to discuss possible solutions.
+
+### Setting up your local environment
+Install a version of `Python` supported by `comtypes` into your Windows environment.  
+Start by [forking](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the `comtypes` repository, then [clone your forked repository using `git`](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).  
+
+### Working on developments
+Create a new git branch in your local repository, and start coding!
+
+Tests can be run with `python -m unittest discover -v -s ./comtypes/test -t comtypes\test` command.
+
+When `comtypes.client.GetModule` is called, it parses the COM library, generates `.py` files under `.../comtypes/gen/...`, imports and returns `Python` modules.  
+Those `.py` files act like ”caches”.
+
+If there are some problems with the developing code base, partial or non-executable modules might be created in `.../comtypes/gen/...`.  
+Importing them will cause some error.  
+If that happens, you should run `python -m clear_comtypes_cache` to clear those caches.  
+The command will delete the entire `.../comtypes/gen` directory.  
+Importing `comtypes.gen.client` will restore the directory and `__init__.py` file.
+
+### Pull requests
+When you have resolved your issue, open a pull request in the `comtypes` repository.  
+Please include the issue number on the PR comment.  
+When enough PRs have been accepted to resolve the issue, please close the issue or mention it to the person(s) involved.
+
+## Contributing to documentation :books:
+
+Documents are in the [`.../docs` directory](https://github.com/enthought/comtypes/tree/master/docs).
+
+Follow the same steps as in [the codebase for contributions](#contributing-to-the-codebase-open_file_folder).
+
+## Final words :green_heart:
+Thank you very much for your contributions!  
+Hope that your contribution will be more profitable for your project and for the work of the community participants.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,16 +9,10 @@ shallow_clone: true
 
 environment:
    matrix:
-     - py: Python27
-     - py: Python27-x64
-     - py: Python33
-     - py: Python33-x64
-     - py: Python34
-     - py: Python34-x64
-     - py: Python35
-     - py: Python35-x64
-     - py: Python36
-     - py: Python36-x64
+     - py: Python37
+     - py: Python37-x64
+     - py: Python38
+     - py: Python38-x64
      - py: Python39
      - py: Python39-x64
      - py: Python310

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -918,7 +918,7 @@ if TYPE_CHECKING:
         pass
     @overload
     def CoCreateInstance(clsid, interface, clsctx=None, punkouter=None):
-        # type: (GUID, Type[_T_IUnknown], Optional[int], Optional[pUnkOuter]) -> IUnknown
+        # type: (GUID, Type[_T_IUnknown], Optional[int], Optional[pUnkOuter]) -> _T_IUnknown
         pass
 
 def CoCreateInstance(clsid, interface=None, clsctx=None, punkouter=None):

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -17,7 +17,7 @@ import comtypes.client
 from comtypes.tools import codegenerator, tlbparser
 
 if TYPE_CHECKING:
-    from typing import Any, Tuple, List, Optional, Union as _UnionT
+    from typing import Any, Tuple, List, Optional, Dict, Union as _UnionT
 
 
 logger = logging.getLogger(__name__)
@@ -247,8 +247,8 @@ def _create_wrapper_module(tlib, pathname):
 
 
 def _get_known_symbols():
-    # type: () -> dict[str, str]
-    known_symbols = {}  # type: dict[str, str]
+    # type: () -> Dict[str, str]
+    known_symbols = {}  # type: Dict[str, str]
     for mod_name in (
         "comtypes.persist",
         "comtypes.typeinfo",
@@ -259,7 +259,7 @@ def _get_known_symbols():
     ):
         mod = importlib.import_module(mod_name)
         if hasattr(mod, "__known_symbols__"):
-            names = mod.__known_symbols__  # type: list[str]
+            names = mod.__known_symbols__  # type: List[str]
         else:
             names = list(mod.__dict__)
         for name in names:
@@ -267,6 +267,7 @@ def _get_known_symbols():
     return known_symbols
 
 ################################################################
+
 
 if __name__ == "__main__":
     # When started as script, generate typelib wrapper from .tlb file.

--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,12 @@ classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Operating System :: Microsoft :: Windows',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 
@@ -182,6 +185,7 @@ setup_params = dict(
     ],
 
     platforms=["Windows"],
+    python_requires=">=3.7",
 )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -68,14 +68,13 @@ class test(Command):
 
 try:
     from wheel.bdist_wheel import bdist_wheel
-    class bdist_wheel_win(bdist_wheel, object):  # @TODO - Python 2 compatible (also super() below) still needed?
+    class bdist_wheel_win(bdist_wheel):
         def get_tag(self):
             win_plats = (  # Copied the list from DistUtils
                 "win-amd64",
                 "win32",
                 "win-arm64",
                 "win-arm32",
-                "win-ia64",  # Py2 only
             )
             tag = super(self.__class__, self).get_tag()
             return tuple(tag[:-1]) + (".".join(wp.replace("-", "_") for wp in win_plats),)

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,24 @@ class test(Command):
             self.failure = self.failure or package_failure
 
 
+try:
+    from wheel.bdist_wheel import bdist_wheel
+    class bdist_wheel_win(bdist_wheel, object):  # @TODO - Python 2 compatible (also super() below) still needed?
+        def get_tag(self):
+            win_plats = (  # Copied the list from DistUtils
+                "win-amd64",
+                "win32",
+                "win-arm64",
+                "win-arm32",
+                "win-ia64",  # Py2 only
+            )
+            tag = super(self.__class__, self).get_tag()
+            return tuple(tag[:-1]) + (".".join(wp.replace("-", "_") for wp in win_plats),)
+
+except ImportError:
+    bdist_wheel_win = None
+
+
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -151,6 +169,7 @@ setup_params = dict(
     cmdclass={
         'test': test,
         'build_py': build_py,
+        'bdist_wheel': bdist_wheel_win,
         'install': post_install,
     },
 

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,8 @@ setup_params = dict(
         "comtypes.tools",
         "comtypes.test",
     ],
+
+    platforms=["Windows"],
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
*COM* is *Win* specific and doesn't work on other *OS*es, therefore it shouldn't be possible to install the *.whl* on those *OS*es.
More: if it is installed on such *OS*es (although [\[PyPI\]: comtypes](https://pypi.org/project/comtypes) mentions the *Operating System* value as *Microsoft :: Windows* -  but that's easy to be ignored), the error is ambiguous as most people are not aware of the *CTypes* extension module (*\_ctypes.pyd* / *\_ctypes\*.so*). Example: [\[SO\]: cannot import name 'COMError' from '\_ctypes'](https://stackoverflow.com/q/74677364/4788546).

This *PR* addresses the above, using *Python*'s packaging mechanism. Drawbacks:
- The wheel name is long (comtypes-1.1.14-py3.py2-none-win\_amd64.win32.win\_arm64.win\_arm32.win\_ia64.whl*), but that shouldn't be a problem when *PIP* installing most people (again) pay no attention to this detail
- The platform list must be maintained (since the entries are now whitelisted, when a new one will be available (new architecture, *128bit*?) it will have to be added manually)

**Tests**:

- Built the *.whl* (it works on both *Win*, *Nix*). Sample command: `"e:\Work\Dev\VEnvs\py_pc064_03.09_test0\Scripts\python.exe" setup.py bdist_wheel --python-tag py3.py2`
- Installed it successfully on a combination of *Python* versions (*3.\**, *2.7*) and architectures (Intel only (*pc064*, *pc032*)) on *Win* (importing the module afterwards, was successful as well)
    - Failed to install on a *Linux*
