### PR TITLE
Prevent .whl installation (OOTB) on non Win

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,12 @@ classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Operating System :: Microsoft :: Windows',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 
@@ -182,6 +185,7 @@ setup_params = dict(
     ],
 
     platforms=["Windows"],
+    python_requires=">=3.7",
 )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -68,14 +68,13 @@ class test(Command):
 
 try:
     from wheel.bdist_wheel import bdist_wheel
-    class bdist_wheel_win(bdist_wheel, object):  # @TODO - Python 2 compatible (also super() below) still needed?
+    class bdist_wheel_win(bdist_wheel):
         def get_tag(self):
             win_plats = (  # Copied the list from DistUtils
                 "win-amd64",
                 "win32",
                 "win-arm64",
                 "win-arm32",
-                "win-ia64",  # Py2 only
             )
             tag = super(self.__class__, self).get_tag()
             return tuple(tag[:-1]) + (".".join(wp.replace("-", "_") for wp in win_plats),)

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,24 @@ class test(Command):
             self.failure = self.failure or package_failure
 
 
+try:
+    from wheel.bdist_wheel import bdist_wheel
+    class bdist_wheel_win(bdist_wheel, object):  # @TODO - Python 2 compatible (also super() below) still needed?
+        def get_tag(self):
+            win_plats = (  # Copied the list from DistUtils
+                "win-amd64",
+                "win32",
+                "win-arm64",
+                "win-arm32",
+                "win-ia64",  # Py2 only
+            )
+            tag = super(self.__class__, self).get_tag()
+            return tuple(tag[:-1]) + (".".join(wp.replace("-", "_") for wp in win_plats),)
+
+except ImportError:
+    bdist_wheel_win = None
+
+
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -151,6 +169,7 @@ setup_params = dict(
     cmdclass={
         'test': test,
         'build_py': build_py,
+        'bdist_wheel': bdist_wheel_win,
         'install': post_install,
     },
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ try:
                 "win-arm64",
                 "win-arm32",
             )
-            tag = super(self.__class__, self).get_tag()
+            tag = super().get_tag()
             return tuple(tag[:-1]) + (".".join(wp.replace("-", "_") for wp in win_plats),)
 
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,8 @@ setup_params = dict(
         "comtypes.tools",
         "comtypes.test",
     ],
+
+    platforms=["Windows"],
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is the same as #394, but somehow I got the branches messed up, and ended in a situation that some other commits (already present in the target branch) were included in my *PR*.

Cherry-picked the commits from the old branch in this one.

The *.whl* will **no longer**:

 - Install on non *Win*
 - Install on *Python* < *3.7*
 - Build on *Python 2*
