### PR TITLE
adjust comment indentations in files under the `.../comtypes/`

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -150,8 +150,8 @@ class ReturnHRESULT(Exception):
     without logging an error.
     """
 
-##class IDLWarning(UserWarning):
-##    "Warn about questionable type information"
+# class IDLWarning(UserWarning):
+#    "Warn about questionable type information"
 
 _GUID = GUID
 IID = GUID
@@ -395,7 +395,7 @@ class _cominterface_meta(type):
             # XXX I'm no longer sure why the code generator generates
             # "_methods_ = []" in the interface definition, and later
             # overrides this by "Interface._methods_ = [...]
-##            assert self.__dict__.get("_methods_", None) is None
+            # assert self.__dict__.get("_methods_", None) is None
             self._make_methods(value)
             self._make_specials()
         elif name == "_disp_methods_":

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -133,8 +133,8 @@ def hack(inst, mth, paramflags, interface, mthname):
     args_out = len(args_out_idx)
 
     ## XXX Remove this:
-##    if args_in != code.co_argcount - 1:
-##        return catch_errors(inst, mth, interface, mthname)
+    # if args_in != code.co_argcount - 1:
+    #     return catch_errors(inst, mth, interface, mthname)
 
     clsid = getattr(inst, "_reg_clsid_", None)
 
@@ -142,9 +142,9 @@ def hack(inst, mth, paramflags, interface, mthname):
         # Method implementations could check for and return E_POINTER
         # themselves.  Or an error will be raised when
         # 'outargs[i][0] = value' is executed.
-##        for a in outargs:
-##            if not a:
-##                return E_POINTER
+        # for a in outargs:
+        #     if not a:
+        #         return E_POINTER
 
         #make argument list for handler by index array built above
         inargs = []

--- a/comtypes/_safearray.py
+++ b/comtypes/_safearray.py
@@ -5,14 +5,14 @@ from ctypes.wintypes import *
 from comtypes import HRESULT, GUID
 
 ################################################################
-##if __debug__:
-##    from ctypeslib.dynamic_module import include
-##    include("""\
-##    #define UNICODE
-##    #define NO_STRICT
-##    #include <windows.h>
-##    """,
-##            persist=True)
+# if __debug__:
+#     from ctypeslib.dynamic_module import include
+#     include("""\
+#     #define UNICODE
+#     #define NO_STRICT
+#     #include <windows.h>
+#     """,
+#             persist=True)
 
 ################################################################
 

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -505,30 +505,30 @@ class tagVARIANT(Structure):
             return v.value
 
 
-# these are missing:
-##    getter[VT_ERROR]
-##    getter[VT_ARRAY]
-##    getter[VT_BYREF|VT_UI1]
-##    getter[VT_BYREF|VT_I2]
-##    getter[VT_BYREF|VT_I4]
-##    getter[VT_BYREF|VT_R4]
-##    getter[VT_BYREF|VT_R8]
-##    getter[VT_BYREF|VT_BOOL]
-##    getter[VT_BYREF|VT_ERROR]
-##    getter[VT_BYREF|VT_CY]
-##    getter[VT_BYREF|VT_DATE]
-##    getter[VT_BYREF|VT_BSTR]
-##    getter[VT_BYREF|VT_UNKNOWN]
-##    getter[VT_BYREF|VT_DISPATCH]
-##    getter[VT_BYREF|VT_ARRAY]
-##    getter[VT_BYREF|VT_VARIANT]
-##    getter[VT_BYREF]
-##    getter[VT_BYREF|VT_DECIMAL]
-##    getter[VT_BYREF|VT_I1]
-##    getter[VT_BYREF|VT_UI2]
-##    getter[VT_BYREF|VT_UI4]
-##    getter[VT_BYREF|VT_INT]
-##    getter[VT_BYREF|VT_UINT]
+    # these are missing:
+    # getter[VT_ERROR]
+    # getter[VT_ARRAY]
+    # getter[VT_BYREF|VT_UI1]
+    # getter[VT_BYREF|VT_I2]
+    # getter[VT_BYREF|VT_I4]
+    # getter[VT_BYREF|VT_R4]
+    # getter[VT_BYREF|VT_R8]
+    # getter[VT_BYREF|VT_BOOL]
+    # getter[VT_BYREF|VT_ERROR]
+    # getter[VT_BYREF|VT_CY]
+    # getter[VT_BYREF|VT_DATE]
+    # getter[VT_BYREF|VT_BSTR]
+    # getter[VT_BYREF|VT_UNKNOWN]
+    # getter[VT_BYREF|VT_DISPATCH]
+    # getter[VT_BYREF|VT_ARRAY]
+    # getter[VT_BYREF|VT_VARIANT]
+    # getter[VT_BYREF]
+    # getter[VT_BYREF|VT_DECIMAL]
+    # getter[VT_BYREF|VT_I1]
+    # getter[VT_BYREF|VT_UI2]
+    # getter[VT_BYREF|VT_UI4]
+    # getter[VT_BYREF|VT_INT]
+    # getter[VT_BYREF|VT_UINT]
 
     value = property(_get_value, _set_value)
 
@@ -630,9 +630,9 @@ class IEnumVARIANT(IUnknown):
     def __getitem__(self, index):
         self.Reset()
         # Does not yet work.
-##        if isinstance(index, slice):
-##            self.Skip(index.start or 0)
-##            return self.Next(index.stop or sys.maxint)
+        # if isinstance(index, slice):
+        #     self.Skip(index.start or 0)
+        #     return self.Next(index.stop or sys.maxint)
         self.Skip(index)
         item, fetched = self.Next(1)
         if fetched:
@@ -694,7 +694,7 @@ tagEXCEPINFO._fields_ = [
     ('bstrHelpFile', BSTR),
     ('dwHelpContext', DWORD),
     ('pvReserved', c_void_p),
-##    ('pfnDeferredFillIn', WINFUNCTYPE(HRESULT, POINTER(tagEXCEPINFO))),
+    # ('pfnDeferredFillIn', WINFUNCTYPE(HRESULT, POINTER(tagEXCEPINFO))),
     ('pfnDeferredFillIn', c_void_p),
     ('scode', SCODE),
 ]
@@ -942,8 +942,8 @@ _ctype_to_vartype = {
     POINTER(BSTR): VT_BYREF|VT_BSTR,
 
     # These are not yet implemented:
-##    POINTER(IUnknown): VT_UNKNOWN,
-##    POINTER(IDispatch): VT_DISPATCH,
+    # POINTER(IUnknown): VT_UNKNOWN,
+    # POINTER(IDispatch): VT_DISPATCH,
     }
 
 _vartype_to_ctype = {}

--- a/comtypes/persist.py
+++ b/comtypes/persist.py
@@ -39,7 +39,7 @@ class IPropertyBag(IUnknown):
                   ( ['in'], WSTRING, 'pszPropName' ),
                   ( ['in', 'out'], POINTER(VARIANT), 'pVar' ),
                   ( ['in'], POINTER(IErrorLog), 'pErrorLog' )),
-##                  ( ['in', 'out'], POINTER(IErrorLog), 'pErrorLog' )),
+                # ( ['in', 'out'], POINTER(IErrorLog), 'pErrorLog' )),
         COMMETHOD([], HRESULT, 'Write',
                   ( ['in'], WSTRING, 'pszPropName' ),
                   ( ['in'], POINTER(VARIANT), 'pVar' )),

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -218,7 +218,7 @@ def _make_safearray_type(itemtype):
 
         def __setitem__(self, index, value):
             # XXX Need this to implement [in, out] safearrays in COM servers!
-##            print "__setitem__", index, value
+            # print "__setitem__", index, value
             raise TypeError("Setting items not allowed")
 
         def __ctypes_from_outparam__(self):

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -750,7 +750,7 @@ ITypeInfo._methods_ = [
     COMMETHOD([], HRESULT, 'GetImplTypeFlags',
               (['in'], UINT, 'index'),
               (['out'], POINTER(INT))),
-##    STDMETHOD(HRESULT, 'GetIDsOfNames', [POINTER(LPOLESTR), UINT, POINTER(MEMBERID)]),
+    # STDMETHOD(HRESULT, 'GetIDsOfNames', [POINTER(LPOLESTR), UINT, POINTER(MEMBERID)]),
     # this one changed, to accept c_wchar_p array
     STDMETHOD(HRESULT, 'GetIDsOfNames', [POINTER(c_wchar_p), UINT, POINTER(MEMBERID)]),
     STDMETHOD(HRESULT, 'Invoke', [PVOID, MEMBERID, WORD, POINTER(DISPPARAMS), POINTER(VARIANT), POINTER(EXCEPINFO), POINTER(UINT)]),


### PR DESCRIPTION
Adjust indentation of commented-out runtime code beginning with `##`.

I will also submit next PRs for changes, broken down by folder.