### PR TITLE
adjust comment indentations in files under the `.../comtypes/server/`

### DIFF
--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -31,11 +31,11 @@ class IClassFactory(comtypes.IUnknown):
         # An interface was specified and obj is already that interface.
         return obj
 
-##class IExternalConnection(IUnknown):
-##    _iid_ = GUID("{00000019-0000-0000-C000-000000000046}")
-##    _methods_ = [
-##        STDMETHOD(HRESULT, "AddConnection", [c_ulong, c_ulong]),
-##        STDMETHOD(HRESULT, "ReleaseConnection", [c_ulong, c_ulong, c_ulong])]
+# class IExternalConnection(IUnknown):
+#     _iid_ = GUID("{00000019-0000-0000-C000-000000000046}")
+#     _methods_ = [
+#         STDMETHOD(HRESULT, "AddConnection", [c_ulong, c_ulong]),
+#         STDMETHOD(HRESULT, "ReleaseConnection", [c_ulong, c_ulong, c_ulong])]
 
 # The following code is untested:
 

--- a/comtypes/server/automation.py
+++ b/comtypes/server/automation.py
@@ -34,10 +34,10 @@ class VARIANTEnumerator(COMObject):
                 pCeltFetched[0] += 1
         except StopIteration:
             pass
-##        except:
-##            # ReportException? return E_FAIL?
-##            import traceback
-##            traceback.print_exc()
+        # except:
+        #     # ReportException? return E_FAIL?
+        #     import traceback
+        #     traceback.print_exc()
 
         if pCeltFetched[0] == celt:
             return S_OK


### PR DESCRIPTION
Adjust indentation of commented-out runtime code beginning with `##`.

I will also submit next PRs for changes, broken down by folder.