### PR TITLE
adjust comment indentations in files under the `.../comtypes/client/`

### DIFF
--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -73,9 +73,9 @@ def FindOutgoingInterface(source):
         logger.debug("%s using sinkinterface from clsid %s", source, interface)
         return interface
 
-##    interface = find_single_connection_interface(source)
-##    if interface:
-##        return interface
+    # interface = find_single_connection_interface(source)
+    # if interface:
+    #     return interface
 
     raise TypeError("cannot determine source interface")
 
@@ -260,7 +260,7 @@ def PumpEvents(timeout):
     handles = _handles_type(hevt)
     RPC_S_CALLPENDING = -2147417835
 
-##    @ctypes.WINFUNCTYPE(ctypes.c_int, ctypes.c_uint)
+    # @ctypes.WINFUNCTYPE(ctypes.c_int, ctypes.c_uint)
     def HandlerRoutine(dwCtrlType):
         if dwCtrlType == 0: # CTRL+C
             ctypes.windll.kernel32.SetEvent(hevt)

--- a/comtypes/client/dynamic.py
+++ b/comtypes/client/dynamic.py
@@ -104,8 +104,8 @@ class _Dispatch(object):
     def __getattr__(self, name):
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
-##        tc = self._comobj.GetTypeInfo(0).QueryInterface(comtypes.typeinfo.ITypeComp)
-##        dispid = tc.Bind(name)[1].memid
+        # tc = self._comobj.GetTypeInfo(0).QueryInterface(comtypes.typeinfo.ITypeComp)
+        # dispid = tc.Bind(name)[1].memid
         dispid = self._ids.get(name)
         if not dispid:
             dispid = self._comobj.GetIDsOfNames(name)[0]
@@ -146,9 +146,9 @@ class _Dispatch(object):
     def __iter__(self):
         return _Collection(self.__enum())
 
-##    def __setitem__(self, index, value):
-##        self._comobj.Invoke(-3, index, value,
-##                            _invkind=comtypes.automation.DISPATCH_PROPERTYPUT|comtypes.automation.DISPATCH_PROPERTYPUTREF)
+    # def __setitem__(self, index, value):
+    #     self._comobj.Invoke(-3, index, value,
+    #                         _invkind=comtypes.automation.DISPATCH_PROPERTYPUT|comtypes.automation.DISPATCH_PROPERTYPUTREF)
 
 class _Collection(object):
     def __init__(self, enum):

--- a/comtypes/client/lazybind.py
+++ b/comtypes/client/lazybind.py
@@ -111,7 +111,7 @@ class Dispatch(object):
         self.__dict__["_tinfo"] = tinfo
         self.__dict__["_tcomp"] = tinfo.GetTypeComp()
         self.__dict__["_tdesc"] = {}
-##        self.__dict__["_iid"] = tinfo.GetTypeAttr().guid
+        # self.__dict__["_iid"] = tinfo.GetTypeAttr().guid
 
     def __bind(self, name, invkind):
         """Bind (name, invkind) and return a FuncDesc instance or


### PR DESCRIPTION
Adjust indentation of commented-out runtime code beginning with `##`.

I will also submit next PRs for changes, broken down by folder.