### PR TITLE
adjust comment indentations in `.../comtypes/test/TestComServer.py`

### DIFF
--- a/comtypes/test/TestComServer.py
+++ b/comtypes/test/TestComServer.py
@@ -65,36 +65,36 @@ class TestComServer(
         # Hm, why is assignment to value needed?
 
         # these leak
-##        parray[0].value = (1, "2", None, 3.14)
-##        parray[0].value = (1, "2", None)
+        # parray[0].value = (1, "2", None, 3.14)
+        # parray[0].value = (1, "2", None)
 
-##        parray[0].value = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
-##        parray[0].value = (1,), (4,)
+        # parray[0].value = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
+        # parray[0].value = (1,), (4,)
 
-##        parray[0].value = (), ()
-##        parray[0].value = (), 0
+        # parray[0].value = (), ()
+        # parray[0].value = (), 0
 
         # leakage
-##        parray[0].value = (((127900.0, None, 2620),
-##                            (127875.0, None, 2335),
-##                            (127675.0, 1071, None)),
-##                           127800.0)
+        # parray[0].value = (((127900.0, None, 2620),
+        #                     (127875.0, None, 2335),
+        #                     (127675.0, 1071, None)),
+        #                     127800.0)
 
         # reported *no* leakage, but leaks anyway
-##        parray[0].value = ((128000.0, None, 2576),
-##                           (127975.0, None, 1923),
-##                           (127950.0, None, 1734))
+        # parray[0].value = ((128000.0, None, 2576),
+        #                     (127975.0, None, 1923),
+        #                     (127950.0, None, 1734))
 
         # these don't leak
-##        parray[0].value = (1, 2, 3)
-##        parray[0].value = (1, 2, None)
-##        parray[0].value = (1, 3.14)
-##        parray[0].value = [1, "(1, 2, 3)"]
-##        parray[0].value = (1, "2")
-##        parray[0].value = [1, "2"]
-##        parray[0].value = (None, None, None)
+        # parray[0].value = (1, 2, 3)
+        # parray[0].value = (1, 2, None)
+        # parray[0].value = (1, 3.14)
+        # parray[0].value = [1, "(1, 2, 3)"]
+        # parray[0].value = (1, "2")
+        # parray[0].value = [1, "2"]
+        # parray[0].value = (None, None, None)
 
-##        parray[0].value = (),
+        # parray[0].value = (),
 
         return S_OK
 
@@ -124,9 +124,9 @@ class TestComServer(
         self._name = name
         return S_OK
 
-##    def ITestComServer_SetName(self, this, name):
-##        self._name = name
-##        return S_OK
+    # def ITestComServer_SetName(self, this, name):
+    #     self._name = name
+    #     return S_OK
 
     def ITestComServer_sEtNaMe(self, this, name):
         # the method is spelled in a funny way to check case
@@ -134,15 +134,15 @@ class TestComServer(
         self._name = name
         return S_OK
 
-##    [id(18), helpstring("a method with [in] and [out] args in mixed order")]
-##    HRESULT MixedInOut([in] int a, [out] int *b, [in] int c, [out] int *d);
+    # [id(18), helpstring("a method with [in] and [out] args in mixed order")]
+    # HRESULT MixedInOut([in] int a, [out] int *b, [in] int c, [out] int *d);
     def MixedInOut(self, a, c):
         return a+1, c+1
 
 if __name__ == "__main__":
     try:
         from comtypes.server.register import UseCommandLine
-##    logging.basicConfig(level=logging.DEBUG)
+        # logging.basicConfig(level=logging.DEBUG)
         UseCommandLine(TestComServer)
     except Exception:
         import traceback


### PR DESCRIPTION
Adjust indentation of commented-out runtime code beginning with `##`.

I will also submit next PRs for changes, broken down by folder.