### PR TITLE
adjust comment indentations in files under the `.../comtypes/test/`

### DIFF
--- a/comtypes/test/test_DISPPARAMS.py
+++ b/comtypes/test/test_DISPPARAMS.py
@@ -18,8 +18,8 @@ class TestCase(ut.TestCase):
 
         self.assertEqual(dp.rgvarg[0].value, 42)
         # these fail:
-##        self.failUnlessEqual(dp.rgvarg[1].value, "spam")
-##        self.failUnlessEqual(dp.rgvarg[2].value, "foo")
+        # self.failUnlessEqual(dp.rgvarg[1].value, "spam")
+        # self.failUnlessEqual(dp.rgvarg[2].value, "foo")
 
     def X_test_2(self):
         # basically the same test as above

--- a/comtypes/test/test_avmc.py
+++ b/comtypes/test/test_avmc.py
@@ -27,10 +27,10 @@ class Test(unittest.TestCase):
         self.assertEqual(devs[1].Description, "Avmc2")
         self.assertEqual(devs[1].SerialNumber, "5678")
 
-##        # Leaks... where?
-##        def doit():
-##            avmc.FindAllAvmc()
-##        self.check_leaks(doit)
+        # # Leaks... where?
+        # def doit():
+        #     avmc.FindAllAvmc()
+        # self.check_leaks(doit)
 
     def check_leaks(self, func, limit=0):
         bytes = find_memleak(func)

--- a/comtypes/test/test_casesensitivity.py
+++ b/comtypes/test/test_casesensitivity.py
@@ -13,17 +13,17 @@ class TestCase(unittest.TestCase):
         # IWebBrowserApp(IWebBrowser)
         # IWebBrowser2(IWebBrowserApp)
 
-##        print iem.IWebBrowser2.mro()
+        # print iem.IWebBrowser2.mro()
 
         self.assertTrue(issubclass(iem.IWebBrowser2, iem.IWebBrowserApp))
         self.assertTrue(issubclass(iem.IWebBrowserApp, iem.IWebBrowser))
 
-##        print sorted(iem.IWebBrowser.__map_case__.keys())
-##        print "=" * 42
-##        print sorted(iem.IWebBrowserApp.__map_case__.keys())
-##        print "=" * 42
-##        print sorted(iem.IWebBrowser2.__map_case__.keys())
-##        print "=" * 42
+        # print sorted(iem.IWebBrowser.__map_case__.keys())
+        # print "=" * 42
+        # print sorted(iem.IWebBrowserApp.__map_case__.keys())
+        # print "=" * 42
+        # print sorted(iem.IWebBrowser2.__map_case__.keys())
+        # print "=" * 42
 
         # names in the base class __map_case__ must also appear in the
         # subclass.

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -76,8 +76,8 @@ class Test(unittest.TestCase):
             self.assertEqual(d.Name, "foo bar")
 
             # fails.  Why?
-##            d.name = "blah"
-##            self.assertEqual(d.Name, "blah")
+            # d.name = "blah"
+            # self.assertEqual(d.Name, "blah")
 
     def test_comtypes(self):
         from comtypes.client import CreateObject

--- a/comtypes/test/test_ie.py
+++ b/comtypes/test/test_ie.py
@@ -18,28 +18,28 @@ class EventSink:
 
     # some DWebBrowserEvents
     def OnVisible(self, this, *args):
-##        print "OnVisible", args
+        # print "OnVisible", args
         self._events.append("OnVisible")
 
     def BeforeNavigate(self, this, *args):
-##        print "BeforeNavigate", args
+        # print "BeforeNavigate", args
         self._events.append("BeforeNavigate")
 
     def NavigateComplete(self, this, *args):
-##        print "NavigateComplete", args
+        # print "NavigateComplete", args
         self._events.append("NavigateComplete")
 
     # some DWebBrowserEvents2
     def BeforeNavigate2(self, this, *args):
-##        print "BeforeNavigate2", args
+        # print "BeforeNavigate2", args
         self._events.append("BeforeNavigate2")
 
     def NavigateComplete2(self, this, *args):
-##        print "NavigateComplete2", args
+        # print "NavigateComplete2", args
         self._events.append("NavigateComplete2")
 
     def DocumentComplete(self, this, *args):
-##        print "DocumentComplete", args
+        # print "DocumentComplete", args
         self._events.append("DocumentComplete")
 
 

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -56,23 +56,23 @@ def comstring(text, typ=c_wchar_p):
 class Test(unittest.TestCase):
     @unittest.skip("This fails for reasons I don't understand yet")
     def test_c_char(self):
-##        ptr = c_wchar_p("abc")
-##        self.failUnlessEqual(ptr.__ctypes_from_outparam__(),
-##                             "abc")
+        # ptr = c_wchar_p("abc")
+        # self.failUnlessEqual(ptr.__ctypes_from_outparam__(),
+        #                         "abc")
 
-##        p = BSTR("foo bar spam")
+        # p = BSTR("foo bar spam")
 
         x = comstring("Hello, World")
         y = comstring("foo bar")
         z = comstring("spam, spam, and spam")
 
-##        (x.__ctypes_from_outparam__(), x.__ctypes_from_outparam__())
+        # (x.__ctypes_from_outparam__(), x.__ctypes_from_outparam__())
         print((x.__ctypes_from_outparam__(), None)) #x.__ctypes_from_outparam__())
 
-##        print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
-##        print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
-##        print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
-##        print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
+        # print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
+        # print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
+        # print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
+        # print comstring("Hello, World", c_wchar_p).__ctypes_from_outparam__()
 
 if __name__ == "__main__":
     unittest.main()

--- a/comtypes/test/test_urlhistory.py
+++ b/comtypes/test/test_urlhistory.py
@@ -37,8 +37,8 @@ class Test(unittest.TestCase):
         hist = CreateObject(urlhistLib.UrlHistory)
         for x in hist.EnumURLS():
             x.pwcsUrl, x.pwcsTitle
-##            print (x.pwcsUrl, x.pwcsTitle)
-##            print x
+            # print (x.pwcsUrl, x.pwcsTitle)
+            # print x
         def doit():
             for x in hist.EnumURLs():
                 pass

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -245,7 +245,7 @@ class ArrayTest(unittest.TestCase):
 
 ################################################################
 def run_test(rep, msg, func=None, previous={}, results={}):
-##    items = [None] * rep
+    # items = [None] * rep
     if func is None:
         locals = sys._getframe(1).f_locals
         func = eval("lambda: %s" % msg, locals)
@@ -303,7 +303,7 @@ def check_perf(rep=20000):
     d += run_test(rep, "VARIANT([42,]).value", previous=previous, results=results)
 
     print("Average duration %.1f%%" % (d / 10))
-##    cPickle.dump(results, open("result.pickle", "wb"))
+    # cPickle.dump(results, open("result.pickle", "wb"))
 
 if __name__ == '__main__':
     try:

--- a/comtypes/test/test_wmi.py
+++ b/comtypes/test/test_wmi.py
@@ -49,7 +49,7 @@ class Test(ut.TestCase):
                 self.assertTrue(isinstance(prop.Name, base_text_type))
                 prop.Value
                 result[prop.Name] = prop.Value
-##                print "\t", (prop.Name, prop.Value)
+                # print "\t", (prop.Name, prop.Value)
             self.assertEqual(len(item.Properties_), item.Properties_.Count)
             self.assertEqual(len(item.Properties_), len(result))
             self.assertTrue(isinstance(item.Properties_["Description"].Value, text_type))


### PR DESCRIPTION
Adjust indentation of commented-out runtime code beginning with `##`.

This is the last of this type of PR to be submitted by me.