### PR TITLE
Improve COM error message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ If there are some problems with the developing code base, partial or non-executa
 Importing them will cause some error.  
 If that happens, you should run `python -m clear_comtypes_cache` to clear those caches.  
 The command will delete the entire `.../comtypes/gen` directory.  
-Importing `comtypes.gen.client` will restore the directory and `__init__.py` file.
+Importing `comtypes.client` will restore the directory and `__init__.py` file.
 
 ### Pull requests
 When you have resolved your issue, open a pull request in the `comtypes` repository.  

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -7,14 +7,13 @@ from ctypes import _SimpleCData
 try:
     from _ctypes import COMError
 except ImportError as e:
-    e.msg = "\n".join((
-        e.msg,
+    msg = "\n".join((
         "",
         "COM technology not available (maybe it's the wrong platform).",
         "Note that COM is only supported on Windows.",
         "For more details, please check: "
         "https://learn.microsoft.com/en-us/windows/win32/com."))
-    raise e
+    raise ImportError(msg) from e
 import logging
 import os
 import sys

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -4,7 +4,17 @@ __version__ = "1.1.14"
 import atexit
 from ctypes import *
 from ctypes import _SimpleCData
-from _ctypes import COMError
+try:
+    from _ctypes import COMError
+except ImportError as e:
+    e.msg = "\n".join((
+        e.msg,
+        "",
+        "COM technology not available (maybe it's the wrong platform).",
+        "Note that COM is only supported on Windows.",
+        "For more details, please check: "
+        "https://learn.microsoft.com/en-us/windows/win32/com."))
+    raise e
 import logging
 import os
 import sys


### PR DESCRIPTION
An alternative to #405.

*ComTypes* can end up installed (directly or indirectly) on non *Windows* *OS*es.

Message `ImportError: cannot import name 'COMError' from '_ctypes' (/usr/lib/python3.8/lib-dynload/_ctypes.cpython-38-x86_64-linux-gnu.so)` can be a bit hard to understand for some users (especially if there's no *C* background).

This proposes to make it more clear.
