### PR TITLE
add auto-formatter GHA triggered by PR

### DIFF
--- a/.github/workflows/autofmt.yml
+++ b/.github/workflows/autofmt.yml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    branches: [drop_py2]  # TODO: add `master`
+
+jobs:
+    formatter:
+        name: auto-formatter
+        runs-on: windows-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v3
+          - name: Set up Python
+            uses: actions/setup-python@v4
+            with:
+              python-version: 3.7
+          - name: Install black
+            run: pip install black==22.12.0
+          - name: Format
+            run: python -m black comtypes/.
+          - name: Auto-commit
+            uses: stefanzweifel/git-auto-commit-action@v4
+            with:
+              branch: ${{ github.head_ref }}
+              commit_message: auto-format by `black`
+              commit_user_name: github-actions[bot]
+              commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+              commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -1157,6 +1157,7 @@ class CoClass(COMObject):
 ################################################################
 
 
+# fmt: off
 __known_symbols__ = [
     "BIND_OPTS", "tagBIND_OPTS", "BINDOPTS2", "tagBIND_OPTS2", "BSTR",
     "_check_version", "CLSCTX", "tagCLSCTX", "CLSCTX_ALL",
@@ -1183,3 +1184,4 @@ __known_symbols__ = [
     "SOLE_AUTHENTICATION_INFO", "_SOLE_AUTHENTICATION_LIST",
     "SOLE_AUTHENTICATION_LIST", "STDMETHOD", "wireHWND",
 ]
+# fmt: on

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -961,6 +961,7 @@ except (ImportError, AttributeError):
     pass
 
 
+# fmt: off
 __known_symbols__ = [
     "CURRENCY", "CY", "tagCY", "DECIMAL", "tagDEC", "DISPATCH_METHOD",
     "DISPATCH_PROPERTYGET", "DISPATCH_PROPERTYPUT", "DISPATCH_PROPERTYPUTREF",
@@ -984,3 +985,4 @@ __known_symbols__ = [
     "VT_UNKNOWN", "VT_USERDEFINED", "VT_VARIANT", "VT_VECTOR",
     "VT_VERSIONED_STREAM", "VT_VOID",
 ]
+# fmt: on

--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -292,7 +292,9 @@ def CoGetObject(displayname, interface=None, dynamic=False):
                    interface=interface)
 
 
+# fmt: off
 __all__ = [
     "CreateObject", "GetActiveObject", "CoGetObject", "GetEvents",
     "ShowEvents", "PumpEvents", "GetModule", "GetClassObject",
 ]
+# fmt: on

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -106,7 +106,9 @@ def ReportException(hresult, iid, clsid=None, helpfile=None, helpcontext=None,
                        hresult=hresult)
 
 
+# fmt: off
 __all__ = [
     "ICreateErrorInfo", "IErrorInfo", "ISupportErrorInfo", "ReportError",
     "ReportException", "SetErrorInfo", "GetErrorInfo", "CreateErrorInfo",
 ]
+# fmt: on

--- a/comtypes/git.py
+++ b/comtypes/git.py
@@ -46,10 +46,12 @@ RevokeInterfaceFromGlobal = git.RevokeInterfaceFromGlobal
 RegisterInterfaceInGlobal = git.RegisterInterfaceInGlobal
 GetInterfaceFromGlobal = git.GetInterfaceFromGlobal
 
+# fmt: off
 __all__ = [
     "RegisterInterfaceInGlobal", "RevokeInterfaceFromGlobal",
     "GetInterfaceFromGlobal",
 ]
+# fmt: on
 
 
 if __name__ == "__main__":

--- a/comtypes/persist.py
+++ b/comtypes/persist.py
@@ -213,6 +213,7 @@ class DictPropertyBag(COMObject):
         return S_OK
 
 
+# fmt: off
 __known_symbols__ = [
     "CLIPFORMAT", "DictPropertyBag", "IErrorLog", "IPersistFile",
     "IPersistPropertyBag", "IPersistPropertyBag2", "IPropertyBag",
@@ -225,3 +226,4 @@ __known_symbols__ = [
     "STGM_SHARE_DENY_NONE", "STGM_SHARE_DENY_READ", "STGM_SHARE_DENY_WRITE",
     "STGM_SHARE_EXCLUSIVE", "STGM_SIMPLE", "STGM_TRANSACTED", "STGM_WRITE",
 ]
+# fmt: on

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -1019,6 +1019,7 @@ tagARRAYDESC._fields_ = [
 ]
 
 
+# fmt: off
 __known_symbols__ = [
     "tagARRAYDESC", "BINDPTR", "tagBINDPTR", "CALLCONV", "tagCALLCONV",
     "CC_CDECL", "CC_FASTCALL", "CC_FPFASTCALL", "CC_MACPASCAL", "CC_MAX",
@@ -1066,3 +1067,4 @@ __known_symbols__ = [
     "VARFLAG_FRESTRICTED", "VARFLAG_FSOURCE", "VARFLAG_FUIDEFAULT",
     "VARFLAGS", "tagVARFLAGS", "VARKIND", "tagVARKIND",
 ]
+# fmt: on


### PR DESCRIPTION
see #418

I added the auto-formatter GitHub Actions that triggers [`black`](https://pypi.org/project/black/) when PR is submitted or updated.
I added `# fmt: ...` for avoiding redundant format.