### PR TITLE
add workaround for failure on GHA auto-commits

### DIFF
--- a/.github/workflows/autofmt.yml
+++ b/.github/workflows/autofmt.yml
@@ -6,6 +6,9 @@ jobs:
     formatter:
         name: auto-formatter
         runs-on: windows-latest
+        # Because auto-commit to the branch from a forked repository will fail,
+        # so this GHA will be triggered by PRs from the source repository only.
+        if: github.repository == github.event.pull_request.head.repo.full_name
         steps:
           - name: Checkout
             uses: actions/checkout@v3


### PR DESCRIPTION
I found out that `stefanzweifel/git-auto-commit-action` will fail if a contributor PRs from the forked repository due to permissions, so I decided to skip it in that case.
So this GHA will be triggered by PRs from the source repository only (In other words, it is not triggered by most contributors' PRs).

I found there seem to be a lot of security problems with doing auto-commit in a public repository like this with GHA alone.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
https://blog.gitguardian.com/github-actions-security-cheat-sheet/

I will consider alternative tools like [pre-commit-ci](https://github.com/apps/pre-commit-ci/) in my free time during the new year vacation.
