### PR TITLE
remove `hints.AnnoField`

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -336,10 +336,10 @@ class _cominterface_meta(type):
     """
 
     if TYPE_CHECKING:
-        _case_insensitive_ = hints.AnnoField()  # type: bool
-        _iid_ = hints.AnnoField()  # type: GUID
-        _methods_ = hints.AnnoField()  # type: List[_ComMemberSpec]
-        _disp_methods_ = hints.AnnoField()  # type: List[_DispMemberSpec]
+        _case_insensitive_: bool
+        _iid_: GUID
+        _methods_: List[_ComMemberSpec]
+        _disp_methods_: List[_DispMemberSpec]
 
     # This flag is set to True by the atexit handler which calls
     # CoUninitialize.
@@ -862,9 +862,9 @@ if TYPE_CHECKING:
         `builtins.object`.
         """
 
-        __com_QueryInterface = hints.AnnoField()  # type: Callable[[Any, Any], int]
-        __com_AddRef = hints.AnnoField()  # type: Callable[[], int]
-        __com_Release = hints.AnnoField()  # type: Callable[[], int]
+        __com_QueryInterface: Callable[[Any, Any], int]
+        __com_AddRef: Callable[[], int]
+        __com_Release: Callable[[], int]
 
 else:
     _IUnknown_Base = object
@@ -935,13 +935,13 @@ class IPersist(IUnknown):
     if TYPE_CHECKING:
         # Returns the CLSID that uniquely represents an object class that
         # defines the code that can manipulate the object's data.
-        GetClassID = hints.AnnoField()  # type: Callable[[], GUID]
+        GetClassID: Callable[[], GUID]
 
 
 class IServiceProvider(IUnknown):
     _iid_ = GUID("{6D5140C1-7436-11CE-8034-00AA006009FA}")
     if TYPE_CHECKING:
-        _QueryService = hints.AnnoField()  # type: Callable[[Any, Any, Any], int]
+        _QueryService: Callable[[Any, Any, Any], int]
     # Overridden QueryService to make it nicer to use (passing it an
     # interface and it returns a pointer to that interface)
     def QueryService(self, serviceIID, interface):
@@ -1072,9 +1072,9 @@ def GetActiveObject(clsid, interface=None):
 class MULTI_QI(Structure):
     _fields_ = [("pIID", POINTER(GUID)), ("pItf", POINTER(c_void_p)), ("hr", HRESULT)]
     if TYPE_CHECKING:
-        pIID = hints.AnnoField()  # type: GUID
-        pItf = hints.AnnoField()  # type: _Pointer[c_void_p]
-        hr = hints.AnnoField()  # type: HRESULT
+        pIID: GUID
+        pItf: _Pointer[c_void_p]
+        hr: HRESULT
 
 
 class _COAUTHIDENTITY(Structure):
@@ -1115,10 +1115,10 @@ class _COSERVERINFO(Structure):
         ("dwReserved2", c_ulong),
     ]
     if TYPE_CHECKING:
-        dwReserved1 = hints.AnnoField()  # type: int
-        pwszName = hints.AnnoField()  # type: Optional[str]
-        pAuthInfo = hints.AnnoField()  # type: _COAUTHINFO
-        dwReserved2 = hints.AnnoField()  # type: int
+        dwReserved1: int
+        pwszName: Optional[str]
+        pAuthInfo: _COAUTHINFO
+        dwReserved2: int
 
 
 COSERVERINFO = _COSERVERINFO

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -178,11 +178,11 @@ DECIMAL = tagDEC
 # helper extension.  At least the get/set methods.
 class tagVARIANT(Structure):
     if TYPE_CHECKING:
-        vt = hints.AnnoField()  # type: int
-        _ = hints.AnnoField()  # type: U_VARIANT1.__tagVARIANT.U_VARIANT2
-        null = hints.AnnoField()  # type: ClassVar[VARIANT]
-        empty = hints.AnnoField()  # type: ClassVar[VARIANT]
-        missing = hints.AnnoField()  # type: ClassVar[VARIANT]
+        vt: int
+        _: "U_VARIANT1.__tagVARIANT.U_VARIANT2"
+        null: ClassVar["VARIANT"]
+        empty: ClassVar["VARIANT"]
+        missing: ClassVar["VARIANT"]
 
     class U_VARIANT1(Union):
         class __tagVARIANT(Structure):
@@ -709,15 +709,15 @@ IEnumVARIANT._methods_ = [
 
 class tagEXCEPINFO(Structure):
     if TYPE_CHECKING:
-        wCode = hints.AnnoField()  # type: int
-        wReserved = hints.AnnoField()  # type: int
-        bstrSource = hints.AnnoField()  # type: str
-        bstrDescription = hints.AnnoField()  # type: str
-        bstrHelpFile = hints.AnnoField()  # type: str
-        dwHelpContext = hints.AnnoField()  # type: int
-        pvReserved = hints.AnnoField()  # type: Optional[int]
-        pfnDeferredFillIn = hints.AnnoField()  # type: Optional[int]
-        scode = hints.AnnoField()  # type: int
+        wCode: int
+        wReserved: int
+        bstrSource: str
+        bstrDescription: str
+        bstrHelpFile: str
+        dwHelpContext: int
+        pvReserved: Optional[int]
+        pfnDeferredFillIn: Optional[int]
+        scode: int
 
     def __repr__(self):
         return "<EXCEPINFO %s>" % (
@@ -750,10 +750,10 @@ EXCEPINFO = tagEXCEPINFO
 
 class tagDISPPARAMS(Structure):
     if TYPE_CHECKING:
-        rgvarg = hints.AnnoField()  # type: Array[VARIANT]
-        rgdispidNamedArgs = hints.AnnoField()  # type: _Pointer[DISPID]
-        cArgs = hints.AnnoField()  # type: int
-        cNamedArgs = hints.AnnoField()  # type: int
+        rgvarg: Array[VARIANT]
+        rgdispidNamedArgs: _Pointer[DISPID]
+        cArgs: int
+        cNamedArgs: int
     _fields_ = [
         # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 696
         ("rgvarg", POINTER(VARIANTARG)),
@@ -802,12 +802,10 @@ if TYPE_CHECKING:
 
 class IDispatch(IUnknown):
     if TYPE_CHECKING:
-        _disp_methods_ = (
-            hints.AnnoField()
-        )  # type: ClassVar[List[comtypes._DispMemberSpec]]
-        _GetTypeInfo = hints.AnnoField()  # type: Callable[[int, int], IUnknown]
-        __com_GetIDsOfNames = hints.AnnoField()  # type: RawGetIDsOfNamesFunc
-        __com_Invoke = hints.AnnoField()  # type: RawInvokeFunc
+        _disp_methods_: ClassVar[List[comtypes._DispMemberSpec]]
+        _GetTypeInfo: Callable[[int, int], IUnknown]
+        __com_GetIDsOfNames: RawGetIDsOfNamesFunc
+        __com_Invoke: RawInvokeFunc
 
     _iid_ = GUID("{00020400-0000-0000-C000-000000000046}")
     _methods_ = [

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -1,33 +1,4 @@
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    NoReturn,
-    Optional,
-    overload,
-    SupportsIndex,
-    Type,
-    TypeVar,
-    Union as _UnionT,
-)
-
 # symbols those what might occur recursive imports in runtime.
 from comtypes.automation import IDispatch as IDispatch, VARIANT as VARIANT
 from comtypes.server import IClassFactory as IClassFactory
 from comtypes.typeinfo import ITypeInfo as ITypeInfo
-
-def AnnoField() -> Any:
-    """**THIS IS `TYPE_CHECKING` ONLY SYMBOL.
-
-    This is workaround for class field type annotations for old
-    python versions.
-
-    Examples:
-        # instead of class field annotation, like below
-
-        class Foo:
-            # spam: int  # <- not available in old versions.
-            if TYPE_CHECKING:
-                spam = AnnoField()  # type: int  # <- available in old versions.
-    """
-    ...

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
         Union as _UnionT,
     )
     from ctypes import _CData, _Pointer
-    from comtypes import hints
 
 
 # Is the process 64-bit?
@@ -124,8 +123,8 @@ COMTYPES = {
 
 class Parser(object):
     if TYPE_CHECKING:
-        tlib = hints.AnnoField()  # type: typeinfo.ITypeLib
-        items = hints.AnnoField()  # type: Dict[str, Any]
+        tlib: typeinfo.ITypeLib
+        items: Dict[str, Any]
 
     def make_type(self, tdesc, tinfo):
         # type: (typeinfo.TYPEDESC, typeinfo.ITypeInfo) -> Any

--- a/comtypes/tools/typedesc_base.py
+++ b/comtypes/tools/typedesc_base.py
@@ -164,17 +164,13 @@ class StructureBody(object):
 
 class _Struct_Union_Base(object):
     if TYPE_CHECKING:
-        name = comtypes.hints.AnnoField()  # type: str
-        align = comtypes.hints.AnnoField()  # type: int
-        members = (
-            comtypes.hints.AnnoField()
-        )  # type: List[_UnionT[Field, Method, Constructor]]
-        bases = comtypes.hints.AnnoField()  # type: List[_Struct_Union_Base]
-        artificial = comtypes.hints.AnnoField()  # type: Optional[Any]
-        size = comtypes.hints.AnnoField()  # type: Optional[int]
-        _recordinfo_ = (
-            comtypes.hints.AnnoField()
-        )  # type: Tuple[str, int, int, int, str]
+        name: str
+        align: int
+        members: List[_UnionT["Field", Method, Constructor]]
+        bases: List["_Struct_Union_Base"]
+        artificial: Optional[Any]
+        size: Optional[int]
+        _recordinfo_: Tuple[str, int, int, int, str]
 
     location = None
 

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
         Tuple,
         Union as _UnionT,
     )
-    from comtypes import hints
 
     _CT = TypeVar("_CT", bound=_CData)
     _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
@@ -260,7 +259,7 @@ class ITypeLib(IUnknown):
             """Release TLIBATTR"""
             raise
 
-        _GetLibAttr = hints.AnnoField()  # type: Callable[[], _Pointer[TLIBATTR]]
+        _GetLibAttr: Callable[[], _Pointer["TLIBATTR"]]
 
     def GetLibAttr(self):
         # type: () -> TLIBATTR
@@ -360,15 +359,13 @@ class ITypeInfo(IUnknown):
             """Return index into and the containing type lib itself"""
             raise
 
-        ReleaseTypeAttr = hints.AnnoField()  # type: Callable[[_Pointer[TYPEATTR]], int]
-        ReleaseFuncDesc = hints.AnnoField()  # type: Callable[[_Pointer[FUNCDESC]], int]
-        ReleaseVarDesc = hints.AnnoField()  # type: Callable[[_Pointer[VARDESC]], int]
-        _GetTypeAttr = hints.AnnoField()  # type: Callable[[], _Pointer[TYPEATTR]]
-        _GetFuncDesc = hints.AnnoField()  # type: Callable[[int], _Pointer[FUNCDESC]]
-        _GetVarDesc = hints.AnnoField()  # type: Callable[[int], _Pointer[VARDESC]]
-        _GetDocumentation = (
-            hints.AnnoField()
-        )  # type: Callable[[int], Tuple[str, str, int, Optional[str]]]
+        ReleaseTypeAttr: Callable[[_Pointer["TYPEATTR"]], int]
+        ReleaseFuncDesc: Callable[[_Pointer["FUNCDESC"]], int]
+        ReleaseVarDesc: Callable[[_Pointer["VARDESC"]], int]
+        _GetTypeAttr: Callable[[], _Pointer["TYPEATTR"]]
+        _GetFuncDesc: Callable[[int], _Pointer["FUNCDESC"]]
+        _GetVarDesc: Callable[[int], _Pointer["VARDESC"]]
+        _GetDocumentation: Callable[[int], Tuple[str, str, int, Optional[str]]]
 
     def GetTypeAttr(self):
         """Return the TYPEATTR for this type"""
@@ -476,9 +473,7 @@ class ICreateTypeInfo(IUnknown):
     _iid_ = GUID("{00020405-0000-0000-C000-000000000046}")
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 915
     if TYPE_CHECKING:
-        _SetFuncAndParamNames = (
-            hints.AnnoField()
-        )  # Callable[[int, Array[c_wchar_p], int], int]
+        _SetFuncAndParamNames: Callable[[int, Array[c_wchar_p], int], int]
 
     def SetFuncAndParamNames(self, index, *names):
         # type: (int, str) -> int
@@ -677,12 +672,12 @@ def QueryPathOfRegTypeLib(libid, wVerMajor, wVerMinor, lcid=0):
 class tagTLIBATTR(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 4437
     if TYPE_CHECKING:
-        guid = hints.AnnoField()  # type: GUID
-        lcid = hints.AnnoField()  # type: int
-        syskind = hints.AnnoField()  # type: int
-        wMajorVerNum = hints.AnnoField()  # type: int
-        wMinorVerNum = hints.AnnoField()  # type: int
-        wLibFlags = hints.AnnoField()  # type: int
+        guid: GUID
+        lcid: int
+        syskind: int
+        wMajorVerNum: int
+        wMinorVerNum: int
+        wLibFlags: int
 
     def __repr__(self):
         return "TLIBATTR(GUID=%s, Version=%s.%s, LCID=%s, FLags=0x%x)" % (
@@ -700,24 +695,24 @@ TLIBATTR = tagTLIBATTR
 class tagTYPEATTR(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 672
     if TYPE_CHECKING:
-        guid = hints.AnnoField()  # type: GUID
-        lcid = hints.AnnoField()  # type: int
-        dwReserved = hints.AnnoField()  # type: int
-        memidConstructor = hints.AnnoField()  # type: int
-        memidDestructor = hints.AnnoField()  # type: int
-        lpstrSchema = hints.AnnoField()  # type: str
-        cbSizeInstance = hints.AnnoField()  # type: int
-        typekind = hints.AnnoField()  # type: int
-        cFuncs = hints.AnnoField()  # type: int
-        cVars = hints.AnnoField()  # type: int
-        cImplTypes = hints.AnnoField()  # type: int
-        cbSizeVft = hints.AnnoField()  # type: int
-        cbAlignment = hints.AnnoField()  # type: int
-        wTypeFlags = hints.AnnoField()  # type: int
-        wMajorVerNum = hints.AnnoField()  # type: int
-        wMinorVerNum = hints.AnnoField()  # type: int
-        tdescAlias = hints.AnnoField()  # type: TYPEDESC
-        idldescType = hints.AnnoField()  # type: IDLDESC
+        guid: GUID
+        lcid: int
+        dwReserved: int
+        memidConstructor: int
+        memidDestructor: int
+        lpstrSchema: str
+        cbSizeInstance: int
+        typekind: int
+        cFuncs: int
+        cVars: int
+        cImplTypes: int
+        cbSizeVft: int
+        cbAlignment: int
+        wTypeFlags: int
+        wMajorVerNum: int
+        wMinorVerNum: int
+        tdescAlias: "TYPEDESC"
+        idldescType: "IDLDESC"
 
     def __repr__(self):
         return "TYPEATTR(GUID=%s, typekind=%s, funcs=%s, vars=%s, impltypes=%s)" % (
@@ -735,18 +730,18 @@ TYPEATTR = tagTYPEATTR
 class tagFUNCDESC(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 769
     if TYPE_CHECKING:
-        memid = hints.AnnoField()  # type: int
-        lprgscode = hints.AnnoField()  # type: int
-        lprgelemdescParam = hints.AnnoField()  # type: Sequence[ELEMDESC]
-        funckind = hints.AnnoField()  # type: int
-        invkind = hints.AnnoField()  # type: int
-        callconv = hints.AnnoField()  # type: int
-        cParams = hints.AnnoField()  # type: int
-        cParamsOpt = hints.AnnoField()  # type: int
-        oVft = hints.AnnoField()  # type: int
-        cScodes = hints.AnnoField()  # type: int
-        elemdescFunc = hints.AnnoField()  # type: ELEMDESC
-        wFuncFlags = hints.AnnoField()  # type: int
+        memid: int
+        lprgscode: int
+        lprgelemdescParam: Sequence["ELEMDESC"]
+        funckind: int
+        invkind: int
+        callconv: int
+        cParams: int
+        cParamsOpt: int
+        oVft: int
+        cScodes: int
+        elemdescFunc: "ELEMDESC"
+        wFuncFlags: int
 
     def __repr__(self):
         return (
@@ -768,12 +763,12 @@ FUNCDESC = tagFUNCDESC
 class tagVARDESC(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 803
     if TYPE_CHECKING:
-        memid = hints.AnnoField()  # type: int
-        lpstrSchema = hints.AnnoField()  # type: str
-        _ = hints.AnnoField()  # type: N10tagVARDESC5DOLLAR_205E
-        elemdescVar = hints.AnnoField()  # type: ELEMDESC
-        wVarFlags = hints.AnnoField()  # type: int
-        varkind = hints.AnnoField()  # type: int
+        memid: int
+        lpstrSchema: str
+        _: "N10tagVARDESC5DOLLAR_205E"
+        elemdescVar: "ELEMDESC"
+        wVarFlags: int
+        varkind: int
 
 
 VARDESC = tagVARDESC
@@ -782,9 +777,9 @@ VARDESC = tagVARDESC
 class tagBINDPTR(Union):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 3075
     if TYPE_CHECKING:
-        lpfuncdesc = hints.AnnoField()  # type: _Pointer[FUNCDESC]
-        lpvardesc = hints.AnnoField()  # type: _Pointer[VARDESC]
-        lptcomp = hints.AnnoField()  # type: ITypeComp
+        lpfuncdesc: _Pointer["FUNCDESC"]
+        lpvardesc: _Pointer["VARDESC"]
+        lptcomp: ITypeComp
 
 
 BINDPTR = tagBINDPTR
@@ -793,8 +788,8 @@ BINDPTR = tagBINDPTR
 class tagTYPEDESC(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 582
     if TYPE_CHECKING:
-        _ = hints.AnnoField()  # type: N11tagTYPEDESC5DOLLAR_203E
-        vt = hints.AnnoField()  # type: int
+        _: "N11tagTYPEDESC5DOLLAR_203E"
+        vt: int
 
 
 TYPEDESC = tagTYPEDESC
@@ -803,8 +798,8 @@ TYPEDESC = tagTYPEDESC
 class tagIDLDESC(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 633
     if TYPE_CHECKING:
-        dwReserved = hints.AnnoField()  # type: int
-        wIDLFlags = hints.AnnoField()  # type: int
+        dwReserved: int
+        wIDLFlags: int
 
 
 IDLDESC = tagIDLDESC
@@ -813,9 +808,9 @@ IDLDESC = tagIDLDESC
 class tagARRAYDESC(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 594
     if TYPE_CHECKING:
-        tdescElem = hints.AnnoField()  # type: TYPEDESC
-        cDims = hints.AnnoField()  # type: int
-        rgbounds = hints.AnnoField()  # type: Sequence[SAFEARRAYBOUND]
+        tdescElem: TYPEDESC
+        cDims: int
+        rgbounds: Sequence["SAFEARRAYBOUND"]
 
 
 ################################################################
@@ -1075,7 +1070,7 @@ ICreateTypeInfo._methods_ = [
 class IProvideClassInfo(IUnknown):
     _iid_ = GUID("{B196B283-BAB4-101A-B69C-00AA00341D07}")
     if TYPE_CHECKING:
-        GetClassInfo = hints.AnnoField()  # type: Callable[[], ITypeInfo]
+        GetClassInfo: Callable[[], ITypeInfo]
     _methods_ = [
         # Returns the ITypeInfo interface for the object's coclass type information.
         COMMETHOD(
@@ -1087,7 +1082,7 @@ class IProvideClassInfo(IUnknown):
 class IProvideClassInfo2(IProvideClassInfo):
     _iid_ = GUID("{A6BC3AC0-DBAA-11CE-9DE3-00AA004BB851}")
     if TYPE_CHECKING:
-        GetGUID = hints.AnnoField()  # type: Callable[[int], GUID]
+        GetGUID: Callable[[int], GUID]
     _methods_ = [
         # Returns the GUID for the object's outgoing IID for its default event set.
         COMMETHOD(
@@ -1117,9 +1112,9 @@ tagTLIBATTR._fields_ = [
 class N11tagTYPEDESC5DOLLAR_203E(Union):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 584
     if TYPE_CHECKING:
-        lptdesc = hints.AnnoField()  # type: TYPEDESC
-        lpadesc = hints.AnnoField()  # type: tagARRAYDESC
-        hreftype = hints.AnnoField()  # type: int
+        lptdesc: TYPEDESC
+        lpadesc: tagARRAYDESC
+        hreftype: int
 
 
 N11tagTYPEDESC5DOLLAR_203E._fields_ = [
@@ -1166,8 +1161,8 @@ tagTYPEATTR._fields_ = [
 class N10tagVARDESC5DOLLAR_205E(Union):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 807
     if TYPE_CHECKING:
-        oInst = hints.AnnoField()  # type: int
-        lpvarValue = hints.AnnoField()  # type: VARIANT
+        oInst: int
+        lpvarValue: VARIANT
 
 
 N10tagVARDESC5DOLLAR_205E._fields_ = [
@@ -1180,29 +1175,29 @@ N10tagVARDESC5DOLLAR_205E._fields_ = [
 class tagELEMDESC(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 661
     if TYPE_CHECKING:
-        tdesc = hints.AnnoField()  # type: TYPEDESC
-        _ = hints.AnnoField()  # type: N11tagELEMDESC5DOLLAR_204E
+        tdesc: TYPEDESC
+        _: "N11tagELEMDESC5DOLLAR_204E"
 
 
 class N11tagELEMDESC5DOLLAR_204E(Union):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 663
     if TYPE_CHECKING:
-        idldesc = hints.AnnoField()  # type: IDLDESC
-        paramdesc = hints.AnnoField()  # type: PARAMDESC
+        idldesc: IDLDESC
+        paramdesc: "PARAMDESC"
 
 
 class tagPARAMDESC(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 609
     if TYPE_CHECKING:
-        pparamdescex = hints.AnnoField()  # type: tagPARAMDESCEX
-        wParamFlags = hints.AnnoField()  # type: int
+        pparamdescex: "tagPARAMDESCEX"
+        wParamFlags: int
 
 
 class tagPARAMDESCEX(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 601
     if TYPE_CHECKING:
-        cBytes = hints.AnnoField()  # type: int
-        varDefaultValue = hints.AnnoField()  # type: VARIANTARG
+        cBytes: int
+        varDefaultValue: VARIANTARG
 
 
 LPPARAMDESCEX = POINTER(tagPARAMDESCEX)
@@ -1270,8 +1265,8 @@ tagPARAMDESCEX._fields_ = [
 class tagSAFEARRAYBOUND(Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 226
     if TYPE_CHECKING:
-        cElements = hints.AnnoField()  # type: int
-        lLbound = hints.AnnoField()  # type: int
+        cElements: int
+        lLbound: int
     _fields_ = [
         ("cElements", DWORD),
         ("lLbound", LONG),


### PR DESCRIPTION
see https://github.com/enthought/comtypes/issues/392#issuecomment-1368174561

This is not all modernization of type annotations. Some tasks are left.
- `# type: ... ` comments
- `if TYPE_CHECKING:` bridges
- and etc...

Their resolution is planned in a separate PRs step by step.