### PR TITLE
remove `sys.version_info` bridges from the production codebase

### DIFF
--- a/comtypes/GUID.py
+++ b/comtypes/GUID.py
@@ -1,23 +1,10 @@
 from ctypes import *
 import sys
 
-if sys.version_info >= (2, 6):
 
-    def binary(obj):
-        return bytes(obj)
+def binary(obj):
+    return bytes(obj)
 
-else:
-
-    def binary(obj):
-        return buffer(obj)
-
-
-if sys.version_info >= (3, 0):
-    text_type = str
-    base_text_type = str
-else:
-    text_type = unicode
-    base_text_type = basestring
 
 BYTE = c_byte
 WORD = c_ushort
@@ -41,10 +28,10 @@ class GUID(Structure):
 
     def __init__(self, name=None):
         if name is not None:
-            _CLSIDFromString(text_type(name), byref(self))
+            _CLSIDFromString(str(name), byref(self))
 
     def __repr__(self):
-        return 'GUID("%s")' % text_type(self)
+        return 'GUID("%s")' % str(self)
 
     def __unicode__(self):
         p = c_wchar_p()
@@ -71,7 +58,7 @@ class GUID(Structure):
         return hash(binary(self))
 
     def copy(self):
-        return GUID(text_type(self))
+        return GUID(str(self))
 
     @classmethod
     def from_progid(cls, progid):
@@ -80,11 +67,11 @@ class GUID(Structure):
             progid = progid._reg_clsid_
         if isinstance(progid, cls):
             return progid
-        elif isinstance(progid, base_text_type):
+        elif isinstance(progid, str):
             if progid.startswith("{"):
                 return cls(progid)
             inst = cls()
-            _CLSIDFromProgID(text_type(progid), byref(inst))
+            _CLSIDFromProgID(str(progid), byref(inst))
             return inst
         else:
             raise TypeError("Cannot construct guid from %r" % progid)

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -13,6 +13,7 @@ from ctypes import (
 from _ctypes import CopyComPointer
 import logging
 import os
+import queue
 import sys
 
 from comtypes import COMError, ReturnHRESULT, instancemethod, _encode_idl
@@ -36,11 +37,6 @@ logger = logging.getLogger(__name__)
 _debug = logger.debug
 _warning = logger.warning
 _error = logger.error
-
-if sys.version_info >= (3, 0):
-    int_types = (int,)
-else:
-    int_types = (int, long)
 
 ################################################################
 # COM object implementation
@@ -72,7 +68,7 @@ def winerror(exc):
         return exc.hresult
     elif isinstance(exc, WindowsError):
         code = exc.winerror
-        if isinstance(code, int_types):
+        if isinstance(code, int):
             return code
         # Sometimes, a WindowsError instance has no error code.  An access
         # violation raised by ctypes has only text, for example.  In this
@@ -381,10 +377,6 @@ class LocalServer(object):
         messageloop.run()
 
     def run_mta(self):
-        if sys.version_info >= (3, 0):
-            import queue
-        else:
-            import Queue as queue
         self._queue = queue.Queue()
         self._queue.get()
 

--- a/comtypes/client/_constants.py
+++ b/comtypes/client/_constants.py
@@ -10,11 +10,6 @@ import comtypes
 import comtypes.automation
 import comtypes.typeinfo
 
-if sys.version_info >= (3, 0):
-    base_text_type = str
-else:
-    base_text_type = basestring
-
 
 class _frozen_attr_dict(dict):
     __slots__ = ()
@@ -78,7 +73,7 @@ class Constants(object):
     __slots__ = ("alias", "consts", "enums", "tcomp")
 
     def __init__(self, obj):
-        if isinstance(obj, base_text_type):
+        if isinstance(obj, str):
             tlib = comtypes.typeinfo.LoadTypeLibEx(obj)
         else:
             obj = obj.QueryInterface(comtypes.automation.IDispatch)

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -6,13 +6,7 @@ import os
 import sys
 import types
 from typing import Any, Tuple, List, Optional, Dict, Union as _UnionT
-
-if sys.version_info >= (3, 0):
-    base_text_type = str
-    import winreg
-else:
-    base_text_type = basestring
-    import _winreg as winreg
+import winreg
 
 from comtypes import GUID, typeinfo
 import comtypes.client
@@ -46,7 +40,7 @@ def _resolve_filename(tlib_string, dirpath):
         (abspath, True) or (relpath, False):
             where relpath is an unresolved path.
     """
-    assert isinstance(tlib_string, base_text_type)
+    assert isinstance(tlib_string, str)
     # pathname of type library
     if os.path.isabs(tlib_string):
         # a specific location
@@ -107,7 +101,7 @@ def GetModule(tlib):
     UIAutomation.  The former module contains all the code, the
     latter is a short stub loading the former.
     """
-    if isinstance(tlib, base_text_type):
+    if isinstance(tlib, str):
         tlib_string = tlib
         # if a relative pathname is used, we try to interpret it relative to
         # the directory of the calling module (if not from command line)
@@ -136,8 +130,6 @@ def GetModule(tlib):
     modulename = codegenerator.name_friendly_module(tlib)
     if modulename is None:
         return mod
-    if sys.version_info < (3, 0):
-        modulename = modulename.encode("mbcs")
     # create and import the friendly-named module
     return _create_friendly_module(tlib, modulename)
 
@@ -146,7 +138,7 @@ def _load_tlib(obj):
     # type: (Any) -> typeinfo.ITypeLib
     """Load a pointer of ITypeLib on demand."""
     # obj is a filepath or a ProgID
-    if isinstance(obj, base_text_type):
+    if isinstance(obj, str):
         # in any case, attempt to load and if tlib_string is not valid, then raise
         # as "OSError: [WinError -2147312566] Error loading type library/DLL"
         return typeinfo.LoadTypeLibEx(obj)

--- a/comtypes/connectionpoints.py
+++ b/comtypes/connectionpoints.py
@@ -34,21 +34,11 @@ class IEnumConnections(IUnknown):
     def __iter__(self):
         return self
 
-    if sys.version_info >= (3, 0):
-
-        def __next__(self):
-            cp, fetched = self.Next(1)
-            if fetched == 0:
-                raise StopIteration
-            return cp
-
-    else:
-
-        def next(self):
-            cp, fetched = self.Next(1)
-            if fetched == 0:
-                raise StopIteration
-            return cp
+    def __next__(self):
+        cp, fetched = self.Next(1)
+        if fetched == 0:
+            raise StopIteration
+        return cp
 
 
 class IEnumConnectionPoints(IUnknown):
@@ -58,21 +48,11 @@ class IEnumConnectionPoints(IUnknown):
     def __iter__(self):
         return self
 
-    if sys.version_info >= (3, 0):
-
-        def __next__(self):
-            cp, fetched = self.Next(1)
-            if fetched == 0:
-                raise StopIteration
-            return cp
-
-    else:
-
-        def next(self):
-            cp, fetched = self.Next(1)
-            if fetched == 0:
-                raise StopIteration
-            return cp
+    def __next__(self):
+        cp, fetched = self.Next(1)
+        if fetched == 0:
+            raise StopIteration
+        return cp
 
 
 ################################################################

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -6,11 +6,6 @@ from comtypes.hresult import *
 LPCOLESTR = c_wchar_p
 DWORD = c_ulong
 
-if sys.version_info >= (3, 0):
-    base_text_type = str
-else:
-    base_text_type = basestring
-
 
 class ICreateErrorInfo(IUnknown):
     _iid_ = GUID("{22F03340-547D-101B-8E65-08002B2BD119}")
@@ -84,7 +79,7 @@ def ReportError(
     if helpcontext is not None:
         ei.SetHelpContext(helpcontext)
     if clsid is not None:
-        if isinstance(clsid, base_text_type):
+        if isinstance(clsid, str):
             clsid = GUID(clsid)
         try:
             progid = clsid.as_progid()

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -5,11 +5,8 @@ from comtypes.hresult import *
 
 import sys
 import logging
+import winreg
 
-if sys.version_info >= (3, 0):
-    import winreg
-else:
-    import _winreg as winreg
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -4,11 +4,7 @@ import comtypes
 from comtypes.hresult import *
 from comtypes.server import IClassFactory
 import logging
-
-if sys.version_info >= (3, 0):
-    import queue
-else:
-    import Queue as queue
+import queue
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -35,12 +35,9 @@ Now, debug the object, and when done delete logging info:
 
   python mycomobj.py /nodebug
 """
-import sys, os
-
-if sys.version_info >= (3, 0):
-    import winreg
-else:
-    import _winreg as winreg
+import sys
+import os
+import winreg
 import logging
 
 import comtypes

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -8,11 +8,7 @@ import os
 import sys
 import textwrap
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union as _UnionT
-
-if sys.version_info >= (3, 0):
-    import io
-else:
-    import cStringIO as io
+import io
 
 import comtypes
 from comtypes import typeinfo
@@ -1340,12 +1336,7 @@ class TypeNamer(object):
 
 class ImportedNamespaces(object):
     def __init__(self):
-        if sys.version_info >= (3, 7):
-            self.data = {}
-        else:
-            from collections import OrderedDict
-
-            self.data = OrderedDict()
+        self.data = {}
 
     def add(self, name1, name2=None, symbols=None):
         """Adds a namespace will be imported.
@@ -1460,12 +1451,7 @@ class ImportedNamespaces(object):
 
 class DeclaredNamespaces(object):
     def __init__(self):
-        if sys.version_info >= (3, 7):
-            self.data = {}
-        else:
-            from collections import OrderedDict
-
-            self.data = OrderedDict()
+        self.data = {}
 
     def add(self, alias, definition, comment=None):
         """Adds a namespace will be declared.


### PR DESCRIPTION
I have removed the obviously dead code part of the production codebase, which is the conditional branch using `sys.version_info`.

Since the `add_metaclass` also has used symbols defined by those conditional branches, I removed it together here.

This PR contains the scope of #388.

As for the test codes, they have not been done, so I will post issues about them.