### PR TITLE
change type hints from comment annotations to inline annotations in `comtypes/client/...`

### DIFF
--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -44,8 +44,7 @@ _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
 logger = logging.getLogger(__name__)
 
 
-def wrap_outparam(punk):
-    # type: (Any) -> Any
+def wrap_outparam(punk: Any) -> Any:
     logger.debug("wrap_outparam(%s)", punk)
     if not punk:
         return None
@@ -54,8 +53,7 @@ def wrap_outparam(punk):
     return punk
 
 
-def GetBestInterface(punk):
-    # type: (Any) -> Any
+def GetBestInterface(punk: Any) -> Any:
     """Try to QueryInterface a COM pointer to the 'most useful'
     interface.
 
@@ -151,21 +149,23 @@ ctypes.POINTER(automation.IDispatch).__ctypes_from_outparam__ = wrap_outparam  #
 #
 # Object creation
 #
-if comtypes.TYPE_CHECKING:
-
-    @overload
-    def GetActiveObject(progid):
-        # type: (_UnionT[str, CoClass, GUID]) -> Any
-        pass
-
-    @overload
-    def GetActiveObject(progid, interface):
-        # type: (_UnionT[str, CoClass, GUID], Type[_T_IUnknown]) -> _T_IUnknown
-        pass
+@overload
+def GetActiveObject(progid: _UnionT[str, CoClass, GUID]) -> Any:
+    ...
 
 
-def GetActiveObject(progid, interface=None, dynamic=False):
-    # type: (_UnionT[str, CoClass, GUID], Optional[Any], bool) -> Any
+@overload
+def GetActiveObject(
+    progid: _UnionT[str, CoClass, GUID], interface: Type[_T_IUnknown]
+) -> _T_IUnknown:
+    ...
+
+
+def GetActiveObject(
+    progid: _UnionT[str, CoClass, GUID],
+    interface: Optional[Type[IUnknown]] = None,
+    dynamic: bool = False,
+) -> Any:
     """Return a pointer to a running COM object that has been
     registered with COM.
 
@@ -188,8 +188,9 @@ def GetActiveObject(progid, interface=None, dynamic=False):
     return _manage(obj, clsid, interface=interface)
 
 
-def _manage(obj, clsid, interface):
-    # type: (Any, Optional[GUID], Optional[Type[IUnknown]]) -> Any
+def _manage(
+    obj: Any, clsid: Optional[GUID], interface: Optional[Type[IUnknown]]
+) -> Any:
     obj.__dict__["__clsid"] = str(clsid)
     if interface is None:
         obj = GetBestInterface(obj)
@@ -221,35 +222,33 @@ def GetClassObject(progid, clsctx=None, pServerInfo=None, interface=None):
     return comtypes.CoGetClassObject(clsid, clsctx, pServerInfo, interface)
 
 
-if TYPE_CHECKING:
+@overload
+def CreateObject(progid: _UnionT[str, CoClass, GUID]) -> Any:
+    ...
 
-    @overload
-    def CreateObject(progid):
-        # type: (_UnionT[str, CoClass, GUID]) -> Any
-        pass
 
-    @overload
-    def CreateObject(
-        progid,
-        clsctx=None,
-        machine=None,
-        interface=None,
-        dynamic=False,
-        pServerInfo=None,
-    ):
-        # type: (_UnionT[str, CoClass, GUID], Optional[int], Optional[str], Optional[Type[_T_IUnknown]], bool, Optional[comtypes.COSERVERINFO]) -> _T_IUnknown
-        pass
+@overload
+def CreateObject(
+    progid: _UnionT[str, CoClass, GUID],
+    clsctx: Optional[int] = None,
+    machine: Optional[str] = None,
+    interface: Optional[Type[_T_IUnknown]] = None,
+    dynamic: bool = ...,
+    pServerInfo: Optional[comtypes.COSERVERINFO] = None,
+) -> _T_IUnknown:
+    ...
 
 
 def CreateObject(
-    progid,  # which object to create
-    clsctx=None,  # how to create the object
-    machine=None,  # where to create the object
-    interface=None,  # the interface we want
-    dynamic=False,  # use dynamic dispatch
-    pServerInfo=None,  # server info struct for remoting
-):
-    # type: (_UnionT[str, CoClass, GUID], Optional[int], Optional[str], Optional[Type[IUnknown]], bool, Optional[comtypes.COSERVERINFO]) -> Any
+    progid: _UnionT[str, CoClass, GUID],  # which object to create
+    clsctx: Optional[int] = None,  # how to create the object
+    machine: Optional[str] = None,  # where to create the object
+    interface: Optional[Type[IUnknown]] = None,  # the interface we want
+    dynamic: bool = False,  # use dynamic dispatch
+    pServerInfo: Optional[
+        comtypes.COSERVERINFO
+    ] = None,  # server info struct for remoting
+) -> Any:
     """Create a COM object from 'progid', and try to QueryInterface()
     it to the most useful interface, generating typelib support on
     demand.  A pointer to this interface is returned.
@@ -304,21 +303,21 @@ def CreateObject(
     return _manage(obj, clsid, interface=interface)
 
 
-if TYPE_CHECKING:
-
-    @overload
-    def CoGetObject(displayname, interface):
-        # type: (str, Type[_T_IUnknown]) -> _T_IUnknown
-        pass
-
-    @overload
-    def CoGetObject(displayname, interface=None, dynamic=False):
-        # type: (str, None, bool) -> Any
-        pass
+@overload
+def CoGetObject(displayname: str, interface: Type[_T_IUnknown]) -> _T_IUnknown:
+    ...
 
 
-def CoGetObject(displayname, interface=None, dynamic=False):
-    # type: (str, Optional[Type[comtypes.IUnknown]], bool) -> Any
+@overload
+def CoGetObject(displayname: str, interface: None = None, dynamic: bool = False) -> Any:
+    ...
+
+
+def CoGetObject(
+    displayname: str,
+    interface: Optional[Type[comtypes.IUnknown]] = None,
+    dynamic: bool = False,
+) -> Any:
     """Create an object by calling CoGetObject(displayname).
 
     Additional parameters have the same meaning as in CreateObject().

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -18,8 +18,7 @@ logger = logging.getLogger(__name__)
 PATH = os.environ["PATH"].split(os.pathsep)
 
 
-def _my_import(fullname):
-    # type: (str) -> types.ModuleType
+def _my_import(fullname: str) -> types.ModuleType:
     """helper function to import dotted modules"""
     import comtypes.gen as g
 
@@ -28,8 +27,7 @@ def _my_import(fullname):
     return importlib.import_module(fullname)
 
 
-def _resolve_filename(tlib_string, dirpath):
-    # type: (str, str) -> Tuple[str, bool]
+def _resolve_filename(tlib_string: str, dirpath: str) -> Tuple[str, bool]:
     """Tries to make sense of a type library specified as a string.
 
     Args:
@@ -58,8 +56,7 @@ def _resolve_filename(tlib_string, dirpath):
     return tlib_string, False
 
 
-def GetModule(tlib):
-    # type: (_UnionT[Any, typeinfo.ITypeLib]) -> types.ModuleType
+def GetModule(tlib: _UnionT[Any, typeinfo.ITypeLib]) -> types.ModuleType:
     """Create a module wrapping a COM typelibrary on demand.
 
     'tlib' must be ...
@@ -106,7 +103,7 @@ def GetModule(tlib):
         # if a relative pathname is used, we try to interpret it relative to
         # the directory of the calling module (if not from command line)
         frame = sys._getframe(1)
-        _file_ = frame.f_globals.get("__file__", None)  # type: str
+        _file_: str = frame.f_globals.get("__file__", None)
         pathname, is_abs = _resolve_filename(
             tlib_string, _file_ and os.path.dirname(_file_)
         )
@@ -134,8 +131,7 @@ def GetModule(tlib):
     return _create_friendly_module(tlib, modulename)
 
 
-def _load_tlib(obj):
-    # type: (Any) -> typeinfo.ITypeLib
+def _load_tlib(obj: Any) -> typeinfo.ITypeLib:
     """Load a pointer of ITypeLib on demand."""
     # obj is a filepath or a ProgID
     if isinstance(obj, str):
@@ -171,8 +167,7 @@ def _load_tlib(obj):
     raise TypeError("'%r' is not supported type for loading typelib" % obj)
 
 
-def _create_module_in_file(modulename, code):
-    # type: (str, str) -> types.ModuleType
+def _create_module_in_file(modulename: str, code: str) -> types.ModuleType:
     """create module in file system, and import it"""
     # `modulename` is 'comtypes.gen.xxx'
     filename = "%s.py" % modulename.split(".")[-1]
@@ -184,8 +179,7 @@ def _create_module_in_file(modulename, code):
     return _my_import(modulename)
 
 
-def _create_module_in_memory(modulename, code):
-    # type: (str, str) -> types.ModuleType
+def _create_module_in_memory(modulename: str, code: str) -> types.ModuleType:
     """create module in memory system, and import it"""
     # `modulename` is 'comtypes.gen.xxx'
     import comtypes.gen as g
@@ -199,8 +193,9 @@ def _create_module_in_memory(modulename, code):
     return mod
 
 
-def _create_friendly_module(tlib, modulename):
-    # type: (typeinfo.ITypeLib, str) -> types.ModuleType
+def _create_friendly_module(
+    tlib: typeinfo.ITypeLib, modulename: str
+) -> types.ModuleType:
     """helper which creates and imports the friendly-named module."""
     try:
         mod = _my_import(modulename)
@@ -220,8 +215,9 @@ def _create_friendly_module(tlib, modulename):
     return _create_module_in_file(modulename, code)
 
 
-def _create_wrapper_module(tlib, pathname):
-    # type: (typeinfo.ITypeLib, Optional[str]) -> types.ModuleType
+def _create_wrapper_module(
+    tlib: typeinfo.ITypeLib, pathname: Optional[str]
+) -> types.ModuleType:
     """helper which creates and imports the real typelib wrapper module."""
     modulename = codegenerator.name_wrapper_module(tlib)
     if modulename in sys.modules:
@@ -245,9 +241,8 @@ def _create_wrapper_module(tlib, pathname):
     return _create_module_in_file(modulename, code)
 
 
-def _get_known_symbols():
-    # type: () -> Dict[str, str]
-    known_symbols = {}  # type: Dict[str, str]
+def _get_known_symbols() -> Dict[str, str]:
+    known_symbols: Dict[str, str] = {}
     for mod_name in (
         "comtypes.persist",
         "comtypes.typeinfo",
@@ -258,7 +253,7 @@ def _get_known_symbols():
     ):
         mod = importlib.import_module(mod_name)
         if hasattr(mod, "__known_symbols__"):
-            names = mod.__known_symbols__  # type: List[str]
+            names: List[str] = mod.__known_symbols__
         else:
             names = list(mod.__dict__)
         for name in names:

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -103,9 +103,9 @@ def GetModule(tlib: _UnionT[Any, typeinfo.ITypeLib]) -> types.ModuleType:
         # if a relative pathname is used, we try to interpret it relative to
         # the directory of the calling module (if not from command line)
         frame = sys._getframe(1)
-        _file_: str = frame.f_globals.get("__file__", None)
+        _file_: Optional[str] = frame.f_globals.get("__file__", None)
         pathname, is_abs = _resolve_filename(
-            tlib_string, _file_ and os.path.dirname(_file_)
+            tlib_string, _file_ and os.path.dirname(_file_)  # type: ignore
         )
         logger.debug("GetModule(%s), resolved: %s", pathname, is_abs)
         tlib = _load_tlib(pathname)  # don't register


### PR DESCRIPTION
The `GetClassObject` is left as is as it is not tested at this time. (Same reason I did not change about `comtypes.CoGetClassObject` in #453)