### PR TITLE
Update `tlbparser` type annotations

### DIFF
--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -8,7 +8,6 @@ from typing import (
     List,
     Optional,
     Type,
-    TYPE_CHECKING,
     TypeVar,
     Tuple,
     Union as _UnionT,


### PR DESCRIPTION
`TYPE_CHECKING` is removed from import part.

There are other `typing` symbols that are unused at this time, but leaving them as they should become necessary as more type hints are added.

I am concerned about the possibility of conflicts in the import part more than it is YAGNI.