### PR TITLE
modernize `test_client`

### DIFF
--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -12,10 +12,6 @@ comtypes.client.GetModule("scrrun.dll")
 from comtypes.gen import Scripting
 
 
-
-
-
-
 class Test_GetModule(ut.TestCase):
     def test_tlib_string(self):
         mod = comtypes.client.GetModule("scrrun.dll")

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -12,10 +12,6 @@ comtypes.client.GetModule("scrrun.dll")
 from comtypes.gen import Scripting
 
 
-if sys.version_info >= (3, 0):
-    text_type = str
-else:
-    text_type = unicode
 
 
 
@@ -130,7 +126,6 @@ class Test_CreateObject(ut.TestCase):
 
     def test_clsid_string(self):
         # create from string clsid
-        comtypes.client.CreateObject(text_type(Scripting.Dictionary._reg_clsid_))
         comtypes.client.CreateObject(str(Scripting.Dictionary._reg_clsid_))
 
     def test_remote(self):

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -18,16 +18,6 @@ else:
     text_type = unicode
 
 
-# HACK: Prefer to use `contextlib.redirect_stdout`, but it's New in version 3.4
-@contextlib.contextmanager
-def silence_stdout():
-    old_target = sys.stdout
-    try:
-        with open(os.devnull, "w") as new_target:
-            sys.stdout = new_target
-            yield new_target
-    finally:
-        sys.stdout = old_target
 
 
 class Test_GetModule(ut.TestCase):
@@ -267,9 +257,8 @@ class Test_Constants(ut.TestCase):
         # float (Constant c_float)
         self.assertEqual(consts.Speech_Default_Weight, sapi.Speech_Default_Weight)
 
-    @ut.skipUnless(sys.version_info >= (3, 0), "Some words are not in Python2 keywords")
     def test_munged_definitions(self):
-        with silence_stdout():  # supress warnings
+        with contextlib.redirect_stdout(None):  # supress warnings
             MSVidCtlLib = comtypes.client.GetModule("msvidctl.dll")
             consts = comtypes.client.Constants("msvidctl.dll")
         # `None` is a Python3 keyword.


### PR DESCRIPTION
- remove `sys.version_info` bridges, like #449 
- start using `contextlib.redirect_stdout` instead of udf `silence_stdout` to supress warnings
  - references:
    - https://docs.python.org/3/library/sys.html#sys.__stdin__
    - https://docs.python.org/3.11/library/contextlib.html#contextlib.redirect_stdout
    - https://stackoverflow.com/questions/6735917/redirecting-stdout-to-nothing-in-python
    - https://github.com/python/typeshed/issues/3210