### PR TITLE
make explicit the symbols that imports from the wrapper module into the friendly module

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -215,10 +215,8 @@ class ModuleGenerator(object):
         # the module is always regenerated if the import fails
         logger.info("# Generating %s", modulename)
         # determine the Python module name
-        modname = codegenerator.name_wrapper_module(tlib).split(".")[-1]
-        code = "from comtypes.gen import %s\n" % modname
-        code += "globals().update(%s.__dict__)\n" % modname
-        code += "__name__ = '%s'" % modulename
+        modname = codegenerator.name_wrapper_module(tlib)
+        code = self.codegen.generate_friendly_code(modname)
         if comtypes.client.gen_dir is None:
             return _create_module_in_memory(modulename, code)
         return _create_module_in_file(modulename, code)

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -187,7 +187,7 @@ def _create_module_in_memory(modulename: str, code: str) -> types.ModuleType:
 
 
 class ModuleGenerator(object):
-    def __init__(self):
+    def __init__(self) -> None:
         self.codegen = codegenerator.CodeGenerator(_get_known_symbols())
 
     def generate(

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -240,7 +240,7 @@ class ModuleGenerator(object):
         if pathname is None:
             pathname = tlbparser.get_tlib_filename(tlib)
         items = list(p.parse().values())
-        code = self.codegen.generate_code(items, filename=pathname)
+        code = self.codegen.generate_wrapper_code(items, filename=pathname)
         for ext_tlib in self.codegen.externals:  # generates dependency COM-lib modules
             GetModule(ext_tlib)
         if comtypes.client.gen_dir is None:

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -497,7 +497,7 @@ class CodeGenerator(object):
                 assert os.path.isfile(p)
             self.names.add("typelib_path")
 
-    def generate_code(self, items, filename):
+    def generate_wrapper_code(self, items, filename):
 
         tlib_mtime = None
 

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -14,6 +14,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union as _UnionT,
 )
@@ -1380,6 +1381,10 @@ class ImportedNamespaces(object):
                 IUnknown
             )
             import ctypes.wintypes
+            >>> assert imports.get_symbols() == {
+            ...     'Decimal', 'GUID', 'COMMETHOD', 'DISPMETHOD', 'IUnknown',
+            ...     'dispid', 'CoClass', 'BSTR', 'DISPPROPERTY'
+            ... }
             >>> print(imports.getvalue(for_stub=True))
             from ctypes import *
             import datetime
@@ -1432,6 +1437,14 @@ class ImportedNamespaces(object):
             return self.data[import_] == from_
         return False
 
+    def get_symbols(self) -> Set[str]:
+        names = set()
+        for key, val in self.data.items():
+            if val is None or key == "*":
+                continue
+            names.add(key)
+        return names
+
     def _make_line(self, from_, imports, for_stub):
         if for_stub:
             import_ = ", ".join("%s as %s" % (n, n) for n in imports)
@@ -1483,8 +1496,17 @@ class DeclaredNamespaces(object):
             >>> print(declarations.getvalue())
             STRING = c_char_p
             _lcid = 0  # change this if required
+            >>> assert declarations.get_symbols() == {
+            ...     'STRING', '_lcid'
+            ... }
         """
         self.data[(alias, definition)] = comment
+
+    def get_symbols(self) -> Set[str]:
+        names = set()
+        for alias, _ in self.data.keys():
+            names.add(alias)
+        return names
 
     def getvalue(self):
         lines = []

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -876,6 +876,7 @@ class CodeGenerator(object):
         )
         print(file=self.stream)
         print(file=self.stream)
+        self.names.add("Library")
 
     def External(self, ext: typedesc.External) -> None:
         modname = name_wrapper_module(ext.tlib)

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -509,7 +509,15 @@ class CodeGenerator(object):
     def generate_wrapper_code(
         self, tdescs: Sequence[Any], filename: Optional[str]
     ) -> str:
+        """Returns the code for the COM type library wrapper module.
 
+        The returned `Python` code string is containing definitions of interfaces,
+        coclasses, constants, and structures.
+
+        The module will have long name that is derived from the type library guid, lcid
+        and version numbers.
+        Such as `comtypes.gen._xxxxxxxx_xxxx_xxxx_xxxx_xxxxxxxxxxxx_l_M_m`.
+        """
         tlib_mtime = None
 
         if filename is not None:
@@ -570,7 +578,15 @@ class CodeGenerator(object):
         return output.getvalue()
 
     def generate_friendly_code(self, modname: str) -> str:
-        # `modname` is wrapper module name like `comtypes.gen._xxxx..._x_x_x`
+        """Returns the code for the COM type library friendly module.
+
+        The returned `Python` code string is containing `from {modname} import
+        DefinedInWrapper, ...` and `__all__ = ['DefinedInWrapper', ...]`
+        The `modname` is the wrapper module name like `comtypes.gen._xxxx..._x_x_x`.
+
+        The module will have shorter name that is derived from the type library name.
+        Such as "comtypes.gen.stdole" and "comtypes.gen.Excel".
+        """
         output = io.StringIO()
         txtwrapper = textwrap.TextWrapper(
             subsequent_indent="    ", initial_indent="    ", break_long_words=False

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -558,6 +558,28 @@ class CodeGenerator(object):
             print("_check_version(%r, %f)" % (version, tlib_mtime), file=output)
         return output.getvalue()
 
+    def generate_friendly_code(self, modname: str) -> str:
+        # `modname` is wrapper module name like `comtypes.gen._xxxx..._x_x_x`
+        output = io.StringIO()
+        txtwrapper = textwrap.TextWrapper(
+            subsequent_indent="    ", initial_indent="    ", break_long_words=False
+        )
+        joined_names = ", ".join(str(n) for n in self.names)
+        symbols = f"from {modname} import {joined_names}"
+        if len(symbols) > 80:
+            wrapped_names = "\n".join(txtwrapper.wrap(joined_names))
+            symbols = f"from {modname} import (\n{wrapped_names}\n)"
+        print(symbols, file=output)
+        print(file=output)
+        print(file=output)
+        quoted_names = ", ".join(repr(str(n)) for n in self.names)
+        dunder_all = "__all__ = [%s]" % quoted_names
+        if len(dunder_all) > 80:
+            wrapped_quoted_names = "\n".join(txtwrapper.wrap(quoted_names))
+            dunder_all = "__all__ = [\n%s\n]" % wrapped_quoted_names
+        print(dunder_all, file=output)
+        return output.getvalue()
+
     def need_VARIANT_imports(self, value):
         text = repr(value)
         if "Decimal(" in text:

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -604,10 +604,10 @@ class CodeGenerator(object):
         print(file=output)
         print(file=output)
         quoted_names = ", ".join(repr(str(n)) for n in self.names)
-        dunder_all = "__all__ = [%s]" % quoted_names
+        dunder_all = f"__all__ = [{quoted_names}]"
         if len(dunder_all) > 80:
             wrapped_quoted_names = "\n".join(txtwrapper.wrap(quoted_names))
-            dunder_all = "__all__ = [\n%s\n]" % wrapped_quoted_names
+            dunder_all = f"__all__ = [\n{wrapped_quoted_names}\n]"
         print(dunder_all, file=output)
         return output.getvalue()
 

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -7,7 +7,16 @@ import logging
 import os
 import sys
 import textwrap
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union as _UnionT
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union as _UnionT,
+)
 import io
 
 import comtypes
@@ -497,7 +506,9 @@ class CodeGenerator(object):
                 assert os.path.isfile(p)
             self.names.add("typelib_path")
 
-    def generate_wrapper_code(self, items, filename):
+    def generate_wrapper_code(
+        self, tdescs: Sequence[Any], filename: Optional[str]
+    ) -> str:
 
         tlib_mtime = None
 
@@ -521,7 +532,7 @@ class CodeGenerator(object):
         self.declarations.add("_lcid", "0", "change this if required")
         self._generate_typelib_path(filename)
 
-        items = set(items)
+        items = set(tdescs)
         loops = 0
         while items:
             loops += 1

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -592,7 +592,10 @@ class CodeGenerator(object):
         txtwrapper = textwrap.TextWrapper(
             subsequent_indent="    ", initial_indent="    ", break_long_words=False
         )
-        joined_names = ", ".join(str(n) for n in self.names)
+        importing_symbols = set(self.names)
+        importing_symbols.update(self.imports.get_symbols())
+        importing_symbols.update(self.declarations.get_symbols())
+        joined_names = ", ".join(str(n) for n in importing_symbols)
         symbols = f"from {modname} import {joined_names}"
         if len(symbols) > 80:
             wrapped_names = "\n".join(txtwrapper.wrap(joined_names))

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -495,6 +495,7 @@ class CodeGenerator(object):
                     os.path.abspath(os.path.join(comtypes.gen.__path__[0], path))
                 )
                 assert os.path.isfile(p)
+            self.names.add("typelib_path")
 
     def generate_code(self, items, filename):
 


### PR DESCRIPTION
## **THIS IS FOR [`drop_py2`](https://github.com/enthought/comtypes/tree/drop_py2) PLAN! related to #392.**

Friendly modules such as `comtypes.gen.stdole` have imported the symbols of the wrapper module in the following way so far.

```py
from comtypes.gen import _00020430_0000_0000_C000_000000000046_0_2_0
globals().update(_00020430_0000_0000_C000_000000000046_0_2_0.__dict__)
__name__ = 'comtypes.gen.stdole'
```

This is not redundant, however, all the type hinting information that is so important in modern Python is lost.
Therefore, all symbols specified by `CodeGenerator.names`, `CodeGenerator.imports` and `CodeGenerator.declarations` are explicitly imported into the friendly module.
- During this work, I noticed that `typelib_path` and `Library` were public symbols but not included in `__all__`, so I added them.

The generated `comtypes.gen.stdole` code changes as follows.
```py
from comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0 import (
    FontEvents, FONTBOLD, IUnknown, OLE_CANCELBOOL,
    OLE_YSIZE_CONTAINER, dispid, StdFont, DISPMETHOD,
    OLE_YPOS_HIMETRIC, typelib_path, OLE_HANDLE, IFont,
    OLE_XSIZE_HIMETRIC, GUID, BSTR, IFontEventsDisp, Picture, Default,
    OLE_XSIZE_CONTAINER, OLE_COLOR, HRESULT, FONTUNDERSCORE,
    _check_version, OLE_YSIZE_HIMETRIC, CoClass, Monochrome, Library,
    EXCEPINFO, FONTITALIC, _lcid, OLE_XPOS_PIXELS, OLE_XPOS_CONTAINER,
    OLE_XPOS_HIMETRIC, IEnumVARIANT, Unchecked, VgaColor, IDispatch,
    Font, Checked, StdPicture, IPicture, OLE_XSIZE_PIXELS, FONTNAME,
    OLE_TRISTATE, IPictureDisp, VARIANT_BOOL, IFontDisp, COMMETHOD,
    LoadPictureConstants, FONTSIZE, Color, Gray, FONTSTRIKETHROUGH,
    OLE_ENABLEDEFAULTBOOL, DISPPARAMS, OLE_OPTEXCLUSIVE,
    OLE_YPOS_CONTAINER, DISPPROPERTY, OLE_YSIZE_PIXELS,
    OLE_YPOS_PIXELS
)


__all__ = [
    'FontEvents', 'FONTBOLD', 'OLE_XPOS_CONTAINER', 'OLE_CANCELBOOL',
    'OLE_YSIZE_CONTAINER', 'OLE_XPOS_HIMETRIC', 'StdFont', 'VgaColor',
    'Unchecked', 'OLE_YPOS_HIMETRIC', 'typelib_path', 'Font',
    'OLE_HANDLE', 'OLE_YSIZE_PIXELS', 'Checked', 'IFont',
    'OLE_XSIZE_HIMETRIC', 'StdPicture', 'IPicture',
    'OLE_XSIZE_PIXELS', 'FONTNAME', 'IFontEventsDisp', 'Picture',
    'Default', 'OLE_XSIZE_CONTAINER', 'IPictureDisp', 'OLE_TRISTATE',
    'OLE_COLOR', 'IFontDisp', 'OLE_YSIZE_HIMETRIC',
    'LoadPictureConstants', 'Monochrome', 'FONTSIZE', 'Library',
    'Color', 'Gray', 'FONTSTRIKETHROUGH', 'FONTITALIC',
    'OLE_ENABLEDEFAULTBOOL', 'OLE_XPOS_PIXELS', 'OLE_OPTEXCLUSIVE',
    'OLE_YPOS_CONTAINER', 'FONTUNDERSCORE', 'OLE_YPOS_PIXELS'
]
```
- Previously, the `__file__` and `__repr__` had unintentionally become those of the wrapper module because all namespaces had been overwritten, but with this change, the `__file__` and `__repr__` are now "normally"(related to [#328](https://github.com/enthought/comtypes/issues/328#issue-1309516731)).
- `_00020430_0000_0000_0000_C000_0000000000000046_0_2_0` symbol is removed from `comtypes.gen.stdole`.
- Symbols imported into wrapper module by wildcard(`from ctypes import *`) would not be imported to friendly modules.

Also, the argument name of `generate_wrapper_code` (originally `generate_code`) was changed because it does not go well with type annotations.