### PR TITLE
Correcting type hint for CreateObject

### DIFF
--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -223,13 +223,13 @@ def GetClassObject(progid, clsctx=None, pServerInfo=None, interface=None):
 
 
 @overload
-def CreateObject(progid: _UnionT[str, CoClass, GUID]) -> Any:
+def CreateObject(progid: _UnionT[str, Type[CoClass], GUID]) -> Any:
     ...
 
 
 @overload
 def CreateObject(
-    progid: _UnionT[str, CoClass, GUID],
+    progid: _UnionT[str, Type[CoClass], GUID],
     clsctx: Optional[int] = None,
     machine: Optional[str] = None,
     interface: Optional[Type[_T_IUnknown]] = None,
@@ -240,7 +240,7 @@ def CreateObject(
 
 
 def CreateObject(
-    progid: _UnionT[str, CoClass, GUID],  # which object to create
+    progid: _UnionT[str, Type[CoClass], GUID],  # which object to create
     clsctx: Optional[int] = None,  # how to create the object
     machine: Optional[str] = None,  # where to create the object
     interface: Optional[Type[IUnknown]] = None,  # the interface we want
@@ -289,7 +289,7 @@ def CreateObject(
             pServerInfo,
         )
         if machine is not None and pServerInfo is not None:
-            msg = "You can notset both the machine name and server info."
+            msg = "You cannot set both the machine name and server info."
             raise ValueError(msg)
         obj = comtypes.CoCreateInstanceEx(
             clsid,


### PR DESCRIPTION
I noticed that there is a small mistake in the type annotation of `CreateObject`, visible in vscode, `comtypes/test/test_client.py`:

![screenshot_type](https://user-images.githubusercontent.com/17198703/212546366-a9a44355-050d-4dba-a6c7-ec3dbc4cbcda.png)

This is fixed in this pull request. The typical (and, afaik, only actual) use of `CreateObject` is to pass in a subclass of IUnknown, and not an instance thereof.

(I made some temporary modifications to the file so type checking works at all; it appears that this will be fixed by https://github.com/enthought/comtypes/pull/469 anyway.)