### PR TITLE
Add unit test for generated IEnum (#468)

### DIFF
--- a/comtypes/test/test_enum.py
+++ b/comtypes/test/test_enum.py
@@ -1,3 +1,4 @@
+import contextlib
 import unittest as ut
 
 import comtypes
@@ -6,20 +7,16 @@ import comtypes.client
 
 class Test_Enum(ut.TestCase):
     def test_enum(self):
-        comtypes.client.GetModule("msvidctl.dll")
-        comtypes.client.GetModule("quartz.dll")
+        with contextlib.redirect_stdout(None):  # supress warnings, see test_client.py
+            comtypes.client.GetModule("msvidctl.dll")
         from comtypes.gen import MSVidCtlLib as vidlib
-        from comtypes.gen import QuartzTypeLib as quartz
 
-        # FilgraphManager has the same CLSID as FilterGraph
-        filtergraph = comtypes.CoCreateInstance(
-            quartz.FilgraphManager._reg_clsid_,
-            vidlib.IGraphBuilder,
-            comtypes.CLSCTX_INPROC_SERVER,
+        avisplitter = comtypes.client.CreateObject(
+            "{1b544c20-fd0b-11ce-8c63-00aa0044b51e}",  # CLSID_AviSplitter
+            interface=vidlib.IBaseFilter,
         )
-        enum_filters = filtergraph.EnumFilters()
-        # make sure enum_filters is iterable
-        [_ for _ in enum_filters]
+        pins = list(avisplitter.EnumPins())
+        self.assertGreater(len(pins), 0)
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_enum.py
+++ b/comtypes/test/test_enum.py
@@ -1,0 +1,26 @@
+import unittest as ut
+
+import comtypes
+import comtypes.client
+
+
+class Test_Enum(ut.TestCase):
+    def test_enum(self):
+        comtypes.client.GetModule("msvidctl.dll")
+        comtypes.client.GetModule("quartz.dll")
+        from comtypes.gen import MSVidCtlLib as vidlib
+        from comtypes.gen import QuartzTypeLib as quartz
+
+        # FilgraphManager has the same CLSID as FilterGraph
+        filtergraph = comtypes.CoCreateInstance(
+            quartz.FilgraphManager._reg_clsid_,
+            vidlib.IGraphBuilder,
+            comtypes.CLSCTX_INPROC_SERVER,
+        )
+        enum_filters = filtergraph.EnumFilters()
+        # make sure enum_filters is iterable
+        [_ for _ in enum_filters]
+
+
+if __name__ == "__main__":
+    ut.main()

--- a/comtypes/test/test_enum.py
+++ b/comtypes/test/test_enum.py
@@ -1,7 +1,7 @@
 import contextlib
 import unittest as ut
 
-import comtypes
+from comtypes import POINTER
 import comtypes.client
 
 
@@ -15,7 +15,10 @@ class Test_Enum(ut.TestCase):
             "{1b544c20-fd0b-11ce-8c63-00aa0044b51e}",  # CLSID_AviSplitter
             interface=vidlib.IBaseFilter,
         )
-        pins = list(avisplitter.EnumPins())
+        pinEnum = avisplitter.EnumPins()
+        self.assertIsInstance(pinEnum, POINTER(vidlib.IEnumPins))
+        # make sure pinEnum is iterable and non-empty
+        pins = list(pinEnum)
         self.assertGreater(len(pins), 0)
 
 

--- a/comtypes/test/test_ienum.py
+++ b/comtypes/test/test_ienum.py
@@ -1,18 +1,21 @@
 import contextlib
 import unittest as ut
 
-from comtypes import POINTER
+from ctypes import POINTER
+from comtypes import GUID
 import comtypes.client
 
 
-class Test_Enum(ut.TestCase):
-    def test_enum(self):
+class Test_IEnum(ut.TestCase):
+    def test_ienum(self):
         with contextlib.redirect_stdout(None):  # supress warnings, see test_client.py
             comtypes.client.GetModule("msvidctl.dll")
         from comtypes.gen import MSVidCtlLib as vidlib
 
+        CLSID_AviSplitter = GUID("{1b544c20-fd0b-11ce-8c63-00aa0044b51e}")
+
         avisplitter = comtypes.client.CreateObject(
-            "{1b544c20-fd0b-11ce-8c63-00aa0044b51e}",  # CLSID_AviSplitter
+            CLSID_AviSplitter,
             interface=vidlib.IBaseFilter,
         )
         pinEnum = avisplitter.EnumPins()


### PR DESCRIPTION
This fixes #468 by adding a unit test for a generated IEnum... interfaces. Unlike the test discussed in #353, this one does not require any portable device to be connected. As far as I am aware, the DirectShow interfaces should exist on every Windows since 2000.

I also verified that this test fails when you reintroduce the error of #353.