### PR TITLE
Add enumeration definitions in the friendly modules

### DIFF
--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -229,6 +229,15 @@ class Test_Constants(ut.TestCase):
         self.assertEqual(consts.TextCompare, Scripting.TextCompare)
         self.assertEqual(consts.DatabaseCompare, Scripting.DatabaseCompare)
 
+    def test_enums_in_friendly_mod(self):
+        consts = comtypes.client.Constants("scrrun.dll")
+        comtypes.client.GetModule("scrrun.dll")
+        from comtypes.gen import Scripting
+
+        for e in Scripting.StandardStreamTypes:
+            self.assertIn(e.name, consts.StandardStreamTypes)
+            self.assertEqual(consts.StandardStreamTypes[e.name], e.value)
+
     def test_returns_other_than_enum_members(self):
         obj = comtypes.client.CreateObject("SAPI.SpVoice")
         from comtypes.gen import SpeechLib as sapi

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -573,14 +573,7 @@ class CodeGenerator(object):
         print(self.declarations.getvalue(), file=output)
         print(file=output)
         print(self.stream.getvalue(), file=output)
-        names = ", ".join(repr(str(n)) for n in self.names)
-        dunder_all = "__all__ = [%s]" % names
-        if len(dunder_all) > 80:
-            wrapper = textwrap.TextWrapper(
-                subsequent_indent="    ", initial_indent="    ", break_long_words=False
-            )
-            dunder_all = "__all__ = [\n%s\n]" % "\n".join(wrapper.wrap(names))
-        print(dunder_all, file=output)
+        print(self._make_dunder_all_part(), file=output)
         print(file=output)
         if tlib_mtime is not None:
             print("_check_version(%r, %f)" % (version, tlib_mtime), file=output)
@@ -597,41 +590,58 @@ class CodeGenerator(object):
         Such as "comtypes.gen.stdole" and "comtypes.gen.Excel".
         """
         output = io.StringIO()
-        print(f"import {modname} as __wrapper_module__", file=output)
-        txtwrapper = textwrap.TextWrapper(
-            subsequent_indent="    ", initial_indent="    ", break_long_words=False
-        )
         print("from enum import IntFlag", file=output)
         print(file=output)
-        importing_symbols = set(self.names)
-        importing_symbols -= set(self.enums.get_symbols())
-        enum_aliases = {k: v for k, v in self.aliases.items() if v in self.enums}
-        importing_symbols -= set(enum_aliases)
-        importing_symbols.update(self.imports.get_symbols())
-        importing_symbols.update(self.declarations.get_symbols())
-        joined_names = ", ".join(str(n) for n in importing_symbols)
-        symbols = f"from {modname} import {joined_names}"
-        if len(symbols) > 80:
-            wrapped_names = "\n".join(txtwrapper.wrap(joined_names))
-            symbols = f"from {modname} import (\n{wrapped_names}\n)"
-        print(symbols, file=output)
+        print(f"import {modname} as __wrapper_module__", file=output)
+        print(self._make_friendly_module_import_part(modname), file=output)
         print(file=output)
         print(file=output)
         print(self.enums.getvalue("__wrapper_module__"), file=output)
+        print(file=output)
+        print(file=output)
+        enum_aliases = self.enum_aliases
         if enum_aliases:
             for k, v in enum_aliases.items():
                 print(f"{k} = {v}", file=output)
-        else:
-            print("# no alias for enumerations", file=output)
-        print(file=output)
-        print(file=output)
-        quoted_names = ", ".join(repr(str(n)) for n in self.names)
-        dunder_all = f"__all__ = [{quoted_names}]"
-        if len(dunder_all) > 80:
-            wrapped_quoted_names = "\n".join(txtwrapper.wrap(quoted_names))
-            dunder_all = f"__all__ = [\n{wrapped_quoted_names}\n]"
-        print(dunder_all, file=output)
+            print(file=output)
+            print(file=output)
+        print(self._make_dunder_all_part(), file=output)
         return output.getvalue()
+
+    def _make_dunder_all_part(self) -> str:
+        joined_names = ", ".join(repr(str(n)) for n in self.names)
+        dunder_all = f"__all__ = [{joined_names}]"
+        if len(dunder_all) > 80:
+            txtwrapper = textwrap.TextWrapper(
+                subsequent_indent="    ", initial_indent="    ", break_long_words=False
+            )
+            joined_names = "\n".join(txtwrapper.wrap(joined_names))
+            dunder_all = f"__all__ = [\n{joined_names}\n]"
+        return dunder_all
+
+    def _make_friendly_module_import_part(self, modname: str) -> str:
+        # The `modname` is the wrapper module name like `comtypes.gen._xxxx..._x_x_x`
+        txtwrapper = textwrap.TextWrapper(
+            subsequent_indent="    ", initial_indent="    ", break_long_words=False
+        )
+        symbols = set(self.names)
+        symbols.update(self.imports.get_symbols())
+        symbols.update(self.declarations.get_symbols())
+        symbols -= set(self.enums.get_symbols())
+        symbols -= set(self.enum_aliases)
+        joined_names = ", ".join(str(n) for n in symbols)
+        part = f"from {modname} import {joined_names}"
+        if len(part) > 80:
+            txtwrapper = textwrap.TextWrapper(
+                subsequent_indent="    ", initial_indent="    ", break_long_words=False
+            )
+            joined_names = "\n".join(txtwrapper.wrap(joined_names))
+            part = f"from {modname} import (\n{joined_names}\n)"
+        return part
+
+    @property
+    def enum_aliases(self) -> Dict[str, str]:
+        return {k: v for k, v in self.aliases.items() if v in self.enums}
 
     def need_VARIANT_imports(self, value):
         text = repr(value)
@@ -1573,4 +1583,4 @@ class EnumerationNamespaces(object):
                 ref = f"{wrapper_module_name}.{member_name}"
                 lines.append(f"    {member_name} = {ref}")
             blocks.append("\n".join(lines))
-        return "\n\n".join(blocks)
+        return "\n\n\n".join(blocks)

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -596,7 +596,7 @@ class CodeGenerator(object):
         print(self._make_friendly_module_import_part(modname), file=output)
         print(file=output)
         print(file=output)
-        print(self.enums.getvalue("__wrapper_module__"), file=output)
+        print(self.enums.getvalue(), file=output)
         print(file=output)
         print(file=output)
         enum_aliases = self.enum_aliases
@@ -1558,13 +1558,14 @@ class EnumerationNamespaces(object):
             >>> enums.add('Bar', 'bacon')
             >>> assert 'Foo' in enums
             >>> assert 'Baz' not in enums
-            >>> print(enums.getvalue('_0123'))  # <BLANKLINE> is necessary for doctest
+            >>> print(enums.getvalue())  # <BLANKLINE> is necessary for doctest
             class Foo(IntFlag):
-                ham = _0123.ham
-                spam = _0123.spam
+                ham = __wrapper_module__.ham
+                spam = __wrapper_module__.spam
+            <BLANKLINE>
             <BLANKLINE>
             class Bar(IntFlag):
-                bacon = _0123.bacon
+                bacon = __wrapper_module__.bacon
         """
         self.data.setdefault(enum_name, []).append(member_name)
 
@@ -1574,13 +1575,12 @@ class EnumerationNamespaces(object):
     def get_symbols(self) -> Set[str]:
         return set(self.data)
 
-    def getvalue(self, wrapper_module_name: str) -> str:
+    def getvalue(self) -> str:
         blocks = []
         for enum_name, enum_members in self.data.items():
             lines = []
             lines.append(f"class {enum_name}(IntFlag):")
             for member_name in enum_members:
-                ref = f"{wrapper_module_name}.{member_name}"
-                lines.append(f"    {member_name} = {ref}")
+                lines.append(f"    {member_name} = __wrapper_module__.{member_name}")
             blocks.append("\n".join(lines))
         return "\n\n\n".join(blocks)


### PR DESCRIPTION
#345

I have modified the `codegenerator` so that the Python friendly enumerations are defined in the friendly module as derived classes of `enum.IntFlag`.

Specifically, for example, the `Scripting.py` changes as follows before and after this change.


```py
import comtypes.gen._420B2830_E718_11CF_893D_00A0C9054228_0_1_0 as __wrapper_module__
from comtypes.gen._420B2830_E718_11CF_893D_00A0C9054228_0_1_0 import (
    FileAttribute, DriveTypeConst, TristateMixed, IFileSystem,
    SystemFolder, IFileCollection, StandardStreamTypes,
    _check_version, GUID, IFolderCollection, Dictionary, Directory,
    Remote, Library, StdOut, IOMode,
    __MIDL___MIDL_itf_scrrun_0001_0001_0003, WindowsFolder, VARIANT,
    Alias, helpstring, TristateUseDefault, IScriptEncoder, Archive,
    TextStream, IDrive, IFile, HRESULT, Hidden, StdErr, Folders,
    dispid, typelib_path, IFileSystem3, ReadOnly, ForWriting, StdIn,
    FileSystemObject, ForAppending, Encoder, CDRom, IDriveCollection,
    COMMETHOD, Volume, CompareMethod, BinaryCompare, IDictionary,
    BSTR, Normal, TristateTrue, TristateFalse, Fixed, UnknownType,
    Files, File, _lcid, Tristate, SpecialFolderConst, ForReading,
    ITextStream, __MIDL___MIDL_itf_scrrun_0001_0001_0001, Removable,
    RamDisk, VARIANT_BOOL, Drives, Folder, TemporaryFolder, CoClass,
    __MIDL___MIDL_itf_scrrun_0000_0000_0001, System,
    __MIDL___MIDL_itf_scrrun_0001_0001_0002, Compressed, TextCompare,
    DatabaseCompare, IFolder, IUnknown, Drive
)


__all__ = [
    'Encoder', 'FileAttribute', 'CDRom', 'IDriveCollection',
    'DriveTypeConst', 'TristateMixed', 'Volume', 'SystemFolder',
    'IFileSystem', 'IFileCollection', 'CompareMethod',
    'StandardStreamTypes', 'BinaryCompare', 'IDictionary', 'Normal',
    'TristateTrue', 'TristateFalse', 'Fixed', 'IFolderCollection',
    'Dictionary', 'Directory', 'Remote', 'Library', 'StdOut',
    'IOMode', '__MIDL___MIDL_itf_scrrun_0001_0001_0003',
    'UnknownType', 'WindowsFolder', 'Files', 'File', 'Tristate',
    'Alias', 'ForReading', 'SpecialFolderConst', 'ITextStream',
    'TristateUseDefault', 'IScriptEncoder',
    '__MIDL___MIDL_itf_scrrun_0001_0001_0001', 'Archive', 'Removable',
    'RamDisk', 'IDrive', 'TextStream', 'IFile', 'Drives', 'Folder',
    'Hidden', 'StdErr', 'Folders', 'TemporaryFolder', 'typelib_path',
    '__MIDL___MIDL_itf_scrrun_0000_0000_0001', 'ReadOnly', 'System',
    'IFileSystem3', 'ForWriting', 'Compressed',
    '__MIDL___MIDL_itf_scrrun_0001_0001_0002', 'StdIn', 'TextCompare',
    'DatabaseCompare', 'FileSystemObject', 'IFolder', 'Drive',
    'ForAppending'
]


```
↓
```py
from enum import IntFlag

import comtypes.gen._420B2830_E718_11CF_893D_00A0C9054228_0_1_0 as __wrapper_module__
from comtypes.gen._420B2830_E718_11CF_893D_00A0C9054228_0_1_0 import (
    Hidden, Volume, Alias, TextCompare, SystemFolder,
    FileSystemObject, Fixed, typelib_path, IDrive, IFile, IDictionary,
    CoClass, _lcid, ForWriting, RamDisk, StdIn, COMMETHOD, Removable,
    CDRom, Files, TristateUseDefault, Archive, TristateMixed,
    _check_version, WindowsFolder, Remote, DatabaseCompare,
    TextStream, IUnknown, helpstring, HRESULT, IFolderCollection,
    Encoder, ITextStream, Dictionary, Compressed, VARIANT, BSTR,
    IFileCollection, IDriveCollection, Folder, VARIANT_BOOL, Drives,
    Folders, System, StdOut, UnknownType, File, ForAppending, StdErr,
    ReadOnly, BinaryCompare, IFolder, IScriptEncoder, IFileSystem,
    Drive, Normal, Directory, ForReading, TristateTrue, IFileSystem3,
    Library, dispid, TemporaryFolder, TristateFalse, GUID
)


class __MIDL___MIDL_itf_scrrun_0001_0001_0003(IntFlag):
    StdIn = __wrapper_module__.StdIn
    StdOut = __wrapper_module__.StdOut
    StdErr = __wrapper_module__.StdErr


class CompareMethod(IntFlag):
    BinaryCompare = __wrapper_module__.BinaryCompare
    TextCompare = __wrapper_module__.TextCompare
    DatabaseCompare = __wrapper_module__.DatabaseCompare


class __MIDL___MIDL_itf_scrrun_0000_0000_0001(IntFlag):
    Normal = __wrapper_module__.Normal
    ReadOnly = __wrapper_module__.ReadOnly
    Hidden = __wrapper_module__.Hidden
    System = __wrapper_module__.System
    Volume = __wrapper_module__.Volume
    Directory = __wrapper_module__.Directory
    Archive = __wrapper_module__.Archive
    Alias = __wrapper_module__.Alias
    Compressed = __wrapper_module__.Compressed


class __MIDL___MIDL_itf_scrrun_0001_0001_0002(IntFlag):
    WindowsFolder = __wrapper_module__.WindowsFolder
    SystemFolder = __wrapper_module__.SystemFolder
    TemporaryFolder = __wrapper_module__.TemporaryFolder


class __MIDL___MIDL_itf_scrrun_0001_0001_0001(IntFlag):
    UnknownType = __wrapper_module__.UnknownType
    Removable = __wrapper_module__.Removable
    Fixed = __wrapper_module__.Fixed
    Remote = __wrapper_module__.Remote
    CDRom = __wrapper_module__.CDRom
    RamDisk = __wrapper_module__.RamDisk


class IOMode(IntFlag):
    ForReading = __wrapper_module__.ForReading
    ForWriting = __wrapper_module__.ForWriting
    ForAppending = __wrapper_module__.ForAppending


class Tristate(IntFlag):
    TristateTrue = __wrapper_module__.TristateTrue
    TristateFalse = __wrapper_module__.TristateFalse
    TristateUseDefault = __wrapper_module__.TristateUseDefault
    TristateMixed = __wrapper_module__.TristateMixed


StandardStreamTypes = __MIDL___MIDL_itf_scrrun_0001_0001_0003
FileAttribute = __MIDL___MIDL_itf_scrrun_0000_0000_0001
DriveTypeConst = __MIDL___MIDL_itf_scrrun_0001_0001_0001
SpecialFolderConst = __MIDL___MIDL_itf_scrrun_0001_0001_0002


__all__ = [
    'DriveTypeConst', 'FileAttribute', 'Hidden', 'Compressed',
    'SpecialFolderConst', '__MIDL___MIDL_itf_scrrun_0001_0001_0003',
    'StandardStreamTypes', 'Volume',
    '__MIDL___MIDL_itf_scrrun_0001_0001_0001', 'IFileCollection',
    'Alias', 'TextCompare', 'IDriveCollection', 'Folder',
    'SystemFolder', '__MIDL___MIDL_itf_scrrun_0000_0000_0001',
    'IOMode', 'FileSystemObject', 'Drives', 'Fixed', 'Folders',
    'typelib_path', 'IDrive', 'Tristate', 'System', 'StdOut', 'IFile',
    'UnknownType', 'File', 'IDictionary', 'ForAppending',
    'ForWriting', 'StdErr', 'CompareMethod', 'RamDisk', 'ReadOnly',
    'StdIn', '__MIDL___MIDL_itf_scrrun_0001_0001_0002',
    'BinaryCompare', 'Encoder', 'IFolder', 'IScriptEncoder',
    'Removable', 'IFileSystem', 'CDRom', 'Files',
    'TristateUseDefault', 'Drive', 'Archive', 'Normal',
    'TristateMixed', 'Directory', 'WindowsFolder', 'Remote',
    'DatabaseCompare', 'ForReading', 'TristateTrue', 'IFileSystem3',
    'Library', 'TextStream', 'TemporaryFolder', 'TristateFalse',
    'IFolderCollection', 'ITextStream', 'Dictionary'
]


```

<details>
<summary>(edited: code snippet was changed after merging #493)</summary>

Previous description:

```py
from comtypes.gen._420B2830_E718_11CF_893D_00A0C9054228_0_1_0 import (
    TextCompare, IFileSystem3, Fixed, StdIn,
    __MIDL___MIDL_itf_scrrun_0001_0001_0001, StdOut, IUnknown, CDRom,
    Files, _check_version, helpstring, System, Normal, StdErr,
    HRESULT, ForAppending, CompareMethod, typelib_path, ReadOnly,
    Alias, IOMode, VARIANT_BOOL, Removable, Library,
    TristateUseDefault, Drive, IDriveCollection, ForWriting, Encoder,
    IScriptEncoder, Directory, IFileCollection, _lcid, RamDisk,
    Dictionary, GUID, COMMETHOD, StandardStreamTypes, TristateTrue,
    SpecialFolderConst, IFile, Hidden, SystemFolder, IFileSystem,
    Archive, TextStream, IFolderCollection, FileAttribute,
    __MIDL___MIDL_itf_scrrun_0001_0001_0002, IDrive, FileSystemObject,
    BSTR, CoClass, BinaryCompare, TristateMixed, Remote, Tristate,
    Compressed, UnknownType, Drives, TemporaryFolder, VARIANT,
    DatabaseCompare, __MIDL___MIDL_itf_scrrun_0000_0000_0001,
    WindowsFolder, File, dispid, TristateFalse, IDictionary,
    ForReading, ITextStream, Folders,
    __MIDL___MIDL_itf_scrrun_0001_0001_0003, IFolder, Folder,
    DriveTypeConst, Volume
)


__all__ = [
    'TextCompare', 'StandardStreamTypes', 'IFileSystem3', 'Fixed',
    'StdIn', '__MIDL___MIDL_itf_scrrun_0001_0001_0001', 'StdOut',
    'CDRom', 'Files', 'TristateTrue', 'SpecialFolderConst', 'IFile',
    'Hidden', 'System', 'DriveTypeConst', 'Normal', 'SystemFolder',
    'Folder', 'IFileSystem', 'StdErr', 'Archive', 'ForAppending',
    'TextStream', 'IFolderCollection', 'CompareMethod',
    'FileAttribute', '__MIDL___MIDL_itf_scrrun_0001_0001_0002',
    'IDrive', 'FileSystemObject', 'typelib_path', 'ReadOnly',
    'BinaryCompare', 'TristateMixed', 'Remote', 'Tristate',
    'Compressed', 'UnknownType', 'Alias', 'Drives', 'Dictionary',
    'DatabaseCompare', '__MIDL___MIDL_itf_scrrun_0000_0000_0001',
    'IOMode', 'WindowsFolder', 'File', 'Library', 'TristateFalse',
    'IDictionary', 'ForReading', 'TristateUseDefault', 'ITextStream',
    'Drive', 'IDriveCollection', 'Folders', 'ForWriting', 'Encoder',
    '__MIDL___MIDL_itf_scrrun_0001_0001_0003', 'IScriptEncoder',
    'Directory', 'IFolder', 'IFileCollection', 'RamDisk',
    'TemporaryFolder', 'Removable', 'Volume'
]

```
↓
```py
from enum import IntFlag

from comtypes.gen import _420B2830_E718_11CF_893D_00A0C9054228_0_1_0
from comtypes.gen._420B2830_E718_11CF_893D_00A0C9054228_0_1_0 import (
    ForAppending, GUID, TristateMixed, Removable, Alias, Folders,
    IDriveCollection, CoClass, Remote, IFileSystem, DatabaseCompare,
    Compressed, ForWriting, Directory, UnknownType, VARIANT,
    typelib_path, ReadOnly, IFileCollection, StdIn, IFolder,
    helpstring, StdErr, Volume, SystemFolder, TemporaryFolder, _lcid,
    Fixed, Drive, IFileSystem3, System, BSTR, BinaryCompare, Folder,
    ITextStream, Hidden, Normal, COMMETHOD, CDRom, File, HRESULT,
    TristateFalse, IDrive, TristateUseDefault, Drives, RamDisk,
    IFolderCollection, Archive, IUnknown, TextCompare, Encoder,
    TristateTrue, dispid, IFile, Files, ForReading, IDictionary,
    TextStream, WindowsFolder, _check_version, StdOut, Dictionary,
    Library, VARIANT_BOOL, FileSystemObject, IScriptEncoder
)


class __MIDL___MIDL_itf_scrrun_0001_0001_0002(IntFlag):
    WindowsFolder = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.WindowsFolder
    SystemFolder = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.SystemFolder
    TemporaryFolder = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.TemporaryFolder


class IOMode(IntFlag):
    ForReading = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.ForReading
    ForWriting = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.ForWriting
    ForAppending = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.ForAppending


class Tristate(IntFlag):
    TristateTrue = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.TristateTrue
    TristateFalse = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.TristateFalse
    TristateUseDefault = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.TristateUseDefault
    TristateMixed = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.TristateMixed


class __MIDL___MIDL_itf_scrrun_0001_0001_0003(IntFlag):
    StdIn = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.StdIn
    StdOut = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.StdOut
    StdErr = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.StdErr


class __MIDL___MIDL_itf_scrrun_0000_0000_0001(IntFlag):
    Normal = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Normal
    ReadOnly = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.ReadOnly
    Hidden = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Hidden
    System = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.System
    Volume = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Volume
    Directory = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Directory
    Archive = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Archive
    Alias = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Alias
    Compressed = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Compressed


class CompareMethod(IntFlag):
    BinaryCompare = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.BinaryCompare
    TextCompare = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.TextCompare
    DatabaseCompare = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.DatabaseCompare


class __MIDL___MIDL_itf_scrrun_0001_0001_0001(IntFlag):
    UnknownType = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.UnknownType
    Removable = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Removable
    Fixed = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Fixed
    Remote = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.Remote
    CDRom = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.CDRom
    RamDisk = _420B2830_E718_11CF_893D_00A0C9054228_0_1_0.RamDisk


SpecialFolderConst = __MIDL___MIDL_itf_scrrun_0001_0001_0002
StandardStreamTypes = __MIDL___MIDL_itf_scrrun_0001_0001_0003
FileAttribute = __MIDL___MIDL_itf_scrrun_0000_0000_0001
DriveTypeConst = __MIDL___MIDL_itf_scrrun_0001_0001_0001


__all__ = [
    'ForAppending', 'Hidden', 'Normal',
    '__MIDL___MIDL_itf_scrrun_0001_0001_0003', 'CDRom', 'File',
    'TristateMixed', '__MIDL___MIDL_itf_scrrun_0000_0000_0001',
    'Removable', 'Alias', 'Tristate', 'TristateFalse', 'Folders',
    'IDrive', 'IDriveCollection', 'CompareMethod', 'Remote',
    'IFileSystem', 'TristateUseDefault', 'FileAttribute',
    'DatabaseCompare', 'Compressed',
    '__MIDL___MIDL_itf_scrrun_0001_0001_0001', 'Drives', 'ForWriting',
    'RamDisk', 'IOMode', 'IFolderCollection', 'Directory', 'Archive',
    'UnknownType', 'StandardStreamTypes', 'typelib_path', 'ReadOnly',
    'TextCompare', 'Encoder', 'TristateTrue', 'IFileCollection',
    'StdIn', 'IFolder', 'StdErr', 'Volume', 'IFile', 'SystemFolder',
    'SpecialFolderConst', 'TemporaryFolder', 'Files', 'ForReading',
    'Fixed', 'IDictionary', 'TextStream', 'Drive', 'IFileSystem3',
    'WindowsFolder', 'StdOut', 'System',
    '__MIDL___MIDL_itf_scrrun_0001_0001_0002', 'Dictionary',
    'BinaryCompare', 'DriveTypeConst', 'Folder', 'Library',
    'ITextStream', 'FileSystemObject', 'IScriptEncoder'
]
```

</details>

So far I have been trying to define enums in the wrapper modules.
However, the executable wrapper module code is generated relying on the enumeration type names are assigned as aliases of `c_int`.

Defining enumeration types in the friendly module does not affect the wrapper module implementation. And it is a low-cost implementation way.

This is backward-compatibility-breaking that changes symbols in the friendly modules previously imported as aliases of `c_int`.

There may be projects that still want to use these symbols (like `TgtEnum`) as aliases for `c_int` after this change.
But, in that case, changing the codebase as followings are able to correspond without much effort.
- from `from comtypes.gen.friendly import TgtEnum`
  - to `from comtypes.gen import friendly; TgtEnum = friendly.__wrapper_module__.TgtEnum`
  - to `TgtEnum = c_int`

<details>
<summary>(edited: explanation of alternatives was changed after merging #493)</summary>

Previous description:

There may be projects that still want to use these symbols as aliases for `c_int` after this change.
But, in that case, changing the code from `from comtypes.gen.friendly import TgtEnum` to `TgtEnum = c_int` is able to correspond without much effort.

</details>