### PR TITLE
change `_MemberSpec`s to `NamedTuple`s

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -744,9 +744,7 @@ def DISPPROPERTY(idlflags, proptype, name) -> _DispMemberSpec:
 #     )
 
 
-def COMMETHOD(
-    idlflags, restype, methodname, *argspec
-) -> _ComMemberSpec:
+def COMMETHOD(idlflags, restype, methodname, *argspec) -> _ComMemberSpec:
     """Specifies a COM method slot with idlflags.
 
     XXX should explain the sematics of the arguments.

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -47,7 +47,6 @@ from comtypes._memberspec import (
     _ComMemberSpec,
     DispMemberGenerator,
     _DispMemberSpec,
-    _ParamFlagType,
     _encode_idl,
     _resolve_argspec,
 )
@@ -721,7 +720,7 @@ class dispid(int):
 # instances with more methods or properties, and should not behave as an unpackable.
 
 
-def STDMETHOD(restype, name, argtypes=()) -> _ComMemberSpec[None]:
+def STDMETHOD(restype, name, argtypes=()) -> _ComMemberSpec:
     "Specifies a COM method slot without idlflags"
     return _ComMemberSpec(restype, name, argtypes, None, (), None)
 
@@ -747,7 +746,7 @@ def DISPPROPERTY(idlflags, proptype, name) -> _DispMemberSpec:
 
 def COMMETHOD(
     idlflags, restype, methodname, *argspec
-) -> _ComMemberSpec[tuple[_ParamFlagType, ...]]:
+) -> _ComMemberSpec:
     """Specifies a COM method slot with idlflags.
 
     XXX should explain the sematics of the arguments.

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -47,6 +47,7 @@ from comtypes._memberspec import (
     _ComMemberSpec,
     DispMemberGenerator,
     _DispMemberSpec,
+    _ParamFlagType,
     _encode_idl,
     _resolve_argspec,
 )
@@ -720,17 +721,17 @@ class dispid(int):
 # instances with more methods or properties, and should not behave as an unpackable.
 
 
-def STDMETHOD(restype, name, argtypes=()):
+def STDMETHOD(restype, name, argtypes=()) -> _ComMemberSpec[None]:
     "Specifies a COM method slot without idlflags"
     return _ComMemberSpec(restype, name, argtypes, None, (), None)
 
 
-def DISPMETHOD(idlflags, restype, name, *argspec):
+def DISPMETHOD(idlflags, restype, name, *argspec) -> _DispMemberSpec:
     "Specifies a method of a dispinterface"
     return _DispMemberSpec("DISPMETHOD", name, tuple(idlflags), restype, argspec)
 
 
-def DISPPROPERTY(idlflags, proptype, name):
+def DISPPROPERTY(idlflags, proptype, name) -> _DispMemberSpec:
     "Specifies a property of a dispinterface"
     return _DispMemberSpec("DISPPROPERTY", name, tuple(idlflags), proptype, ())
 
@@ -744,7 +745,9 @@ def DISPPROPERTY(idlflags, proptype, name):
 #     )
 
 
-def COMMETHOD(idlflags, restype, methodname, *argspec):
+def COMMETHOD(
+    idlflags, restype, methodname, *argspec
+) -> _ComMemberSpec[tuple[_ParamFlagType, ...]]:
     """Specifies a COM method slot with idlflags.
 
     XXX should explain the sematics of the arguments.

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -3,14 +3,12 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generic,
     Iterator,
     List,
     NamedTuple,
     Optional,
     Tuple,
     Type,
-    TypeVar,
     Union as _UnionT,
 )
 
@@ -85,16 +83,13 @@ def _resolve_argspec(
     return tuple(paramflags), tuple(argtypes)
 
 
-_PFs = TypeVar("_PFs", bound=Optional[Tuple[_ParamFlagType, ...]])
-
-
-class _ComMemberSpec(NamedTuple, Generic[_PFs]):
+class _ComMemberSpec(NamedTuple):
     """Specifier for a slot of COM method or property."""
 
     restype: Optional[Type[_CData]]
     name: str
     argtypes: Tuple[Type[_CData], ...]
-    paramflags: _PFs
+    paramflags: Optional[Tuple[_ParamFlagType, ...]]
     idlflags: Tuple[_UnionT[str, int], ...]
     doc: Optional[str]
 


### PR DESCRIPTION
#392 

In versions where `typing` is supported, it should be more elegant to use `NamedTuple` than to reproduce the `__iter__` behavior of the tuple in a custom class.

The `NamedTuple` has a [restriction on inheritance](https://github.com/python/cpython/blob/ce558e69d4087dd3653207de78345fbb8a2c7835/Lib/typing.py#L2670-L2675), so `_MemberSpec` cannot be used as the base class as before.

So the current `_MemberSpec` is a Union type of `_ComMemberSpec` and `_DispMemberSpec`.