### PR TITLE
split `DISPPARAMS` instantiation in `IDispatch.Invoke` method with `__make_dp` method

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -857,32 +857,21 @@ class IDispatch(IUnknown):
         _lcid = kw.pop("_lcid", 0)
         if kw:
             raise ValueError("named parameters not yet implemented")
-
+        array = (VARIANT * len(args))()
+        for i, a in enumerate(args[::-1]):
+            array[i].value = a
+        dp = DISPPARAMS()
+        dp.cArgs = len(args)
+        dp.rgvarg = array
         result = VARIANT()
         excepinfo = EXCEPINFO()
         argerr = c_uint()
 
         if _invkind in (DISPATCH_PROPERTYPUT, DISPATCH_PROPERTYPUTREF):  # propput
-            array = (VARIANT * len(args))()
-
-            for i, a in enumerate(args[::-1]):
-                array[i].value = a
-
-            dp = DISPPARAMS()
-            dp.cArgs = len(args)
             dp.cNamedArgs = 1
-            dp.rgvarg = array
             dp.rgdispidNamedArgs = pointer(DISPID(DISPID_PROPERTYPUT))
         else:
-            array = (VARIANT * len(args))()
-
-            for i, a in enumerate(args[::-1]):
-                array[i].value = a
-
-            dp = DISPPARAMS()
-            dp.cArgs = len(args)
             dp.cNamedArgs = 0
-            dp.rgvarg = array
 
         try:
             self.__com_Invoke(


### PR DESCRIPTION
#392

This is a simple method extraction refactoring that is keeping backward compatibility.

This change provides the following benefits:

- Improved Readability: The `Invoke` method is long and complex, the instantiation of the `DISPPARAMS` class within it was hard to understand. By splitting it into the `__make_dp` method, the `Invoke` method codebase becomes more concise and readable.

- Preparation for Future Enhancement: This change might serve as a preparation for the upcoming implementation of 'named arguments' mentioned in #371.