### PR TITLE
Support named args for dispmethod

### DIFF
--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -2,7 +2,7 @@ import ctypes
 from typing import Any, NamedTuple
 from typing import Dict, List, Tuple, Type
 from typing import Optional, Union as _UnionT
-from typing import Callable, Iterator
+from typing import Callable, Iterator, Sequence
 
 from comtypes import _CData
 import comtypes
@@ -43,7 +43,7 @@ def _unpack_argspec(
 
 
 def _resolve_argspec(
-    items: Tuple[_ArgSpecElmType, ...]
+    items: Sequence[_ArgSpecElmType],
 ) -> Tuple[Tuple[_ParamFlagType, ...], Tuple[Type[_CData], ...]]:
     """Unpacks and converts from argspec to paramflags and argtypes.
 

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -7,7 +7,10 @@ from ctypes import *
 from ctypes import _Pointer
 from _ctypes import CopyComPointer
 from ctypes.wintypes import DWORD, LONG, UINT, VARIANT_BOOL, WCHAR, WORD
-from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING, Type
+from typing import Any, ClassVar, overload, TYPE_CHECKING
+from typing import Optional, Union as _UnionT
+from typing import Dict, List, Tuple, Type
+from typing import Callable, Sequence
 
 from comtypes import _CData, BSTR, COMError, COMMETHOD, GUID, IID, IUnknown, STDMETHOD
 from comtypes.hresult import *
@@ -855,6 +858,24 @@ class IDispatch(IUnknown):
             memid, riid_null, lcid, invkind, dp, var, None, argerr
         )
         return var._get_value(dynamic=True)
+
+    @overload
+    def Invoke(
+        self, dispid: int, *args: Any, _invkind: int = ..., _lcid: int = ...
+    ) -> Any:
+        ...  # noqa
+
+    @overload
+    def Invoke(
+        self,
+        dispid: int,
+        *args: Any,
+        _argspec: Sequence["hints._ArgSpecElmType"],
+        _invkind: int = ...,
+        _lcid: int = ...,
+        **kw: Any,
+    ) -> Any:
+        ...  # noqa
 
     def Invoke(self, dispid: int, *args: Any, **kw: Any) -> Any:
         """Invoke a method or property."""

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -874,7 +874,7 @@ class IDispatch(IUnknown):
         """Invoke a method or property."""
 
         # Memory management in Dispatch::Invoke calls:
-        # http://msdn.microsoft.com/library/en-us/automat/htm/chap5_4x2q.asp
+        # https://learn.microsoft.com/en-us/previous-versions/windows/desktop/automat/passing-parameters
         # Quote:
         #     The *CALLING* code is responsible for releasing all strings and
         #     objects referred to by rgvarg[ ] or placed in *pVarResult.

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -32,6 +32,7 @@ from comtypes import IUnknown as IUnknown, GUID as GUID
 from comtypes.automation import IDispatch as IDispatch, VARIANT as VARIANT
 from comtypes.server import IClassFactory as IClassFactory
 from comtypes.typeinfo import ITypeInfo as ITypeInfo
+from comtypes._memberspec import _ArgSpecElmType as _ArgSpecElmType
 from comtypes._safearray import tagSAFEARRAY as tagSAFEARRAY
 
 Incomplete: TypeAlias = Any

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -32,7 +32,10 @@ from comtypes import IUnknown as IUnknown, GUID as GUID
 from comtypes.automation import IDispatch as IDispatch, VARIANT as VARIANT
 from comtypes.server import IClassFactory as IClassFactory
 from comtypes.typeinfo import ITypeInfo as ITypeInfo
-from comtypes._memberspec import _ArgSpecElmType as _ArgSpecElmType
+from comtypes._memberspec import (
+    _ArgSpecElmType as _ArgSpecElmType,
+    _ParamFlagType as _ParamFlagType,
+)
 from comtypes._safearray import tagSAFEARRAY as tagSAFEARRAY
 
 Incomplete: TypeAlias = Any

--- a/comtypes/test/test_DISPPARAMS.py
+++ b/comtypes/test/test_DISPPARAMS.py
@@ -40,5 +40,160 @@ class TestCase(ut.TestCase):
         self.assertEqual(dp.rgvarg[2].value, "foo")
 
 
+class Test_DispParamsGenerator(ut.TestCase):
+    def _get_rgvargs(self, dp):
+        return [dp.rgvarg[i].value for i in range(dp.cArgs)]
+
+    def test_invkind(self):
+        from comtypes.automation import (
+            DispParamsGenerator,
+            DISPATCH_METHOD,
+            DISPATCH_PROPERTYGET,
+            DISPATCH_PROPERTYPUT,
+            DISPATCH_PROPERTYPUTREF,
+            DISPID_PROPERTYPUT,
+        )
+
+        def _is_null(d):
+            return not bool(d)
+
+        def _is_dispid_propput(d):
+            return d.contents.value == DISPID_PROPERTYPUT
+
+        for invkind, id_validator, c_namedargs in [
+            (DISPATCH_METHOD, lambda d: not bool(d), 0),
+            (DISPATCH_PROPERTYGET, _is_null, 0),
+            (DISPATCH_PROPERTYPUT, _is_dispid_propput, 1),
+            (DISPATCH_PROPERTYPUTREF, _is_dispid_propput, 1),
+        ]:
+            with self.subTest(
+                invkind=invkind, id_validator=id_validator, c_namedargs=c_namedargs
+            ):
+                dp = DispParamsGenerator(invkind, ()).generate(9)
+                self.assertEqual(self._get_rgvargs(dp), [9])
+                self.assertTrue(id_validator(dp.rgdispidNamedArgs))
+                self.assertEqual(dp.cArgs, 1)
+                self.assertEqual(dp.cNamedArgs, c_namedargs)
+
+    def test_c_args(self):
+        from comtypes.automation import DispParamsGenerator, DISPATCH_METHOD
+
+        for args, c_args in [
+            ((), 0),
+            ((9,), 1),
+            (("foo", 3.14), 2),
+            ((2, "bar", 1.41), 3),
+        ]:
+            with self.subTest(args=args, c_args=c_args):
+                dp = DispParamsGenerator(DISPATCH_METHOD, ()).generate(*args)
+                self.assertEqual(dp.cArgs, c_args)
+
+    def test_no_argspec(self):
+        from comtypes.automation import DispParamsGenerator, DISPATCH_METHOD
+
+        gen = DispParamsGenerator(DISPATCH_METHOD, ())
+        for args, rgvargs in [
+            ((), []),
+            ((9,), [9]),
+            (("foo", 3.14), [3.14, "foo"]),
+            ((2, "bar", 1.41), [1.41, "bar", 2]),
+        ]:
+            with self.subTest(args=args, rgvargs=rgvargs):
+                dp = gen.generate(*args)
+                self.assertEqual(self._get_rgvargs(dp), rgvargs)
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(4, 3.14, "foo", a="spam")
+        self.assertEqual(ce.exception.args, ("got an unexpected keyword argument 'a'",))
+
+    def test_argspec_in_x2(self):
+        from comtypes.automation import DispParamsGenerator, DISPATCH_METHOD
+
+        IN = ["in"]
+        spec = ((IN, ..., "a"), (IN, ..., "b"))
+        gen = DispParamsGenerator(DISPATCH_METHOD, spec)  # type: ignore
+        self.assertEqual(self._get_rgvargs(gen.generate(3, 2.2)), [2.2, 3])
+        self.assertEqual(self._get_rgvargs(gen.generate(b=1.4, a=2)), [1.4, 2])
+        self.assertEqual(self._get_rgvargs(gen.generate(5, b=3.1)), [3.1, 5])
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(1, a=2)
+        self.assertEqual(ce.exception.args, ("got multiple values for argument 'a'",))
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(a=3)
+        self.assertEqual(
+            ce.exception.args, ("missing 1 required positional argument: 'b'",)
+        )
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(a=1, b=2, c=3)
+        self.assertEqual(ce.exception.args, ("got an unexpected keyword argument 'c'",))
+        # THOSE MIGHT RAISE `COMError` IN CALLER.
+        self.assertEqual(self._get_rgvargs(gen.generate()), [])
+        self.assertEqual(self._get_rgvargs(gen.generate(1, 2, 3)), [3, 2, 1])
+
+    def test_argspec_in_x1_and_optin_x1(self):
+        from comtypes.automation import DispParamsGenerator, DISPATCH_METHOD
+
+        IN, OPT_IN = ["in"], ["in", "optional"]
+        spec = ((IN, ..., "a"), (OPT_IN, ..., "b", "foo"))
+        gen = DispParamsGenerator(DISPATCH_METHOD, spec)  # type: ignore
+        self.assertEqual(self._get_rgvargs(gen.generate(2)), [2])
+        self.assertEqual(self._get_rgvargs(gen.generate(4, "bar")), ["bar", 4])
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(b="baz")
+        self.assertEqual(
+            ce.exception.args, ("missing 1 required positional argument: 'a'",)
+        )
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(4, "bar", b="baz")
+        self.assertEqual(ce.exception.args, ("got multiple values for argument 'b'",))
+
+    def test_argspec_in_x3(self):
+        from comtypes.automation import DispParamsGenerator, DISPATCH_METHOD
+
+        IN = ["in"]
+        spec = ((IN, ..., "a"), (IN, ..., "b"), (IN, ..., "c"), (IN, ..., "d"))
+        gen = DispParamsGenerator(DISPATCH_METHOD, spec)  # type: ignore
+        self.assertEqual(self._get_rgvargs(gen.generate(1, 2, 3, 4)), [4, 3, 2, 1])
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(d=4)
+        self.assertEqual(
+            ce.exception.args,
+            ("missing 3 required positional arguments: 'a', 'b' and 'c'",),
+        )
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(a=1, c=3)
+        self.assertEqual(
+            ce.exception.args,
+            ("missing 2 required positional arguments: 'b' and 'd'",),
+        )
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(1, b=2, d=4)
+        self.assertEqual(
+            ce.exception.args,
+            ("missing 1 required positional argument: 'c'",),
+        )
+
+    def test_argspec_optin_x3(self):
+        from comtypes.automation import DispParamsGenerator, DISPATCH_METHOD
+
+        OPT_IN = ["in", "optional"]
+        spec = (
+            (OPT_IN, ..., "a", 1),
+            (OPT_IN, ..., "b", 3.1),
+            (OPT_IN, ..., "c", "foo"),
+        )
+        gen = DispParamsGenerator(DISPATCH_METHOD, spec)  # type: ignore
+        self.assertEqual(self._get_rgvargs(gen.generate()), [])
+        self.assertEqual(self._get_rgvargs(gen.generate(a=2)), [2])
+        self.assertEqual(self._get_rgvargs(gen.generate(b=1.7)), [1.7, 1])
+        self.assertEqual(self._get_rgvargs(gen.generate(c="bar")), ["bar", 3.1, 1])
+        self.assertEqual(self._get_rgvargs(gen.generate(2, c="bar")), ["bar", 3.1, 2])
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(d=5)
+        self.assertEqual(ce.exception.args, ("got an unexpected keyword argument 'd'",))
+        with self.assertRaises(TypeError) as ce:
+            gen.generate(3, a=5)
+        self.assertEqual(ce.exception.args, ("got multiple values for argument 'a'",))
+
+
 if __name__ == "__main__":
     ut.main()

--- a/comtypes/test/test_namedargs.py
+++ b/comtypes/test/test_namedargs.py
@@ -1,0 +1,227 @@
+from _ctypes import COMError
+from pathlib import Path
+import tempfile
+import unittest as ut
+
+from comtypes import client
+from comtypes.automation import VARIANT
+
+# TODO: Add TestCase using non-env-specific typelib.
+
+
+class Test_Excel(ut.TestCase):
+    """for DispMethods"""
+
+    def setUp(self):
+        try:
+            client.GetModule(("{00020813-0000-0000-C000-000000000046}",))
+            from comtypes.gen import Excel
+
+            self.Excel = Excel
+            self.xl = client.CreateObject(
+                Excel.Application, interface=Excel._Application
+            )
+        except (ImportError, OSError):
+            self.skipTest("This depends on Excel.")
+
+    def tearDown(self):
+        # Close all open workbooks without saving, then quit excel.
+        for wb in self.xl.Workbooks:
+            wb.Close(0)
+        self.xl.Quit()
+        del self.xl
+
+    def test_range_value(self):
+        xl = self.xl
+        xl.Workbooks.Add()
+        xl.Range["A1:C1"].Value[()] = (10, "20", 31.4)
+        xl.Range["A2:C2"].Value[()] = ("x", "y", "z")
+        xl.Range["A3:C3"].Value[:] = ("3", "2", "1")
+        rng = xl.Range("A1:C3")
+        expected_values = ((10.0, 20.0, 31.4), ("x", "y", "z"), (3.0, 2.0, 1.0))
+        self.assertTrue(
+            rng.Value[self.Excel.xlRangeValueDefault]
+            == rng.Value(RangeValueDataType=self.Excel.xlRangeValueDefault)
+            == rng.Value(VARIANT.missing)
+            == rng.Value()
+            == expected_values
+        )
+        with self.assertRaises(TypeError):
+            rng.Value(
+                self.Excel.xlRangeValueDefault,
+                RangeValueDataType=self.Excel.xlRangeValueDefault,
+            )
+        with self.assertRaises(TypeError):
+            rng.Value(self.Excel.xlRangeValueDefault, Foo="Ham")
+        with self.assertRaises(TypeError):
+            rng.Value(Foo="Ham")
+
+    def test_range_address(self):
+        Excel = self.Excel
+        self.xl.Workbooks.Add()
+        rng = self.xl.Range("A1:C3")
+        self.assertTrue(
+            rng.Address()
+            == rng.Address(None)
+            == rng.Address[None, None]
+            == rng.Address(RowAbsolute=True)
+            == rng.Address(ColumnAbsolute=True)
+            == rng.Address(RowAbsolute=True, ColumnAbsolute=True)
+            == rng.Address(ColumnAbsolute=True, RowAbsolute=True)
+            == "$A$1:$C$3"
+        )
+        self.assertTrue(
+            rng.Address(RowAbsolute=False)
+            == rng.Address[False]
+            == rng.Address(ColumnAbsolute=True, RowAbsolute=False)
+            == "$A1:$C3"
+        )
+        self.assertTrue(
+            rng.Address[None, False]
+            == rng.Address(ColumnAbsolute=False)
+            == rng.Address(ColumnAbsolute=False, RowAbsolute=True)
+            == "A$1:C$3"
+        )
+        self.assertTrue(
+            rng.Address[None, None, self.Excel.xlR1C1]
+            == rng.Address(None, ReferenceStyle=self.Excel.xlR1C1)
+            == rng.Address(ReferenceStyle=self.Excel.xlR1C1)
+            == "R1C1:R3C3"
+        )
+        with self.assertRaises(TypeError):
+            rng.Address(Foo="Ham")
+        with self.assertRaises(COMError):
+            rng.Address(False, False, Excel.xlR1C1, False, self.xl.Range("D4"), False)
+        with self.assertRaises(TypeError):
+            rng.Address(
+                False, False, Excel.xlR1C1, False, self.xl.Range("D4"), Foo="Ham"
+            )
+        with self.assertRaises(TypeError):
+            rng.Address(
+                RowAbsolute=False,
+                ColumnAbsolute=False,
+                ReferenceStyle=Excel.xlR1C1,
+                External=False,
+                RelativeTo=self.xl.Range("D4"),
+                Foo="Ham",
+            )
+        with self.assertRaises(TypeError):
+            rng.Address(
+                RowAbsolute=False,
+                ColumnAbsolute=False,
+                ReferenceStyle=Excel.xlR1C1,
+                External=False,
+                Foo="Ham",
+            )
+
+    def test_range_autofill(self):
+        Excel = self.Excel
+        xl = self.xl
+        xl.Workbooks.Add()
+        xl.Range["A1:E1"].Value[()] = (1, 1, 1, 1, 1)
+        xl.Range["A2:E2"].Value[()] = (2, 2, 2, 2, 2)
+        xl.Range("A1").AutoFill(xl.Range("A1:A4"))
+        xl.Range("B1").AutoFill(xl.Range("B1:B4"), Excel.xlFillSeries)
+        xl.Range("C1:C2").AutoFill(xl.Range("C1:C4"), Excel.xlFillCopy)
+        xl.Range("C1:C2").AutoFill(xl.Range("C1:C4"), Type=Excel.xlFillCopy)
+        xl.Range("D1:D2").AutoFill(Destination=xl.Range("D1:D4"), Type=Excel.xlFillCopy)
+        xl.Range("E1:E3").AutoFill(Type=Excel.xlFillCopy, Destination=xl.Range("E1:E4"))
+        self.assertEqual(
+            xl.Range("A1:E4").Value(),
+            (
+                (1.0, 1.0, 1.0, 1.0, 1.0),
+                (1.0, 2.0, 2.0, 2.0, 2.0),
+                (1.0, 3.0, 1.0, 1.0, None),
+                (1.0, 4.0, 2.0, 2.0, 1.0),
+            ),
+        )
+        with self.assertRaises(COMError):
+            xl.Range("A1").AutoFill()
+        with self.assertRaises(TypeError):
+            xl.Range("B1").AutoFill(xl.Range("B1:B4"), Destination=xl.Range("B1:B4"))
+        with self.assertRaises(TypeError):
+            xl.Range("B1").AutoFill(Type=Excel.xlFillCopy)
+        with self.assertRaises(TypeError):
+            xl.Range("B1").AutoFill(
+                xl.Range("B1:B4"), Type=Excel.xlFillCopy, Foo="spam"
+            )
+
+
+class Test_IDictionary(ut.TestCase):
+    """for ComMethods"""
+
+    def setUp(self):
+        client.GetModule("scrrun.dll")
+        from comtypes.gen import Scripting
+
+        self.dic = client.CreateObject(
+            Scripting.Dictionary, interface=Scripting.IDictionary
+        )
+
+    def tearDown(self):
+        del self.dic
+
+    def test_takes_valid_args(self):
+        self.dic.Add(Key="foo", Item="spam")
+        self.dic.Add("bar", Item="ham")
+        self.dic.Add(Item="bacon", Key="baz")
+        self.dic.Add("qux", "egg")
+        self.assertEqual(set(self.dic.Keys()), {"foo", "bar", "baz", "qux"})
+        self.assertEqual(set(self.dic.Items()), {"spam", "ham", "bacon", "egg"})
+
+    def test_takes_invalid_args(self):
+        with self.assertRaises(TypeError):
+            self.dic.Add(Key="foo", Item="spam", Eric="Idle")
+        with self.assertRaises(TypeError):
+            self.dic.Add("foo", "spam", Eric="Idle")
+        with self.assertRaises(TypeError):
+            self.dic.Add("foo")
+
+
+class Test_FSO(ut.TestCase):
+    """for ComMethods"""
+
+    def setUp(self):
+        client.GetModule("scrrun.dll")
+        from comtypes.gen import Scripting
+
+        self.fso = client.CreateObject(
+            Scripting.FileSystemObject, interface=Scripting.IFileSystem
+        )
+
+    def tearDown(self):
+        del self.fso
+
+    def test_takes_valid_args(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp_dir = Path(t)
+            tmp_file = tmp_dir / "tmp.txt"
+            for args, kwargs in [
+                ((tmp_file.__fspath__(),), {}),
+                ((tmp_file.__fspath__(), True), {}),
+                ((tmp_file.__fspath__(),), {"Force": True}),
+                ((), {"FileSpec": tmp_file.__fspath__(), "Force": True}),
+                ((), {"Force": True, "FileSpec": tmp_file.__fspath__()}),
+            ]:
+                tmp_file.touch()
+                with self.subTest(args=args, kwargs=kwargs):
+                    self.fso.DeleteFile(*args, **kwargs)
+                    self.assertFalse(tmp_file.exists())
+
+    def test_takes_invalid_args(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp_dir = Path(t)
+            tmp_file = tmp_dir / "tmp.txt"
+            tmp_file.touch()
+            with self.assertRaises(TypeError):
+                self.fso.DeleteFile()
+            with self.assertRaises(TypeError):
+                self.fso.DeleteFile(Force=True)
+            with self.assertRaises(TypeError):
+                self.fso.DeleteFile(
+                    tmp_file.__fspath__(), FileSpec=tmp_file.__fspath__()
+                )
+
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
#371 

I was trying to implement the #400 functionality.
However, I realized that it is misleading to have a function annotation that allows named arguments to be accepted, since a dispmethod called via `IDispatch.Invoke` will raise an error when a named (with default value) argument is passed at runtime.

So, I improved the process of instantiating `DISPPARAMS` so that it can also accept named arguments in dispmethod.
Using `_argspec` passed to `IDispatch.Invoke`, it completes default values for optional arguments that were not passed, to ensure that the passed argument names are correct.

This added functionality is only triggered when named arguments are passed to dispmethod.
Same as before, when just only positional arguments are passed, the VARIANT array is assigned to `DISPPARAMS.rgvarg` in the reverse order.
Therefore, this change does not break backward compatibility.
In the case that an element of `argspec` is not what the newly added processing expects, and an error is raised when passing named arguments, it can be avoided by passing only positional arguments.

The `bound_named_property` has also been improved to allow passing named arguments.

As for testing, I used Excel to verify that it is possible to pass named arguments to a dispmethod.
I have Excel in my development environment, so I can run this test and make sure it passes.
However, AppVeyor CI does not have Excel, so I am not able to fully guarantee End2End operation with CI.
Instead, I generously cover the test of `DISPPARAMS` instantiation process, which can be executed independent of Excel and the environment.
commethod (and stdmethod) were originally designed to accept named arguments, but there were no tests to do so explicitly, so I added them.

If there is a dispmethod in an environment-independent library that can easily provide fixtures, I will try to test with that object as well, so I am looking for feedback.