### PR TITLE
importing the wrapper-module into the friendly-module using an abstracted name, `__wrapper_module__`

### DIFF
--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -74,6 +74,10 @@ class Test_GetModule(ut.TestCase):
         # NOTE: `WindowsInstaller`, which has `Patch` definition in dll.
         comtypes.client.GetModule("msi.dll")
 
+    def test_abstracted_wrapper_module_in_friendly_module(self):
+        mod = comtypes.client.GetModule("scrrun.dll")
+        self.assertTrue(hasattr(mod, "__wrapper_module__"))
+
     def test_raises_typerror_if_takes_unsupported(self):
         with self.assertRaises(TypeError):
             comtypes.client.GetModule(object())

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -589,6 +589,7 @@ class CodeGenerator(object):
         Such as "comtypes.gen.stdole" and "comtypes.gen.Excel".
         """
         output = io.StringIO()
+        print(f"import {modname} as __wrapper_module__", file=output)
         txtwrapper = textwrap.TextWrapper(
             subsequent_indent="    ", initial_indent="    ", break_long_words=False
         )


### PR DESCRIPTION
see #492 