### PR TITLE
add support for Python3.12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,8 @@ environment:
      - py: Python310-x64
      - py: Python311
      - py: Python311-x64
+     - py: Python312
+     - py: Python312-x64
 
 test_script:
    - C:\%py%\python.exe setup.py install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ environment:
      - py: Python312-x64
 
 test_script:
+   - C:\%py%\Scripts\pip.exe install --upgrade setuptools
    - C:\%py%\python.exe setup.py install
    - C:\%py%\Scripts\pip.exe uninstall comtypes -y
    - C:\%py%\python.exe test_pip_install.py

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,10 @@ import sys
 import os
 import subprocess
 
-from distutils.core import Command
-from distutils.command.install import install
-from setuptools import setup
+from setuptools import Command, setup
+from setuptools.command.install import install
+from setuptools.command.build_py import build_py
 
-from distutils.command.build_py import build_py
 
 with open('README.md') as readme_stream:
     readme = readme_stream.read()


### PR DESCRIPTION
Appveyor's `Visual Studio 2022` image now supports Python 3.12 (https://github.com/appveyor/ci/issues/3879#issuecomment-1786252102).

CI for this package can now also be run with the new Python.

I want to make sure that the test passes and that `comtypes` works with Python 3.12.

Edited:
As per https://peps.python.org/pep-0632/, `distutils` has been removed starting from Python 3.12, so `setup.py` was changed.