### PR TITLE
Fix `TypeError` when defining enumeration types

### DIFF
--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -74,6 +74,16 @@ class Test_GetModule(ut.TestCase):
         # NOTE: `WindowsInstaller`, which has `Patch` definition in dll.
         comtypes.client.GetModule("msi.dll")
 
+    def test_the_name_of_the_enum_member_and_the_coclass_are_duplicated(self):
+        # NOTE: In `MSHTML`, the name `htmlInputImage` is used both as a member of
+        # the `_htmlInput` enum type and as a CoClass that has `IHTMLElement` and
+        # others as interfaces.
+        # If a CoClass is assigned where an integer should be assigned, such as in
+        # the definition of an enumeration, the generation of the module will fail.
+        # See also https://github.com/enthought/comtypes/issues/524
+        with contextlib.redirect_stdout(None):  # supress warnings
+            comtypes.client.GetModule("mshtml.tlb")
+
     def test_abstracted_wrapper_module_in_friendly_module(self):
         mod = comtypes.client.GetModule("scrrun.dll")
         self.assertTrue(hasattr(mod, "__wrapper_module__"))

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -671,7 +671,7 @@ class CodeGenerator(object):
         tp_name = self._to_type_name(tp)
         print("%s = %d" % (tp_name, value), file=self.stream)
         if tp.enumeration.name:
-            self.enums.add(tp.enumeration.name, tp_name)
+            self.enums.add(tp.enumeration.name, tp_name, value)
         self.names.add(tp_name)
 
     def Enumeration(self, tp: typedesc.Enumeration) -> None:
@@ -1546,28 +1546,28 @@ class DeclaredNamespaces(object):
 
 class EnumerationNamespaces(object):
     def __init__(self):
-        self.data: Dict[str, List[str]] = {}
+        self.data: Dict[str, List[Tuple[str, int]]] = {}
 
-    def add(self, enum_name: str, member_name: str) -> None:
+    def add(self, enum_name: str, member_name: str, value: int) -> None:
         """Adds a namespace will be enumeration and its member.
 
         Examples:
             >>> enums = EnumerationNamespaces()
-            >>> enums.add('Foo', 'ham')
-            >>> enums.add('Foo', 'spam')
-            >>> enums.add('Bar', 'bacon')
+            >>> enums.add('Foo', 'ham', 1)
+            >>> enums.add('Foo', 'spam', 2)
+            >>> enums.add('Bar', 'bacon', 3)
             >>> assert 'Foo' in enums
             >>> assert 'Baz' not in enums
             >>> print(enums.getvalue())  # <BLANKLINE> is necessary for doctest
             class Foo(IntFlag):
-                ham = __wrapper_module__.ham
-                spam = __wrapper_module__.spam
+                ham = 1
+                spam = 2
             <BLANKLINE>
             <BLANKLINE>
             class Bar(IntFlag):
-                bacon = __wrapper_module__.bacon
+                bacon = 3
         """
-        self.data.setdefault(enum_name, []).append(member_name)
+        self.data.setdefault(enum_name, []).append((member_name, value))
 
     def __contains__(self, item: str) -> bool:
         return item in self.data
@@ -1580,7 +1580,7 @@ class EnumerationNamespaces(object):
         for enum_name, enum_members in self.data.items():
             lines = []
             lines.append(f"class {enum_name}(IntFlag):")
-            for member_name in enum_members:
-                lines.append(f"    {member_name} = __wrapper_module__.{member_name}")
+            for member_name, value in enum_members:
+                lines.append(f"    {member_name} = {value}")
             blocks.append("\n".join(lines))
         return "\n\n\n".join(blocks)


### PR DESCRIPTION
This is a patch to prevent the `TypeError` reported in https://github.com/enthought/comtypes/issues/524#issuecomment-2045252482.

In `comtypes`, names of enumeration members are also used as names for constants at the wrapper module level. 
Leveraging this feature, the functionality to define enumeration types within friendly modules was implemented in #475.

However, some COM libraries have duplicated names between enumeration members and CoClass or Interface names.
In other words, integers may not be assigned to these names, they may actually be of a different type. 
When such a situation occurs and `comtypes` attempt to assign a non-integer object to the value of an enumeration member, a `TypeError` is raised.

In this PR, for resolving the aforementioned issue, `comtypes` assigns the integer literal values to the members of the enumeration types instead of referencing the namespace defined within the wrapper module.