### PR TITLE
Define constants and `c_int` aliases earlier than others in wrapper modules

### DIFF
--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -82,7 +82,12 @@ class Test_GetModule(ut.TestCase):
         # the definition of an enumeration, the generation of the module will fail.
         # See also https://github.com/enthought/comtypes/issues/524
         with contextlib.redirect_stdout(None):  # supress warnings
-            comtypes.client.GetModule("mshtml.tlb")
+            mshtml = comtypes.client.GetModule("mshtml.tlb")
+        # When the member of an enumeration and a CoClass have the same name,
+        # the defined later one is assigned to the name in the module.
+        # By asserting whether the CoClass is assigned to that name, it ensures
+        # that the member of the enumeration is defined earlier.
+        self.assertTrue(issubclass(mshtml.htmlInputImage, comtypes.CoClass))
 
     def test_abstracted_wrapper_module_in_friendly_module(self):
         mod = comtypes.client.GetModule("scrrun.dll")


### PR DESCRIPTION
I have noticed something while fixing the bug reported in #524.

In the wrapper module, members of an enumeration are defined as module-level constants.
If they have the same name as a previously defined interface or CoClass, it will overwrite the definition.

The order of type information parsed from the COM library is optimized for the environment, so it is not always fixed.
In other words, symbols with duplicate names cannot be identified as to what type or value they are until the module is generated.

To ensure that the values of constants do not overwrite interfaces or CoClasses, codegenerator generates the codebase that defines the constants before them.