### PR TITLE
Determine whether a COM interface is one of the known symbols not only by its name but also by using its iid

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -186,8 +186,8 @@ def _create_module(modulename: str, code: str) -> types.ModuleType:
 
 class ModuleGenerator(object):
     def __init__(self, tlib: typeinfo.ITypeLib, pathname: Optional[str]) -> None:
-        known_symbols, _ = _get_known_namespaces()
-        self.codegen = codegenerator.CodeGenerator(known_symbols)
+        known_symbols, known_interfaces = _get_known_namespaces()
+        self.codegen = codegenerator.CodeGenerator(known_symbols, known_interfaces)
         self.wrapper_name = codegenerator.name_wrapper_module(tlib)
         self.friendly_name = codegenerator.name_friendly_module(tlib)
         if pathname is None:

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -59,12 +59,17 @@ class Test_GetModule(ut.TestCase):
         mod = comtypes.client.GetModule(typeinfo.LoadTypeLibEx("scrrun.dll"))
         self.assertIs(mod, Scripting)
 
-    def test_imports_IEnumVARIANT_from_other_generated_modules(self):
+    def test_mscorlib(self):
         # NOTE: `codegenerator` generates code that contains unused imports,
         # but removing them are attracting wierd bugs in library-wrappers
         # which depend on externals.
-        # NOTE: `mscorlib`, which imports `IEnumVARIANT` from `stdole`.
-        comtypes.client.GetModule(("{BED7F4EA-1A96-11D2-8F08-00A0C9A6186D}",))
+        # `mscorlib` imports `stdole` wrapper module and refers`IEnumVARIANT` from it.
+        mod = comtypes.client.GetModule(("{BED7F4EA-1A96-11D2-8F08-00A0C9A6186D}",))
+        # NOTE: `ModuleGenerator` treats the `ctypes._Pointer` base class for pointers
+        # as one of the known symbols, but `mscorlib` has the `_Pointer` com interface.
+        # Even though they have the same name, `codegenerator` generates code to define
+        # the `_Pointer` interface, rather than importing `_Pointer` from `ctypes`.
+        self.assertTrue(issubclass(mod._Pointer, comtypes.IUnknown))
 
     def test_no_replacing_Patch_namespace(self):
         # NOTE: An object named `Patch` is defined in some dll.


### PR DESCRIPTION
While fixing the bug reported in #524, I noticed something.

If there is an interface in the COM type library with the same name as a symbol defined in `ctypes` or `ctypes.wintypes`, the `codegenerator` can only identify the symbol by its name, which leads to the symbol being imported and used inappropriately.

To prevent this confusion, the `codegenerator` will now determine whether a COM interface is one of the known symbols not only by its name but also by using its iid.