### PR TITLE
Determine whether a disp interface is one of the known symbols not only by its name but also by using its iid

### DIFF
--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -23,8 +23,10 @@ else:
     from typing_extensions import Protocol
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec, TypeAlias
+    from typing import TypeGuard as TypeGuard
 else:
     from typing_extensions import Concatenate, ParamSpec, TypeAlias
+    from typing_extensions import TypeGuard as TypeGuard
 if sys.version_info >= (3, 11):
     from typing import Self
 else:

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -467,6 +467,32 @@ class CodeGenerator(object):
             self.done.add(item)  # to avoid infinite recursion.
             self.ComInterface(item)
             return
+        if isinstance(item, typedesc.DispInterfaceHead):
+            if self._is_known_interface(item.itf):
+                self.imports.add(item.itf.name, symbols=self.known_symbols)
+                self.done.add(item)
+                return
+            self.done.add(item)
+            self.DispInterfaceHead(item)
+            return
+        if isinstance(item, typedesc.DispInterfaceBody):
+            if self._is_known_interface(item.itf):
+                self.imports.add(item.itf.name, symbols=self.known_symbols)
+                self.done.add(item)
+                return
+            self.done.add(item)
+            self.DispInterfaceBody(item)
+            return
+        if isinstance(item, typedesc.DispInterface):
+            if self._is_known_interface(item):
+                self.imports.add(item.name, symbols=self.known_symbols)
+                self.done.add(item)
+                self.done.add(item.get_head())
+                self.done.add(item.get_body())
+                return
+            self.done.add(item)  # to avoid infinite recursion.
+            self.DispInterface(item)
+            return
         if isinstance(item, typedesc.StructureHead):
             name = getattr(item.struct, "name", None)
         else:
@@ -1103,7 +1129,9 @@ class CodeGenerator(object):
         self.generate(itf.get_body())
         self.names.add(itf.name)
 
-    def _is_known_interface(self, item: typedesc.ComInterface) -> bool:
+    def _is_known_interface(
+        self, item: _UnionT[typedesc.ComInterface, typedesc.DispInterface]
+    ) -> bool:
         """Returns whether an interface is statically defined in `comtypes`,
         based on its name and iid.
         """

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -176,7 +176,7 @@ class ComInterface(object):
         self,
         name: str,
         members: List[ComMethod],
-        base: Any,
+        base: "Optional[ComInterface]",
         iid: str,
         idlflags: List[str],
     ) -> None:


### PR DESCRIPTION
As in https://github.com/enthought/comtypes/pull/529, I have also implemented the same thing for disp interfaces, not only com interfaces.