### PR TITLE
Refactoring `test_findgendir`

### DIFF
--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -42,9 +42,9 @@ class Test(unittest.TestCase):
 
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache
-        template = r"$APPDATA\Python\Python%d%d\comtypes_cache"
         ma, mi = sys.version_info[:2]
-        path = os.path.expandvars(template % (ma, mi))
+        cache = r"$APPDATA\Python\Python%d%d\comtypes_cache" % (ma, mi)
+        path = os.path.expandvars(cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 
@@ -54,10 +54,8 @@ class Test(unittest.TestCase):
         ma, mi = sys.version_info[:2]
         # %TEMP%\comtypes_cache\<imagebasename>-25
         # the image is python25.dll
-        path = os.path.join(
-            tempfile.gettempdir(),
-            r"comtypes_cache\%s%d%d-%d%d" % (IMGBASE, ma, mi, ma, mi),
-        )
+        cache = r"comtypes_cache\%s%d%d-%d%d" % (IMGBASE, ma, mi, ma, mi)
+        path = os.path.join(tempfile.gettempdir(), cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 
@@ -65,10 +63,8 @@ class Test(unittest.TestCase):
         sys.frozen = "console_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
         ma, mi = sys.version_info[:2]
-        path = os.path.join(
-            tempfile.gettempdir(),
-            r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi),
-        )
+        cache = r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi)
+        path = os.path.join(tempfile.gettempdir(), cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 
@@ -76,10 +72,8 @@ class Test(unittest.TestCase):
         sys.frozen = "windows_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
         ma, mi = sys.version_info[:2]
-        path = os.path.join(
-            tempfile.gettempdir(),
-            r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi),
-        )
+        cache = r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi)
+        path = os.path.join(tempfile.gettempdir(), cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -1,8 +1,10 @@
+import contextlib
 import importlib
 import os
 import sys
 import tempfile
 import types
+from typing import Iterator
 import unittest
 from unittest import mock
 
@@ -14,34 +16,32 @@ import comtypes.gen
 IMGBASE = os.path.splitext(os.path.basename(sys.executable))[0]
 
 
+@contextlib.contextmanager
+def patch_empty_module_to_comtypes_gen() -> Iterator[types.ModuleType]:
+    with mock.patch.dict(sys.modules):
+        del sys.modules["comtypes.gen"]
+        mod = sys.modules["comtypes.gen"] = types.ModuleType("comtypes.gen")
+        mod.__path__ = []
+        with mock.patch.object(comtypes, "gen", mod):
+            try:
+                yield mod
+            finally:
+                importlib.reload(comtypes.gen)
+
+
 class Test(unittest.TestCase):
     """Test the comtypes.client._find_gen_dir() function in several
     simulated environments.
     """
-
-    def setUp(self):
-        # save the original comtypes.gen modules and create a
-        # substitute with an empty __path__.
-        self.orig_comtypesgen = sys.modules["comtypes.gen"]
-        del sys.modules["comtypes.gen"]
-        del comtypes.gen
-        mod = sys.modules["comtypes.gen"] = types.ModuleType("comtypes.gen")
-        mod.__path__ = []
-        comtypes.gen = mod
-
-    def tearDown(self):
-        # restore the original comtypes.gen module
-        comtypes.gen = self.orig_comtypesgen
-        sys.modules["comtypes.gen"] = self.orig_comtypesgen
-        importlib.reload(comtypes.gen)
 
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache
         ma, mi = sys.version_info[:2]
         cache = rf"$APPDATA\Python\Python{ma:d}{mi:d}\comtypes_cache"
         path = os.path.expandvars(cache)
-        gen_dir = comtypes.client._find_gen_dir()
-        self.assertEqual(path, gen_dir)
+        with patch_empty_module_to_comtypes_gen():
+            gen_dir = comtypes.client._find_gen_dir()
+            self.assertEqual(path, gen_dir)
 
     # patch py2exe-attributes to `sys` modules
     @mock.patch.object(sys, "frozen", "dll", create=True)
@@ -52,8 +52,9 @@ class Test(unittest.TestCase):
         ma, mi = sys.version_info[:2]
         cache = rf"comtypes_cache\{IMGBASE}{ma:d}{mi:d}-{ma:d}{mi:d}"
         path = os.path.join(tempfile.gettempdir(), cache)
-        gen_dir = comtypes.client._find_gen_dir()
-        self.assertEqual(path, gen_dir)
+        with patch_empty_module_to_comtypes_gen():
+            gen_dir = comtypes.client._find_gen_dir()
+            self.assertEqual(path, gen_dir)
 
     # patch py2exe-attributes to `sys` modules
     @mock.patch.object(sys, "frozen", "console_exe", create=True)
@@ -62,8 +63,9 @@ class Test(unittest.TestCase):
         ma, mi = sys.version_info[:2]
         cache = rf"comtypes_cache\{IMGBASE}-{ma:d}{mi:d}"
         path = os.path.join(tempfile.gettempdir(), cache)
-        gen_dir = comtypes.client._find_gen_dir()
-        self.assertEqual(path, gen_dir)
+        with patch_empty_module_to_comtypes_gen():
+            gen_dir = comtypes.client._find_gen_dir()
+            self.assertEqual(path, gen_dir)
 
     # patch py2exe-attributes to `sys` modules
     @mock.patch.object(sys, "frozen", "windows_exe", create=True)
@@ -72,8 +74,9 @@ class Test(unittest.TestCase):
         ma, mi = sys.version_info[:2]
         cache = rf"comtypes_cache\{IMGBASE}-{ma:d}{mi:d}"
         path = os.path.join(tempfile.gettempdir(), cache)
-        gen_dir = comtypes.client._find_gen_dir()
-        self.assertEqual(path, gen_dir)
+        with patch_empty_module_to_comtypes_gen():
+            gen_dir = comtypes.client._find_gen_dir()
+            self.assertEqual(path, gen_dir)
 
 
 def main():

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -43,7 +43,7 @@ class Test(unittest.TestCase):
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache
         ma, mi = sys.version_info[:2]
-        cache = r"$APPDATA\Python\Python%d%d\comtypes_cache" % (ma, mi)
+        cache = rf"$APPDATA\Python\Python{ma:d}{mi:d}\comtypes_cache"
         path = os.path.expandvars(cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
@@ -51,10 +51,10 @@ class Test(unittest.TestCase):
     def test_frozen_dll(self):
         sys.frozen = "dll"
         sys.frozendllhandle = sys.dllhandle
-        ma, mi = sys.version_info[:2]
-        # %TEMP%\comtypes_cache\<imagebasename>-25
+        # %TEMP%\comtypes_cache\<imagebasename>25-25
         # the image is python25.dll
-        cache = r"comtypes_cache\%s%d%d-%d%d" % (IMGBASE, ma, mi, ma, mi)
+        ma, mi = sys.version_info[:2]
+        cache = rf"comtypes_cache\{IMGBASE}{ma:d}{mi:d}-{ma:d}{mi:d}"
         path = os.path.join(tempfile.gettempdir(), cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
@@ -63,7 +63,7 @@ class Test(unittest.TestCase):
         sys.frozen = "console_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
         ma, mi = sys.version_info[:2]
-        cache = r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi)
+        cache = rf"comtypes_cache\{IMGBASE}-{ma:d}{mi:d}"
         path = os.path.join(tempfile.gettempdir(), cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
@@ -72,7 +72,7 @@ class Test(unittest.TestCase):
         sys.frozen = "windows_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
         ma, mi = sys.version_info[:2]
-        cache = r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi)
+        cache = rf"comtypes_cache\{IMGBASE}-{ma:d}{mi:d}"
         path = os.path.join(tempfile.gettempdir(), cache)
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -10,7 +10,7 @@ import comtypes.client
 import comtypes.gen
 
 
-imgbase = os.path.splitext(os.path.basename(sys.executable))[0]
+IMGBASE = os.path.splitext(os.path.basename(sys.executable))[0]
 
 
 class Test(unittest.TestCase):
@@ -55,7 +55,7 @@ class Test(unittest.TestCase):
         # the image is python25.dll
         path = os.path.join(
             tempfile.gettempdir(),
-            r"comtypes_cache\%s%d%d-%d%d" % (imgbase, ma, mi, ma, mi),
+            r"comtypes_cache\%s%d%d-%d%d" % (IMGBASE, ma, mi, ma, mi),
         )
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
@@ -66,7 +66,7 @@ class Test(unittest.TestCase):
         path = os.path.join(
             tempfile.gettempdir(),
             r"comtypes_cache\%s-%d%d"
-            % (imgbase, sys.version_info[0], sys.version_info[1]),
+            % (IMGBASE, sys.version_info[0], sys.version_info[1]),
         )
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
@@ -77,7 +77,7 @@ class Test(unittest.TestCase):
         path = os.path.join(
             tempfile.gettempdir(),
             r"comtypes_cache\%s-%d%d"
-            % (imgbase, sys.version_info[0], sys.version_info[1]),
+            % (IMGBASE, sys.version_info[0], sys.version_info[1]),
         )
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import sys
 import tempfile
@@ -8,10 +9,6 @@ import comtypes
 import comtypes.client
 import comtypes.gen
 
-if sys.version_info >= (3, 4):
-    from importlib import reload
-else:
-    from imp import reload
 
 imgbase = os.path.splitext(os.path.basename(sys.executable))[0]
 
@@ -41,7 +38,7 @@ class Test(unittest.TestCase):
         # restore the original comtypes.gen module
         comtypes.gen = self.orig_comtypesgen
         sys.modules["comtypes.gen"] = self.orig_comtypesgen
-        reload(comtypes.gen)
+        importlib.reload(comtypes.gen)
 
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import types
 import unittest
+from unittest import mock
 
 import comtypes
 import comtypes.client
@@ -29,12 +30,6 @@ class Test(unittest.TestCase):
         comtypes.gen = mod
 
     def tearDown(self):
-        # Delete py2exe-attributes that we have attached to the sys module
-        for name in "frozen frozendllhandle".split():
-            try:
-                delattr(sys, name)
-            except AttributeError:
-                pass
         # restore the original comtypes.gen module
         comtypes.gen = self.orig_comtypesgen
         sys.modules["comtypes.gen"] = self.orig_comtypesgen
@@ -48,9 +43,10 @@ class Test(unittest.TestCase):
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 
+    # patch py2exe-attributes to `sys` modules
+    @mock.patch.object(sys, "frozen", "dll", create=True)
+    @mock.patch.object(sys, "frozendllhandle", sys.dllhandle, create=True)
     def test_frozen_dll(self):
-        sys.frozen = "dll"
-        sys.frozendllhandle = sys.dllhandle
         # %TEMP%\comtypes_cache\<imagebasename>25-25
         # the image is python25.dll
         ma, mi = sys.version_info[:2]
@@ -59,8 +55,9 @@ class Test(unittest.TestCase):
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 
+    # patch py2exe-attributes to `sys` modules
+    @mock.patch.object(sys, "frozen", "console_exe", create=True)
     def test_frozen_console_exe(self):
-        sys.frozen = "console_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
         ma, mi = sys.version_info[:2]
         cache = rf"comtypes_cache\{IMGBASE}-{ma:d}{mi:d}"
@@ -68,8 +65,9 @@ class Test(unittest.TestCase):
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 
+    # patch py2exe-attributes to `sys` modules
+    @mock.patch.object(sys, "frozen", "windows_exe", create=True)
     def test_frozen_windows_exe(self):
-        sys.frozen = "windows_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
         ma, mi = sys.version_info[:2]
         cache = rf"comtypes_cache\{IMGBASE}-{ma:d}{mi:d}"

--- a/comtypes/test/test_findgendir.py
+++ b/comtypes/test/test_findgendir.py
@@ -43,7 +43,8 @@ class Test(unittest.TestCase):
     def test_script(self):
         # %APPDATA%\Python\Python25\comtypes_cache
         template = r"$APPDATA\Python\Python%d%d\comtypes_cache"
-        path = os.path.expandvars(template % sys.version_info[:2])
+        ma, mi = sys.version_info[:2]
+        path = os.path.expandvars(template % (ma, mi))
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
 
@@ -63,10 +64,10 @@ class Test(unittest.TestCase):
     def test_frozen_console_exe(self):
         sys.frozen = "console_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
+        ma, mi = sys.version_info[:2]
         path = os.path.join(
             tempfile.gettempdir(),
-            r"comtypes_cache\%s-%d%d"
-            % (IMGBASE, sys.version_info[0], sys.version_info[1]),
+            r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi),
         )
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)
@@ -74,10 +75,10 @@ class Test(unittest.TestCase):
     def test_frozen_windows_exe(self):
         sys.frozen = "windows_exe"
         # %TEMP%\comtypes_cache\<imagebasename>-25
+        ma, mi = sys.version_info[:2]
         path = os.path.join(
             tempfile.gettempdir(),
-            r"comtypes_cache\%s-%d%d"
-            % (IMGBASE, sys.version_info[0], sys.version_info[1]),
+            r"comtypes_cache\%s-%d%d" % (IMGBASE, ma, mi),
         )
         gen_dir = comtypes.client._find_gen_dir()
         self.assertEqual(path, gen_dir)


### PR DESCRIPTION
This is a reintroduce of the patch approach which is used in `test_client_regenerate_modules` I wrote in #533.

`test_findgendir` was written at a time when `unittest.mock.patch` was not supported in the standard library, so the temporary patch approach was classical.

While my memory of the `sys.modules` and import system is still fresh, I refactored these test codebases.