### PR TITLE
add `groupby_impltypeflags`

### DIFF
--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1054,7 +1054,7 @@ class CodeGenerator(object):
 
         for itf, _ in coclass.interfaces:
             self.generate(itf.get_head())
-        impl, src = groupby_impltypeflags(coclass.interfaces)
+        impl, src = typedesc.groupby_impltypeflags(coclass.interfaces)
         implemented = [self._to_type_name(itf) for itf in impl]
         sources = [self._to_type_name(itf) for itf in src]
 
@@ -1392,24 +1392,6 @@ class CodeGenerator(object):
         gen = DispPropertyGenerator(prop)
         print(gen.generate(), file=self.stream)
         self.last_item_class = False
-
-
-def groupby_impltypeflags(seq):
-    implemented = []
-    sources = []
-    for itf, impltypeflags in seq:
-        if impltypeflags & typeinfo.IMPLTYPEFLAG_FSOURCE:
-            # source interface
-            where = sources
-        else:
-            # sink interface
-            where = implemented
-        if impltypeflags & typeinfo.IMPLTYPEFLAG_FDEFAULT:
-            # The default interface should be the first item on the list
-            where.insert(0, itf)
-        else:
-            where.append(itf)
-    return implemented, sources
 
 
 class TypeNamer(object):

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1056,19 +1056,19 @@ class CodeGenerator(object):
             self.generate(itf.get_head())
         implemented = []
         sources = []
-        for item in coclass.interfaces:
+        for itf, impltypeflags in coclass.interfaces:
             # item is (interface class, impltypeflags)
-            if item[1] & typeinfo.IMPLTYPEFLAG_FSOURCE:
+            if impltypeflags & typeinfo.IMPLTYPEFLAG_FSOURCE:
                 # source interface
                 where = sources
             else:
                 # sink interface
                 where = implemented
-            if item[1] & typeinfo.IMPLTYPEFLAG_FDEFAULT:
+            if impltypeflags & typeinfo.IMPLTYPEFLAG_FDEFAULT:
                 # The default interface should be the first item on the list
-                where.insert(0, self._to_type_name(item[0]))
+                where.insert(0, self._to_type_name(itf))
             else:
-                where.append(self._to_type_name(item[0]))
+                where.append(self._to_type_name(itf))
 
         if implemented:
             self.last_item_class = False

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1054,21 +1054,9 @@ class CodeGenerator(object):
 
         for itf, _ in coclass.interfaces:
             self.generate(itf.get_head())
-        implemented = []
-        sources = []
-        for itf, impltypeflags in coclass.interfaces:
-            # item is (interface class, impltypeflags)
-            if impltypeflags & typeinfo.IMPLTYPEFLAG_FSOURCE:
-                # source interface
-                where = sources
-            else:
-                # sink interface
-                where = implemented
-            if impltypeflags & typeinfo.IMPLTYPEFLAG_FDEFAULT:
-                # The default interface should be the first item on the list
-                where.insert(0, self._to_type_name(itf))
-            else:
-                where.append(self._to_type_name(itf))
+        impl, src = groupby_impltypeflags(coclass.interfaces)
+        implemented = [self._to_type_name(itf) for itf in impl]
+        sources = [self._to_type_name(itf) for itf in src]
 
         if implemented:
             self.last_item_class = False
@@ -1404,6 +1392,24 @@ class CodeGenerator(object):
         gen = DispPropertyGenerator(prop)
         print(gen.generate(), file=self.stream)
         self.last_item_class = False
+
+
+def groupby_impltypeflags(seq):
+    implemented = []
+    sources = []
+    for itf, impltypeflags in seq:
+        if impltypeflags & typeinfo.IMPLTYPEFLAG_FSOURCE:
+            # source interface
+            where = sources
+        else:
+            # sink interface
+            where = implemented
+        if impltypeflags & typeinfo.IMPLTYPEFLAG_FDEFAULT:
+            # The default interface should be the first item on the list
+            where.insert(0, itf)
+        else:
+            where.append(itf)
+    return implemented, sources
 
 
 class TypeNamer(object):

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1052,7 +1052,7 @@ class CodeGenerator(object):
         print(file=self.stream)
         print(file=self.stream)
 
-        for itf, idlflags in coclass.interfaces:
+        for itf, _ in coclass.interfaces:
             self.generate(itf.get_head())
         implemented = []
         sources = []

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1058,13 +1058,13 @@ class CodeGenerator(object):
         sources = []
         for item in coclass.interfaces:
             # item is (interface class, impltypeflags)
-            if item[1] & 2:  # IMPLTYPEFLAG_FSOURCE
+            if item[1] & typeinfo.IMPLTYPEFLAG_FSOURCE:
                 # source interface
                 where = sources
             else:
                 # sink interface
                 where = implemented
-            if item[1] & 1:  # IMPLTYPEFLAG_FDEAULT
+            if item[1] & typeinfo.IMPLTYPEFLAG_FDEFAULT:
                 # The default interface should be the first item on the list
                 where.insert(0, self._to_type_name(item[0]))
             else:

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -2,7 +2,7 @@
 # in typedesc_base
 
 import ctypes
-from typing import Any, List, Optional, Tuple, Union as _UnionT
+from typing import Any, List, Optional, Sequence, Tuple, Union as _UnionT
 
 from comtypes import typeinfo
 from comtypes.typeinfo import ITypeLib, TLIBATTR
@@ -210,7 +210,14 @@ class CoClass(object):
         self.interfaces.append((itf, idlflags))
 
 
-def groupby_impltypeflags(seq):
+_ImplTypeFlags = int
+_ImplementedInterfaces = Sequence[_UnionT[ComInterface, DispInterface]]
+_SourceInterfaces = Sequence[_UnionT[ComInterface, DispInterface]]
+
+
+def groupby_impltypeflags(
+    seq: Sequence[Tuple[_UnionT[ComInterface, DispInterface], _ImplTypeFlags]]
+) -> Tuple[_ImplementedInterfaces, _SourceInterfaces]:
     implemented = []
     sources = []
     for itf, impltypeflags in seq:

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -4,6 +4,7 @@
 import ctypes
 from typing import Any, List, Optional, Tuple, Union as _UnionT
 
+from comtypes import typeinfo
 from comtypes.typeinfo import ITypeLib, TLIBATTR
 from comtypes.tools.typedesc_base import *
 
@@ -207,3 +208,21 @@ class CoClass(object):
 
     def add_interface(self, itf: Any, idlflags: int) -> None:
         self.interfaces.append((itf, idlflags))
+
+
+def groupby_impltypeflags(seq):
+    implemented = []
+    sources = []
+    for itf, impltypeflags in seq:
+        if impltypeflags & typeinfo.IMPLTYPEFLAG_FSOURCE:
+            # source interface
+            where = sources
+        else:
+            # sink interface
+            where = implemented
+        if impltypeflags & typeinfo.IMPLTYPEFLAG_FDEFAULT:
+            # The default interface should be the first item on the list
+            where.insert(0, itf)
+        else:
+            where.append(itf)
+    return implemented, sources

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -196,6 +196,10 @@ class ComInterface(object):
         return self.itf_head
 
 
+_ImplTypeFlags = int
+_Interface = _UnionT[ComInterface, DispInterface]
+
+
 class CoClass(object):
     def __init__(
         self, name: str, clsid: str, idlflags: List[str], tlibattr: TLIBATTR
@@ -204,19 +208,18 @@ class CoClass(object):
         self.clsid = clsid
         self.idlflags = idlflags
         self.tlibattr = tlibattr
-        self.interfaces: List[Tuple[Any, int]] = []
+        self.interfaces: List[Tuple[_Interface, _ImplTypeFlags]] = []
 
-    def add_interface(self, itf: Any, idlflags: int) -> None:
+    def add_interface(self, itf: _Interface, idlflags: _ImplTypeFlags) -> None:
         self.interfaces.append((itf, idlflags))
 
 
-_ImplTypeFlags = int
-_ImplementedInterfaces = Sequence[_UnionT[ComInterface, DispInterface]]
-_SourceInterfaces = Sequence[_UnionT[ComInterface, DispInterface]]
+_ImplementedInterfaces = Sequence[_Interface]
+_SourceInterfaces = Sequence[_Interface]
 
 
 def groupby_impltypeflags(
-    seq: Sequence[Tuple[_UnionT[ComInterface, DispInterface], _ImplTypeFlags]]
+    seq: Sequence[Tuple[_Interface, _ImplTypeFlags]]
 ) -> Tuple[_ImplementedInterfaces, _SourceInterfaces]:
     implemented = []
     sources = []


### PR DESCRIPTION
Separate the functionality that classifies the interfaces assigned to `_com_interfaces_` and `_outgoing_interfaces_` of `CoClass` from `CodeGenerator.CoClass` into `typedesc.groupby_impltypeflags`.