### PR TITLE
add static typing for when a `CoClass` is assigned as the return value type

### DIFF
--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -21,6 +21,10 @@ if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
     from typing_extensions import Protocol
+if sys.version_info >= (3, 9):
+    from typing import Annotated as Annotated
+else:
+    from typing_extensions import Annotated as Annotated
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec, TypeAlias
     from typing import TypeGuard as TypeGuard

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -36,6 +36,7 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+import comtypes
 from comtypes.automation import IDispatch as IDispatch, VARIANT as VARIANT
 from comtypes.server import IClassFactory as IClassFactory
 from comtypes.typeinfo import ITypeInfo as ITypeInfo
@@ -49,6 +50,16 @@ Hresult: TypeAlias = int
 """The value returned when calling a method with no `[out]` or `[out, retval]`
 arguments and with `HRESULT` as its return type in its COM method definition.
 """
+
+_T_coclass = TypeVar("_T_coclass", bound=comtypes.CoClass)
+
+class FirstComItfOf(Generic[_T_coclass]):
+    """When the type assigned to the parameter marked as `'out'` is `CoClass`,
+    the return type of that method at runtime becomes `_com_interface_[0]`
+    due to the metaclass.
+    This is used as `Annotated` metadata for such parameters, taking `CoClass`
+    as an argument.
+    """
 
 class _MethodTypeDesc(Protocol):
     arguments: List[Tuple[Any, str, List[str], Optional[Any]]]

--- a/comtypes/tools/typeannotator.py
+++ b/comtypes/tools/typeannotator.py
@@ -223,6 +223,11 @@ def _to_outtype(typ: Any) -> str:
         return f"'{typ.name}'"
     elif isinstance(typ, typedesc.ComInterface):
         return f"'{typ.name}'"
+    elif isinstance(typ, typedesc.CoClass):
+        impl, _ = typedesc.groupby_impltypeflags(typ.interfaces)
+        if impl:
+            meta = f"hints.FirstComItfOf['{typ.name}']"
+            return f"hints.Annotated[{_to_outtype(impl[0])}, {meta}]"
     return "hints.Incomplete"
 
 


### PR DESCRIPTION
When `SomeCoClass` is assigned as the return type in the member definition, `SomeCoClass._com_interfaces_[0]`-type instance is returned at runtime.
I have replicated those behavior in static typing.

For example, below is the case with Excel's `Range.Application`.

```py
...
class Application(CoClass):
    _reg_clsid_ = GUID('{000209FF-0000-0000-C000-000000000046}')
    _idlflags_ = []
    _typelib_path_ = typelib_path
    _reg_typelib_ = ('{00020905-0000-0000-C000-000000000046}', 8, 7)


class _Application(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IDispatch):
    _case_insensitive_ = True
    _iid_ = GUID('{00020970-0000-0000-C000-000000000046}')
    _idlflags_ = ['hidden', 'dual', 'nonextensible', 'oleautomation']
    ...


class Range(comtypes.gen._00020430_0000_0000_C000_000000000046_0_2_0.IDispatch):
    _case_insensitive_ = True
    _iid_ = GUID('{0002095E-0000-0000-C000-000000000046}')
    _idlflags_ = ['dual', 'nonextensible', 'oleautomation']

    if TYPE_CHECKING:  # commembers
        ...
        def _get_Application(self) -> hints.Annotated['_Application', hints.FirstComItfOf['Application']]: ...
        Application = hints.normal_property(_get_Application)
        ...


Range._methods_ = [
    ...
    COMMETHOD(
        [dispid(1000), 'propget'],
        HRESULT,
        'Application',
        (['out', 'retval'], POINTER(POINTER(Application)), 'prop')
    ),
    ...
]
```

`FirstComItfOf` assigned to the metadata of `Annotated` would NOT affect behaviors at runtime, NOR does it control static type checkers.
They have no meaning beyond being simple notes.