### PR TITLE
Improve `EnumerationNamespaces` and `CodeGenerator.enum_aliases`

### DIFF
--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -691,7 +691,7 @@ class CodeGenerator(object):
         if keyword.iskeyword(tp.name):
             # XXX use logging!
             if __warn_on_munge__:
-                print("# Fixing keyword as EnumValue for %s" % tp.name)
+                print(f"# Fixing keyword as EnumValue for {tp.name}")
         tp_name = self._to_type_name(tp)
         if tp.enumeration.name:
             self.enums.add(tp.enumeration.name, tp_name, value)

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1613,7 +1613,9 @@ class EnumerationNamespaces(object):
         Examples:
             <BLANKLINE> is necessary for doctest
             >>> enums = EnumerationNamespaces()
+            >>> assert not enums
             >>> enums.add('Foo', 'ham', 1)
+            >>> assert enums
             >>> enums.add('Foo', 'spam', 2)
             >>> enums.add('Bar', 'bacon', 3)
             >>> assert 'Foo' in enums
@@ -1640,6 +1642,9 @@ class EnumerationNamespaces(object):
 
     def __contains__(self, item: str) -> bool:
         return item in self.data
+
+    def __bool__(self) -> bool:
+        return bool(self.data)
 
     def get_symbols(self) -> Set[str]:
         return set(self.data)

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -594,8 +594,9 @@ class CodeGenerator(object):
             for n, v in self.unnamed_enum_members:
                 print(f"{n} = {v}", file=output)
             print(file=output)
-        print(self.enums.to_constants(), file=output)
-        print(file=output)
+        if self.enums:
+            print(self.enums.to_constants(), file=output)
+            print(file=output)
         if self.enum_aliases:
             print("# aliases for enums", file=output)
             for k, v in self.enum_aliases.items():
@@ -625,9 +626,10 @@ class CodeGenerator(object):
         print(self._make_friendly_module_import_part(modname), file=output)
         print(file=output)
         print(file=output)
-        print(self.enums.to_intflags(), file=output)
-        print(file=output)
-        print(file=output)
+        if self.enums:
+            print(self.enums.to_intflags(), file=output)
+            print(file=output)
+            print(file=output)
         if self.enum_aliases:
             for k, v in self.enum_aliases.items():
                 print(f"{k} = {v}", file=output)


### PR DESCRIPTION
- When `typedesc.Typedef.typ` is `typedesc.Enumeration`, it can be determined that it defines an alias for `Enumeration`.

- Since there are some COM type libraries that do not contain enumeration definitions, ensure that excessive line breaks do not occur in such cases.