### PR TITLE
Modernize the constructor arguments and attributes of each stuff in `typedesc`

### DIFF
--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1039,14 +1039,14 @@ class CodeGenerator(object):
         self.last_item_class = True
 
         print("class %s(CoClass):" % coclass.name, file=self.stream)
-        doc = getattr(coclass, "doc", None)
-        if doc:
-            print(self._to_docstring(doc), file=self.stream)
+        if coclass.doc:
+            print(self._to_docstring(coclass.doc), file=self.stream)
         print("    _reg_clsid_ = GUID(%r)" % coclass.clsid, file=self.stream)
         print("    _idlflags_ = %s" % coclass.idlflags, file=self.stream)
         if self.filename is not None:
             print("    _typelib_path_ = typelib_path", file=self.stream)
-        # X print >> self.stream, "POINTER(%s).__ctypes_from_outparam__ = wrap" % coclass.name
+        # X print
+        # >> self.stream, "POINTER(%s).__ctypes_from_outparam__ = wrap" % coclass.name
 
         libid = coclass.tlibattr.guid
         wMajor, wMinor = coclass.tlibattr.wMajorVerNum, coclass.tlibattr.wMinorVerNum

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1162,9 +1162,8 @@ class CodeGenerator(object):
         self.last_item_class = True
 
         print("class %s(%s):" % (head.itf.name, basename), file=self.stream)
-        doc = getattr(head.itf, "doc", None)
-        if doc:
-            print(self._to_docstring(doc), file=self.stream)
+        if head.itf.doc:
+            print(self._to_docstring(head.itf.doc), file=self.stream)
 
         print("    _case_insensitive_ = True", file=self.stream)
         print("    _iid_ = GUID(%r)" % head.itf.iid, file=self.stream)

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1310,9 +1310,8 @@ class CodeGenerator(object):
         self.last_item_class = True
 
         print("class %s(%s):" % (head.itf.name, basename), file=self.stream)
-        doc = getattr(head.itf, "doc", None)
-        if doc:
-            print(self._to_docstring(doc), file=self.stream)
+        if head.itf.doc:
+            print(self._to_docstring(head.itf.doc), file=self.stream)
         print("    _case_insensitive_ = True", file=self.stream)
         print("    _iid_ = GUID(%r)" % head.itf.iid, file=self.stream)
         print("    _idlflags_ = %s" % head.itf.idlflags, file=self.stream)

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -267,10 +267,8 @@ class Parser(object):
             assert vd.varkind == typeinfo.VAR_CONST
             typ = self.make_type(vd.elemdescVar.tdesc, tinfo)
             var_value = vd._.lpvarValue[0].value
-            v = typedesc.Constant(name, typ, var_value)
+            v = typedesc.Constant(name, typ, var_value, var_doc)
             self._register(name, v)
-            if var_doc is not None:
-                v.doc = var_doc
 
     # TKIND_INTERFACE = 3
     def ParseInterface(

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -289,15 +289,9 @@ class Parser(object):
                 warnings.warn(message, UserWarning)
             return None
 
-        itf = typedesc.ComInterface(
-            itf_name,
-            members=[],
-            base=None,
-            iid=str(ta.guid),
-            idlflags=self.interface_type_flags(ta.wTypeFlags),
-        )
-        if itf_doc:
-            itf.doc = itf_doc
+        iid = str(ta.guid)
+        idlflags = self.interface_type_flags(ta.wTypeFlags)
+        itf = typedesc.ComInterface(itf_name, [], None, iid, idlflags, itf_doc)
         self._register(itf_name, itf)
 
         if ta.cImplTypes:

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -548,11 +548,9 @@ class Parser(object):
         #        version, control, hidden, and appobject
         coclass_name, doc = tinfo.GetDocumentation(-1)[0:2]
         tlibattr = tinfo.GetContainingTypeLib()[0].GetLibAttr()
-        coclass = typedesc.CoClass(
-            coclass_name, str(ta.guid), self.coclass_type_flags(ta.wTypeFlags), tlibattr
-        )
-        if doc is not None:
-            coclass.doc = doc
+        clsid = str(ta.guid)
+        idlflags = self.coclass_type_flags(ta.wTypeFlags)
+        coclass = typedesc.CoClass(coclass_name, clsid, idlflags, tlibattr, doc)
         self._register(coclass_name, coclass)
 
         for i in range(ta.cImplTypes):

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -350,15 +350,10 @@ class Parser(object):
         tibase = tinfo.GetRefTypeInfo(hr)
         base = self.parse_typeinfo(tibase)
         members = []
-        itf = typedesc.DispInterface(
-            itf_name,
-            members=members,
-            base=base,
-            iid=str(ta.guid),
-            idlflags=self.interface_type_flags(ta.wTypeFlags),
-        )
-        if doc is not None:
-            itf.doc = str(doc.split("\0")[0])
+        iid = str(ta.guid)
+        idlflags = self.interface_type_flags(ta.wTypeFlags)
+        doc = str(doc.split("\0")[0]) if doc is not None else doc
+        itf = typedesc.DispInterface(itf_name, members, base, iid, idlflags, doc)
         self._register(itf_name, itf)
 
         # This code can only handle pure dispinterfaces.  Dual

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -343,15 +343,13 @@ class Parser(object):
     ) -> typedesc.DispInterface:
         itf_name, doc = tinfo.GetDocumentation(-1)[0:2]
         assert ta.cImplTypes == 1
-
         hr = tinfo.GetRefTypeOfImplType(0)
         tibase = tinfo.GetRefTypeInfo(hr)
         base = self.parse_typeinfo(tibase)
-        members = []
         iid = str(ta.guid)
         idlflags = self.interface_type_flags(ta.wTypeFlags)
         doc = str(doc.split("\0")[0]) if doc is not None else doc
-        itf = typedesc.DispInterface(itf_name, members, base, iid, idlflags, doc)
+        itf = typedesc.DispInterface(itf_name, base, iid, idlflags, doc)
         self._register(itf_name, itf)
 
         # This code can only handle pure dispinterfaces.  Dual
@@ -366,7 +364,7 @@ class Parser(object):
             mth = typedesc.DispProperty(
                 vd.memid, var_name, typ, self.var_flags(vd.wVarFlags), var_doc
             )
-            itf.members.append(mth)
+            itf.add_member(mth)
 
         # At least the EXCEL typelib lists the IUnknown and IDispatch
         # methods even for this kind of interface.  I didn't find any
@@ -417,7 +415,7 @@ class Parser(object):
                 else:
                     default = None
                 mth.add_argument(typ, name, self.param_flags(flags), default)
-            itf.members.append(mth)
+            itf.add_member(mth)
         return itf
 
     def inv_kind(self, invkind: int) -> List[str]:

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -289,7 +289,7 @@ class Parser(object):
 
         iid = str(ta.guid)
         idlflags = self.interface_type_flags(ta.wTypeFlags)
-        itf = typedesc.ComInterface(itf_name, [], None, iid, idlflags, itf_doc)
+        itf = typedesc.ComInterface(itf_name, None, iid, idlflags, itf_doc)
         self._register(itf_name, itf)
 
         if ta.cImplTypes:
@@ -299,7 +299,7 @@ class Parser(object):
 
         assert ta.cVars == 0, "vars on an Interface?"
 
-        members = []
+        members: List[Tuple[int, typedesc.ComMethod]] = []
         for i in range(ta.cFuncs):
             fd = tinfo.GetFuncDesc(i)
             func_name, func_doc = tinfo.GetDocumentation(fd.memid)[:2]
@@ -333,7 +333,7 @@ class Parser(object):
         # Sort the methods by oVft (VTable offset): Some typeinfo
         # don't list methods in VTable order.
         members.sort()
-        itf.members.extend([m[1] for m in members])
+        itf.extend_members([m for _, m in members])
 
         return itf
 

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -1,20 +1,10 @@
-from __future__ import print_function
 import os
 import sys
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Type,
-    TypeVar,
-    Tuple,
-    Union as _UnionT,
-)
-from ctypes import alignment, c_void_p, _Pointer, sizeof, windll
+from typing import Any
+from typing import Dict, List, Optional, Tuple
+from ctypes import alignment, byref, c_void_p, sizeof, windll
 
-from comtypes import automation, _CData, COMError, typeinfo
+from comtypes import automation, BSTR, COMError, typeinfo
 from comtypes.tools import typedesc
 from comtypes.client._code_cache import _get_module_filename
 
@@ -746,9 +736,6 @@ class TypeLibParser(Parser):
 def get_tlib_filename(tlib):
     # seems if the typelib is not registered, there's no way to
     # determine the filename.
-    from ctypes import windll, byref
-    from comtypes import BSTR
-
     la = tlib.GetLibAttr()
     name = BSTR()
     try:

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -180,6 +180,7 @@ class ComInterface(object):
         base: "Optional[ComInterface]",
         iid: str,
         idlflags: List[str],
+        doc: Optional[str],
     ) -> None:
         self.name = name
         self.members = members
@@ -188,6 +189,7 @@ class ComInterface(object):
         self.idlflags = idlflags
         self.itf_head = ComInterfaceHead(self)
         self.itf_body = ComInterfaceBody(self)
+        self.doc = doc
 
     def get_body(self) -> ComInterfaceBody:
         return self.itf_body

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -185,20 +185,22 @@ class ComInterface(object):
     def __init__(
         self,
         name: str,
-        members: List[ComMethod],
         base: "Optional[ComInterface]",
         iid: str,
         idlflags: List[str],
         doc: Optional[str],
     ) -> None:
         self.name = name
-        self.members = members
+        self.members: List[ComMethod] = []
         self.base = base
         self.iid = iid
         self.idlflags = idlflags
         self.itf_head = ComInterfaceHead(self)
         self.itf_body = ComInterfaceBody(self)
         self.doc = doc
+
+    def extend_members(self, members: Sequence[ComMethod]) -> None:
+        self.members.extend(members)
 
     def get_body(self) -> ComInterfaceBody:
         return self.itf_body

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -147,20 +147,22 @@ class DispInterface(object):
     def __init__(
         self,
         name: str,
-        members: List[_UnionT[DispMethod, DispProperty]],
         base: Any,
         iid: str,
         idlflags: List[str],
         doc: Optional[str],
     ) -> None:
         self.name = name
-        self.members = members
+        self.members: List[_UnionT[DispMethod, DispProperty]] = []
         self.base = base
         self.iid = iid
         self.idlflags = idlflags
         self.itf_head = DispInterfaceHead(self)
         self.itf_body = DispInterfaceBody(self)
         self.doc = doc
+
+    def add_member(self, member: _UnionT[DispMethod, DispProperty]) -> None:
+        self.members.append(member)
 
     def get_body(self) -> DispInterfaceBody:
         return self.itf_body

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -202,13 +202,19 @@ _Interface = _UnionT[ComInterface, DispInterface]
 
 class CoClass(object):
     def __init__(
-        self, name: str, clsid: str, idlflags: List[str], tlibattr: TLIBATTR
+        self,
+        name: str,
+        clsid: str,
+        idlflags: List[str],
+        tlibattr: TLIBATTR,
+        doc: Optional[str],
     ) -> None:
         self.name = name
         self.clsid = clsid
         self.idlflags = idlflags
         self.tlibattr = tlibattr
         self.interfaces: List[Tuple[_Interface, _ImplTypeFlags]] = []
+        self.doc = doc
 
     def add_interface(self, itf: _Interface, idlflags: _ImplTypeFlags) -> None:
         self.interfaces.append((itf, idlflags))

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -30,11 +30,16 @@ class TypeLib(object):
 
 class Constant(object):
     def __init__(
-        self, name: str, typ: _UnionT[Typedef, FundamentalType], value: Any
+        self,
+        name: str,
+        typ: _UnionT[Typedef, FundamentalType],
+        value: Any,
+        doc: Optional[str],
     ) -> None:
         self.name = name
         self.typ = typ
         self.value = value
+        self.doc = doc
 
 
 class External(object):

--- a/comtypes/tools/typedesc.py
+++ b/comtypes/tools/typedesc.py
@@ -146,6 +146,7 @@ class DispInterface(object):
         base: Any,
         iid: str,
         idlflags: List[str],
+        doc: Optional[str],
     ) -> None:
         self.name = name
         self.members = members
@@ -154,6 +155,7 @@ class DispInterface(object):
         self.idlflags = idlflags
         self.itf_head = DispInterfaceHead(self)
         self.itf_body = DispInterfaceBody(self)
+        self.doc = doc
 
     def get_body(self) -> DispInterfaceBody:
         return self.itf_body


### PR DESCRIPTION
- In `tlbparser`, if [the `pBstrDocString` parameter of `GetDocumentation`](https://learn.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-itypeinfo-getdocumentation#parameters) was not null, the `doc` attribute was being patched to `CoClass`, `ComInterface`, `DispInterface`, and `Constant`. Such patching is a typical example of legacy code that triggers warnings from static type checkers, and was the reason why `hasattr` had to be used in `codegenerator`.
By taking `doc: str | None` as a constructor argument and assigning it to an attribute, and changing `if hasattr(obj, 'doc', None):` to `if obj.doc:`, this improves the type safety of the codebase.
- `DispInterface` and `ComInterface` were taking an empty list as a constructor argument and assigning it to the `members` attribute. Then, they were directly accessing the `members.append` method to add elements.
By instantiating a list in `__init__` and assigning it to `members` and adding elements through `add_member`/`extend_members`, this simplifies the codebase.