### PR TITLE
Add `npsupport` to CI pipeline matrix

### DIFF
--- a/.github/workflows/autofmt.yml
+++ b/.github/workflows/autofmt.yml
@@ -8,9 +8,9 @@ jobs:
         runs-on: windows-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Set up Python
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
               python-version: 3.7
           - name: Install black

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         architecture: ['x86', 'x64']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -12,6 +12,7 @@ jobs:
         os: [windows-latest, windows-2019]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         architecture: ['x86', 'x64']
+        npsupport: ['with npsupport', 'without npsupport']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -34,6 +35,9 @@ jobs:
           ./server.exe /RegServer
       - name: unittest comtypes
         run: |
+          if ("${{ matrix.npsupport }}" -eq "with npsupport") {
+            pip install numpy
+          }
           python -m unittest discover -v -s ./comtypes/test -t comtypes\test
       - name: Unregister the OutProc COM server
         run: |

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -5,11 +5,11 @@ on:
     branches: [main]
 
 jobs:
-  tests:
+  unit-tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, windows-2019]
+        os: [windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         architecture: ['x86', 'x64']
         npsupport: ['with npsupport', 'without npsupport']
@@ -20,12 +20,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
-      - name: install comtypes
-        run: |
-          pip install --upgrade setuptools
-          python setup.py install
-          pip uninstall comtypes -y
-          python test_pip_install.py
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build and register the OutProc COM server
@@ -43,3 +37,24 @@ jobs:
         run: |
           cd source/CppTestSrv
           ./server.exe /UnregServer
+
+  install-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, windows-2019]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        architecture: ['x86', 'x64']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - name: install comtypes
+        run: |
+          pip install --upgrade setuptools
+          python setup.py install
+          pip uninstall comtypes -y
+          python test_pip_install.py


### PR DESCRIPTION
This package has an optional feature that associated with `numpy`. 
There are some proposals related to `numpy`, like #551.

In the current CI pipeline, tests for the `numpy` related feature are skipped.

I have set it up so that whether to install `numpy` in the runtime environment and test it is specified in the GHA matrix.
This avoids having to start by changing the GHA workflow when a PR related to `npsupport` is submitted in the future.

In addition...,
- update the major version of GHA's `checkout` and `setup-python`
- separate the autotest workflow job into unit-tests and installation-tests.