### PR TITLE
Stop mentioning the last version supporting Windows CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 `comtypes` allows to define, call, and implement custom and dispatch-based COM interfaces in pure `Python`.
 
 This package works on Windows only.
-- [`comtypes==1.1.7`](https://pypi.org/project/comtypes/1.1.7/) is the last version supporting Windows CE.
 
 Available on `Python` 3.7-3.12.
 - [`comtypes==1.2.1`](https://pypi.org/project/comtypes/1.2.1/) is the last version supporting `Python` 2.7 and 3.3-3.6.


### PR DESCRIPTION
Follow-up to #211 that dropped Windows CE support back in 2020. I doubt that any new comtypes user is interested in figuring out the last version that supported Windows CE these days. Therefore suggest removing the sentence from the front page since it's of low relevance.