### PR TITLE
fix importing `_DispMemberSpec` in `automation`

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -20,6 +20,7 @@ from typing import (
 
 from comtypes import BSTR, COMError, COMMETHOD, GUID, IID, IUnknown, STDMETHOD
 from comtypes.hresult import *
+from comtypes._memberspec import _DispMemberSpec
 import comtypes.patcher
 import comtypes
 
@@ -791,7 +792,7 @@ RawInvokeFunc = Callable[
 
 
 class IDispatch(IUnknown):
-    _disp_methods_: ClassVar[List[comtypes._DispMemberSpec]]
+    _disp_methods_: ClassVar[List[_DispMemberSpec]]
     _GetTypeInfo: Callable[[int, int], IUnknown]
     __com_GetIDsOfNames: RawGetIDsOfNamesFunc
     __com_Invoke: RawInvokeFunc


### PR DESCRIPTION
In `automation`, `comtypes._DispMemberSpec` is referencing a private symbol across modules.
Such a way of referencing is undesirable, but it must be accepted if it relates to runtime behavior.
However, `comtypes._DispMemberSpec` used in `automation` was only used for type hints, so it will be fixed here.