### PR TITLE
Implement SAFEARRAY pointers and SAFEARRAYs as method parameters of a Dispatch Interface

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -20,6 +20,7 @@ from typing import (
 
 from comtypes import BSTR, COMError, COMMETHOD, GUID, IID, IUnknown, STDMETHOD
 from comtypes.hresult import *
+from comtypes._memberspec import _DispMemberSpec
 import comtypes.patcher
 import comtypes
 
@@ -404,7 +405,9 @@ class tagVARIANT(Structure):
                 ri.AddRef()
                 self._.pRecInfo = ri
                 self._.pvRecord = cast(value, c_void_p)
-            elif isinstance(ref, _Pointer) and isinstance(ref.contents, _safearray.tagSAFEARRAY):
+            elif isinstance(ref, _Pointer) and isinstance(
+                ref.contents, _safearray.tagSAFEARRAY
+            ):
                 self.vt = VT_ARRAY | ref._vartype_ | VT_BYREF
                 self._.pparray = cast(value, POINTER(POINTER(_safearray.tagSAFEARRAY)))
             else:
@@ -428,7 +431,9 @@ class tagVARIANT(Structure):
                 obj = _midlSAFEARRAY(value._itemtype_).create(value.unpack())
                 memmove(byref(self._), byref(obj), sizeof(obj))
                 self.vt = VT_ARRAY | obj._vartype_
-            elif isinstance(ref, _Pointer) and isinstance(ref.contents, _safearray.tagSAFEARRAY):
+            elif isinstance(ref, _Pointer) and isinstance(
+                ref.contents, _safearray.tagSAFEARRAY
+            ):
                 self.vt = VT_ARRAY | ref._vartype_ | VT_BYREF
                 self._.pparray = cast(value, POINTER(POINTER(_safearray.tagSAFEARRAY)))
             else:
@@ -801,7 +806,7 @@ RawInvokeFunc = Callable[
 
 
 class IDispatch(IUnknown):
-    _disp_methods_: ClassVar[List[comtypes._DispMemberSpec]]
+    _disp_methods_: ClassVar[List[_DispMemberSpec]]
     _GetTypeInfo: Callable[[int, int], IUnknown]
     __com_GetIDsOfNames: RawGetIDsOfNamesFunc
     __com_Invoke: RawInvokeFunc

--- a/comtypes/test/test_dispifc_safearrays.py
+++ b/comtypes/test/test_dispifc_safearrays.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+
+import unittest
+import comtypes
+
+from comtypes import CLSCTX_LOCAL_SERVER
+from comtypes.client import CreateObject, GetModule
+from ctypes import byref, pointer, c_double
+
+ComtypesCppTestSrvLib_GUID = "{07D2AEE5-1DF8-4D2C-953A-554ADFD25F99}"
+
+try:
+    GetModule((ComtypesCppTestSrvLib_GUID, 1, 0, 0))
+    import comtypes.gen.ComtypesCppTestSrvLib as ComtypesCppTestSrvLib
+
+    IMPORT_FAILED = False
+except (ImportError, OSError):
+    IMPORT_FAILED = True
+
+
+@unittest.skipIf(IMPORT_FAILED, "This depends on the out of process COM-server.")
+class Test_DispMethods(unittest.TestCase):
+    """Test dispmethods with safearray and safearray pointer parameters."""
+
+    ZERO_ARRAY = tuple([0.0 for i in range(10)])
+    EXPECTED_INITED_ARRAY = tuple([float(i) for i in range(10)])
+
+    def _create_dispifc(self) -> "ComtypesCppTestSrvLib.IDispSafearrayParamTest":
+        # Explicitely ask for the dispinterface of the component.
+        return CreateObject(
+            "Comtypes.DispSafearrayParamTest",
+            clsctx=CLSCTX_LOCAL_SERVER,
+            interface=ComtypesCppTestSrvLib.IDispSafearrayParamTest,
+        )
+
+    def test_inout_byref(self):
+        dispifc = self._create_dispifc()
+        # Passing a safearray by reference to a method that has declared the parameter
+        # as [in, out] we expect modifications of the safearray on the server side to
+        # also change the safearray on the client side.
+        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double() for i in range(10)])
+        self.assertEqual(test_array.unpack(), self.ZERO_ARRAY)
+        dispifc.InitArray(byref(test_array))
+        self.assertEqual(test_array.unpack(), self.EXPECTED_INITED_ARRAY)
+
+    def test_inout_pointer(self):
+        dispifc = self._create_dispifc()
+        # Passing a safearray pointer to a method that has declared the parameter
+        # as [in, out] we expect modifications of the safearray on the server side to
+        # also change the safearray on the client side.
+        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double() for i in range(10)])
+        self.assertEqual(test_array.unpack(), self.ZERO_ARRAY)
+        dispifc.InitArray(pointer(test_array))
+        self.assertEqual(test_array.unpack(), self.EXPECTED_INITED_ARRAY)
+
+    def test_in_safearray(self):
+        # Passing a safearray to a method that has declared the parameter just as [in]
+        # we expect modifications of the safearray on the server side NOT to change
+        # the safearray on the client side.
+        # We also need to test if the safearray gets properly passed to the method on
+        # the server side. For this, the 'VerifyArray' method returns 'True' if
+        # the safearray items have values equal to the initialization values
+        # provided by 'InitArray'.
+        inited_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double(i) for i in range(10)])
+        # Also perform the inverted test. For this, create a safearray with zeros.
+        zero_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double() for i in range(10)])
+        for sa, expected, array_content in [
+            (inited_array, True, self.EXPECTED_INITED_ARRAY),
+            (zero_array, False, self.ZERO_ARRAY),
+        ]:
+            with self.subTest(expected=expected, array_content=array_content):
+                # Perform the check on initialization values.
+                self.assertEqual(self._create_dispifc().VerifyArray(sa), expected)
+                # Check if the safearray is unchanged although the method
+                # modifies the safearray on the server side.
+                self.assertEqual(sa.unpack(), array_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comtypes/test/test_dispifc_safearrays.py
+++ b/comtypes/test/test_dispifc_safearrays.py
@@ -1,11 +1,12 @@
 # coding: utf-8
 
+from ctypes import byref, c_double, pointer
 import unittest
-import comtypes
 
+import comtypes
+import comtypes.safearray
 from comtypes import CLSCTX_LOCAL_SERVER
 from comtypes.client import CreateObject, GetModule
-from ctypes import byref, pointer, c_double
 
 ComtypesCppTestSrvLib_GUID = "{07D2AEE5-1DF8-4D2C-953A-554ADFD25F99}"
 
@@ -33,12 +34,12 @@ class Test_DispMethods(unittest.TestCase):
             interface=ComtypesCppTestSrvLib.IDispSafearrayParamTest,
         )
 
-    def _create_zero_array(self) -> comtypes.safearray._midlSAFEARRAY:
+    def _create_zero_array(self):
         return comtypes.safearray._midlSAFEARRAY(c_double).create(
             [c_double() for _ in range(10)]
         )
 
-    def _create_consecutive_array(self) -> comtypes.safearray._midlSAFEARRAY:
+    def _create_consecutive_array(self):
         return comtypes.safearray._midlSAFEARRAY(c_double).create(
             [c_double(i) for i in range(10)]
         )
@@ -60,7 +61,7 @@ class Test_DispMethods(unittest.TestCase):
         # also change the safearray on the client side.
         test_array = self._create_zero_array()
         self.assertEqual(test_array.unpack(), self.UNPACKED_ZERO_VALS)
-        dispifc.InitArray(byref(test_array))
+        dispifc.InitArray(pointer(test_array))
         self.assertEqual(test_array.unpack(), self.UNPACKED_CONSECUTIVE_VALS)
 
     def test_in_safearray(self):

--- a/comtypes/test/test_dispifc_safearrays.py
+++ b/comtypes/test/test_dispifc_safearrays.py
@@ -38,7 +38,9 @@ class Test_DispMethods(unittest.TestCase):
         # Passing a safearray by reference to a method that has declared the parameter
         # as [in, out] we expect modifications of the safearray on the server side to
         # also change the safearray on the client side.
-        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double() for i in range(10)])
+        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
+            [c_double() for i in range(10)]
+        )
         self.assertEqual(test_array.unpack(), self.ZERO_ARRAY)
         dispifc.InitArray(byref(test_array))
         self.assertEqual(test_array.unpack(), self.EXPECTED_INITED_ARRAY)
@@ -48,7 +50,9 @@ class Test_DispMethods(unittest.TestCase):
         # Passing a safearray pointer to a method that has declared the parameter
         # as [in, out] we expect modifications of the safearray on the server side to
         # also change the safearray on the client side.
-        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double() for i in range(10)])
+        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
+            [c_double() for i in range(10)]
+        )
         self.assertEqual(test_array.unpack(), self.ZERO_ARRAY)
         dispifc.InitArray(pointer(test_array))
         self.assertEqual(test_array.unpack(), self.EXPECTED_INITED_ARRAY)
@@ -61,9 +65,13 @@ class Test_DispMethods(unittest.TestCase):
         # the server side. For this, the 'VerifyArray' method returns 'True' if
         # the safearray items have values equal to the initialization values
         # provided by 'InitArray'.
-        inited_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double(i) for i in range(10)])
+        inited_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
+            [c_double(i) for i in range(10)]
+        )
         # Also perform the inverted test. For this, create a safearray with zeros.
-        zero_array = comtypes.safearray._midlSAFEARRAY(c_double).create([c_double() for i in range(10)])
+        zero_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
+            [c_double() for i in range(10)]
+        )
         for sa, expected, array_content in [
             (inited_array, True, self.EXPECTED_INITED_ARRAY),
             (zero_array, False, self.ZERO_ARRAY),

--- a/comtypes/test/test_dispifc_safearrays.py
+++ b/comtypes/test/test_dispifc_safearrays.py
@@ -22,8 +22,8 @@ except (ImportError, OSError):
 class Test_DispMethods(unittest.TestCase):
     """Test dispmethods with safearray and safearray pointer parameters."""
 
-    ZERO_ARRAY = tuple([0.0 for i in range(10)])
-    EXPECTED_INITED_ARRAY = tuple([float(i) for i in range(10)])
+    UNPACKED_ZERO_VALS = tuple(0.0 for _ in range(10))
+    UNPACKED_CONSECUTIVE_VALS = tuple(float(i) for i in range(10))
 
     def _create_dispifc(self) -> "ComtypesCppTestSrvLib.IDispSafearrayParamTest":
         # Explicitely ask for the dispinterface of the component.
@@ -33,29 +33,35 @@ class Test_DispMethods(unittest.TestCase):
             interface=ComtypesCppTestSrvLib.IDispSafearrayParamTest,
         )
 
+    def _create_zero_array(self) -> comtypes.safearray._midlSAFEARRAY:
+        return comtypes.safearray._midlSAFEARRAY(c_double).create(
+            [c_double() for _ in range(10)]
+        )
+
+    def _create_consecutive_array(self) -> comtypes.safearray._midlSAFEARRAY:
+        return comtypes.safearray._midlSAFEARRAY(c_double).create(
+            [c_double(i) for i in range(10)]
+        )
+
     def test_inout_byref(self):
         dispifc = self._create_dispifc()
         # Passing a safearray by reference to a method that has declared the parameter
         # as [in, out] we expect modifications of the safearray on the server side to
         # also change the safearray on the client side.
-        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
-            [c_double() for i in range(10)]
-        )
-        self.assertEqual(test_array.unpack(), self.ZERO_ARRAY)
+        test_array = self._create_zero_array()
+        self.assertEqual(test_array.unpack(), self.UNPACKED_ZERO_VALS)
         dispifc.InitArray(byref(test_array))
-        self.assertEqual(test_array.unpack(), self.EXPECTED_INITED_ARRAY)
+        self.assertEqual(test_array.unpack(), self.UNPACKED_CONSECUTIVE_VALS)
 
     def test_inout_pointer(self):
         dispifc = self._create_dispifc()
         # Passing a safearray pointer to a method that has declared the parameter
         # as [in, out] we expect modifications of the safearray on the server side to
         # also change the safearray on the client side.
-        test_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
-            [c_double() for i in range(10)]
-        )
-        self.assertEqual(test_array.unpack(), self.ZERO_ARRAY)
-        dispifc.InitArray(pointer(test_array))
-        self.assertEqual(test_array.unpack(), self.EXPECTED_INITED_ARRAY)
+        test_array = self._create_zero_array()
+        self.assertEqual(test_array.unpack(), self.UNPACKED_ZERO_VALS)
+        dispifc.InitArray(byref(test_array))
+        self.assertEqual(test_array.unpack(), self.UNPACKED_CONSECUTIVE_VALS)
 
     def test_in_safearray(self):
         # Passing a safearray to a method that has declared the parameter just as [in]
@@ -65,23 +71,17 @@ class Test_DispMethods(unittest.TestCase):
         # the server side. For this, the 'VerifyArray' method returns 'True' if
         # the safearray items have values equal to the initialization values
         # provided by 'InitArray'.
-        inited_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
-            [c_double(i) for i in range(10)]
-        )
-        # Also perform the inverted test. For this, create a safearray with zeros.
-        zero_array = comtypes.safearray._midlSAFEARRAY(c_double).create(
-            [c_double() for i in range(10)]
-        )
-        for sa, expected, array_content in [
-            (inited_array, True, self.EXPECTED_INITED_ARRAY),
-            (zero_array, False, self.ZERO_ARRAY),
+        for sa, expected, unpacked_content in [
+            (self._create_consecutive_array(), True, self.UNPACKED_CONSECUTIVE_VALS),
+            # Also perform the inverted test. For this, create a safearray with zeros.
+            (self._create_zero_array(), False, self.UNPACKED_ZERO_VALS),
         ]:
-            with self.subTest(expected=expected, array_content=array_content):
+            with self.subTest(expected=expected, unpacked_content=unpacked_content):
                 # Perform the check on initialization values.
                 self.assertEqual(self._create_dispifc().VerifyArray(sa), expected)
                 # Check if the safearray is unchanged although the method
                 # modifies the safearray on the server side.
-                self.assertEqual(sa.unpack(), array_content)
+                self.assertEqual(sa.unpack(), unpacked_content)
 
 
 if __name__ == "__main__":

--- a/source/CppTestSrv/CFACTORY.CPP
+++ b/source/CppTestSrv/CFACTORY.CPP
@@ -207,7 +207,21 @@ HRESULT CFactory::UnregisterAll()
 	{
 		UnregisterServer(*(g_FactoryDataArray[i].m_pCLSID),
 		                 g_FactoryDataArray[i].m_szVerIndProgID, 
-		                 g_FactoryDataArray[i].m_szProgID) ;
+		                 g_FactoryDataArray[i].m_szProgID,
+						 g_FactoryDataArray[i].m_pLIBID) ;
+		// We can only unregister a TypeLib once.
+		// So if we just unregistered a TypeLib set all pointers to the same TypeLib to NULL.
+		if (g_FactoryDataArray[i].m_pLIBID != NULL)
+		{
+			const GUID* libid = g_FactoryDataArray[i].m_pLIBID ;
+			for(int j = 0 ; j < g_cFactoryDataEntries ; j++)
+			{
+				if (g_FactoryDataArray[j].m_pLIBID != NULL && g_FactoryDataArray[j].m_pLIBID == libid)
+				{
+					g_FactoryDataArray[j].m_pLIBID = NULL ;
+				}
+			}
+		}
 	}
 	return S_OK ;
 }

--- a/source/CppTestSrv/CoComtypesDispSafearrayParamTest.cpp
+++ b/source/CppTestSrv/CoComtypesDispSafearrayParamTest.cpp
@@ -1,0 +1,315 @@
+/*
+	This code is based on example code to the book:
+		Inside COM
+		by Dale E. Rogerson
+		Microsoft Press 1997
+		ISBN 1-57231-349-8
+*/
+
+//
+// CoComtypesDispSafearrayParamTest.cpp - Component
+//
+#include <objbase.h>
+#include <string.h>
+#include <iostream>
+#include <sstream>
+
+#include "Iface.h"
+#include "Util.h"
+#include "CUnknown.h"
+#include "CFactory.h" // Needed for module handle
+#include "CoComtypesDispSafearrayParamTest.h"
+
+// We need to put this declaration here because we explicitely expose a dispinterface
+// in parallel to the dual interface but dispinterfaces don't appear in the
+// MIDL-generated header file.
+EXTERN_C const IID DIID_IDispSafearrayParamTest;
+
+static inline void trace(const char* msg)
+	{ Util::Trace("CoComtypesDispSafearrayParamTest", msg, S_OK) ;}
+static inline void trace(const char* msg, HRESULT hr)
+	{ Util::Trace("CoComtypesDispSafearrayParamTest", msg, hr) ;}
+
+///////////////////////////////////////////////////////////
+//
+// Interface IDualSafearrayParamTest - Implementation
+//
+
+HRESULT __stdcall CB::InitArray(SAFEARRAY* *pptest_array)
+{
+	int i ;
+	double *pdata = NULL ;
+	HRESULT hr ;
+	std::ostringstream sout ;
+
+	// Display the contents of the received SAFEARRAY.
+	hr = SafeArrayAccessData(*pptest_array, reinterpret_cast<void**>(&pdata)) ;
+	if (FAILED(hr)) 
+	{
+		return E_FAIL ;
+	}
+	sout << "Received SAFEARRAY contains:" << std::ends ;
+	trace(sout.str().c_str()) ;
+	sout.str("") ;
+	for (i = 0; i < (*pptest_array)->rgsabound[0].cElements; i++)
+	{
+		sout << "\n\t\t" << "Element# " << i << ": " << pdata[i] << std::ends ;
+		trace(sout.str().c_str()) ;
+		sout.str("") ;
+	}
+
+	// Modify the SAFEARRAY.
+	sout << "Modifying SAFEARRAY contents." << std::ends ;
+	trace(sout.str().c_str()) ;
+	sout.str("") ;
+	for (i = 0; i < (*pptest_array)->rgsabound[0].cElements; i++)
+	{
+		pdata[i] = (double)(i) ;
+	}
+
+	// Display the contents of the modifyied SAFEARRAY.
+	sout << "Modifyied SAFEARRAY now contains:" << std::ends ;
+	trace(sout.str().c_str()) ;
+	sout.str("") ;
+	for (i = 0; i < (*pptest_array)->rgsabound[0].cElements; i++)
+	{
+		sout << "\n\t\t" << "Element# " << i << ": " << pdata[i] << std::ends ;
+		trace(sout.str().c_str()) ;
+		sout.str("") ;
+	}
+	SafeArrayUnaccessData(*pptest_array) ;
+
+	return S_OK ;
+}
+
+HRESULT __stdcall CB::VerifyArray(SAFEARRAY* ptest_array,
+									VARIANT_BOOL* result)
+{
+	long i ;
+	double *pdata = NULL ;
+	HRESULT hr ;
+	std::ostringstream sout ;
+
+	// Display and verify the contents of the received SAFEARRAY.
+	*result = VARIANT_TRUE ;
+	hr = SafeArrayAccessData(ptest_array, reinterpret_cast<void**>(&pdata)) ;
+	if (FAILED(hr)) 
+	{
+		return E_FAIL ;
+	}
+	sout << "Received SAFEARRAY contains:  " << std::ends ;
+	trace(sout.str().c_str()) ;
+	sout.str("") ;
+	for (i = 0; i < ptest_array->rgsabound[0].cElements; i++)
+	{
+		if (pdata[i] != (double)(i))
+		{
+			*result = VARIANT_FALSE ;
+		}
+		sout << "\n\t\t" << "Element# " << i << ": " << pdata[i] << std::ends ;
+		trace(sout.str().c_str()) ;
+		sout.str("") ;
+	}
+
+	// Modify the SAFEARRAY.
+	sout << "Modifying SAFEARRAY contents." << std::ends ;
+	trace(sout.str().c_str()) ;
+	sout.str("") ;
+	for (i = 0; i < ptest_array->rgsabound[0].cElements; i++)
+	{
+		pdata[i] = (double)(0.0) ;
+	}
+
+	// Display the contents of the modifyied SAFEARRAY.
+	sout << "Modified SAFEARRAY now contains:" << std::ends ;
+	trace(sout.str().c_str()) ;
+	sout.str("") ;
+	for (i = 0; i < ptest_array->rgsabound[0].cElements; i++)
+	{
+		sout << "\n\t\t" << "Element# " << i << ": " << pdata[i] << std::ends ;
+		trace(sout.str().c_str()) ;
+		sout.str("") ;
+	}
+	SafeArrayUnaccessData(ptest_array) ;
+
+	return S_OK ;
+}
+
+
+//
+// Constructor
+//
+CB::CB(IUnknown* pUnknownOuter)
+: CUnknown(pUnknownOuter), 
+  m_pITypeInfo(NULL)
+{
+	// Empty
+}
+
+//
+// Destructor
+//
+CB::~CB()
+{
+	if (m_pITypeInfo != NULL)
+	{
+		m_pITypeInfo->Release() ;
+	}
+
+	trace("Destroy self.") ;
+}
+
+//
+// NondelegatingQueryInterface implementation
+//
+HRESULT __stdcall CB::NondelegatingQueryInterface(const IID& iid,
+                                                  void** ppv)
+{ 	
+	if (iid == IID_IDualSafearrayParamTest)
+	{
+		return FinishQI(static_cast<IDualSafearrayParamTest*>(this), ppv) ;
+	}
+	else 	if (iid == DIID_IDispSafearrayParamTest)
+	{
+		trace("Queried for IDispSafearrayParamTest.") ;
+		return FinishQI(static_cast<IDispatch*>(this), ppv) ;
+	}
+	else 	if (iid == IID_IDispatch)
+	{
+		trace("Queried for IDispatch.") ;
+		return FinishQI(static_cast<IDispatch*>(this), ppv) ;
+	}
+	else
+	{
+		return CUnknown::NondelegatingQueryInterface(iid, ppv) ;
+	}
+}
+
+//
+// Load and register the type library.
+//
+HRESULT CB::Init()
+{
+	HRESULT hr ;
+
+	// Load TypeInfo on demand if we haven't already loaded it.
+	if (m_pITypeInfo == NULL)
+	{
+		ITypeLib* pITypeLib = NULL ;
+		hr = ::LoadRegTypeLib(LIBID_ComtypesCppTestSrvLib, 
+		                      1, 0, // Major/Minor version numbers
+		                      0x00, 
+		                      &pITypeLib) ;
+		if (FAILED(hr)) 
+		{
+			trace("LoadRegTypeLib Failed.", hr) ;
+			return hr ;   
+		}
+
+		// Get type information for the interface of the object.
+		hr = pITypeLib->GetTypeInfoOfGuid(IID_IDualSafearrayParamTest,
+		                                  &m_pITypeInfo) ;
+		pITypeLib->Release() ;
+		if (FAILED(hr))  
+		{ 
+			trace("GetTypeInfoOfGuid failed.", hr) ;
+			return hr ;
+		}   
+	}
+	return S_OK ;
+}
+
+///////////////////////////////////////////////////////////
+//
+// Creation function used by CFactory
+//
+HRESULT CB::CreateInstance(IUnknown* pUnknownOuter,
+                           CUnknown** ppNewComponent ) 
+{
+	if (pUnknownOuter != NULL)
+	{
+		// Don't allow aggregation (just for the heck of it).
+		return CLASS_E_NOAGGREGATION ;
+	}
+
+	*ppNewComponent = new CB(pUnknownOuter) ;
+	return S_OK ;
+}
+
+///////////////////////////////////////////////////////////
+//
+// IDispatch implementation
+//
+HRESULT __stdcall CB::GetTypeInfoCount(UINT* pCountTypeInfo)
+{
+	trace("GetTypeInfoCount call succeeded.") ;
+	*pCountTypeInfo = 1 ;
+	return S_OK ;
+}
+
+HRESULT __stdcall CB::GetTypeInfo(
+	UINT iTypeInfo,
+	LCID,          // This object does not support localization.
+	ITypeInfo** ppITypeInfo)
+{    
+	*ppITypeInfo = NULL ;
+
+	if(iTypeInfo != 0)
+	{
+		trace("GetTypeInfo call failed -- bad iTypeInfo index.") ;
+		return DISP_E_BADINDEX ; 
+	}
+
+	trace("GetTypeInfo call succeeded.") ;
+
+	// Call AddRef and return the pointer.
+	m_pITypeInfo->AddRef() ; 
+	*ppITypeInfo = m_pITypeInfo ;
+	return S_OK ;
+}
+
+HRESULT __stdcall CB::GetIDsOfNames(  
+	const IID& iid,
+	OLECHAR** arrayNames,
+	UINT countNames,
+	LCID,          // Localization is not supported.
+	DISPID* arrayDispIDs)
+{
+	if (iid != IID_NULL)
+	{
+		trace("GetIDsOfNames call failed -- bad IID.") ;
+		return DISP_E_UNKNOWNINTERFACE ;
+	}
+
+	trace("GetIDsOfNames call succeeded.") ;
+	HRESULT hr = m_pITypeInfo->GetIDsOfNames(arrayNames,
+	                                         countNames,
+	                                         arrayDispIDs) ;
+	return hr ;
+}
+
+HRESULT __stdcall CB::Invoke(   
+      DISPID dispidMember,
+      const IID& iid,
+      LCID,          // Localization is not supported.
+      WORD wFlags,
+      DISPPARAMS* pDispParams,
+      VARIANT* pvarResult,
+      EXCEPINFO* pExcepInfo,
+      UINT* pArgErr)
+{        
+	if (iid != IID_NULL)
+	{
+		trace("Invoke call failed -- bad IID.") ;
+		return DISP_E_UNKNOWNINTERFACE ;
+	}
+
+	::SetErrorInfo(0, NULL) ;
+
+	trace("Invoke call succeeded.") ;
+	HRESULT hr = m_pITypeInfo->Invoke(
+		static_cast<IDispatch*>(this),
+		dispidMember, wFlags, pDispParams,
+		pvarResult, pExcepInfo, pArgErr) ; 
+	return hr ;
+}

--- a/source/CppTestSrv/CoComtypesDispSafearrayParamTest.h
+++ b/source/CppTestSrv/CoComtypesDispSafearrayParamTest.h
@@ -1,0 +1,78 @@
+/*
+	This code is based on example code to the book:
+		Inside COM
+		by Dale E. Rogerson
+		Microsoft Press 1997
+		ISBN 1-57231-349-8
+*/
+
+//
+// CoComtypesDispSafearrayParamTest.cpp - Component
+//
+
+#include "Iface.h"
+#include "CUnknown.h" 
+
+///////////////////////////////////////////////////////////
+//
+// Component B
+//
+class CB : public CUnknown,
+		   public IDualSafearrayParamTest
+{
+public:	
+	// Creation
+	static HRESULT CreateInstance(IUnknown* pUnknownOuter,
+	                              CUnknown** ppNewComponent ) ;
+
+private:
+	// Declare the delegating IUnknown.
+	DECLARE_IUNKNOWN
+
+	// IUnknown
+	virtual HRESULT __stdcall NondelegatingQueryInterface(const IID& iid,
+	                                                      void** ppv) ;
+
+	// IDispatch
+	virtual HRESULT __stdcall GetTypeInfoCount(UINT* pCountTypeInfo) ;
+
+	virtual HRESULT __stdcall GetTypeInfo(
+		UINT iTypeInfo,
+		LCID,              // Localization is not supported.
+		ITypeInfo** ppITypeInfo) ;
+	
+	virtual HRESULT __stdcall GetIDsOfNames(
+		const IID& iid,
+		OLECHAR** arrayNames,
+		UINT countNames,
+		LCID,              // Localization is not supported.
+		DISPID* arrayDispIDs) ;
+
+	virtual HRESULT __stdcall Invoke(   
+		DISPID dispidMember,
+		const IID& iid,
+		LCID,              // Localization is not supported.
+		WORD wFlags,
+		DISPPARAMS* pDispParams,
+		VARIANT* pvarResult,
+		EXCEPINFO* pExcepInfo,
+		UINT* pArgErr) ;
+
+	// Interface IDualSafearrayParamTest
+	virtual HRESULT __stdcall InitArray(SAFEARRAY* *test_array) ;
+	virtual HRESULT __stdcall VerifyArray(
+										 SAFEARRAY *test_array,
+										 VARIANT_BOOL* result) ;
+
+	// Initialization
+ 	virtual HRESULT Init() ;
+
+	// Constructor
+	CB(IUnknown* pUnknownOuter) ;
+
+	// Destructor
+	~CB() ;
+
+	// Pointer to type information.
+	ITypeInfo* m_pITypeInfo ;
+} ;

--- a/source/CppTestSrv/MAKEFILE
+++ b/source/CppTestSrv/MAKEFILE
@@ -48,6 +48,10 @@ CoComtypesDispRecordParamTest.obj : CoComtypesDispRecordParamTest.cpp \
 		CoComtypesDispRecordParamTest.h iface.h registry.h CUnknown.h
 	cl $(CPP_FLAGS) CoComtypesDispRecordParamTest.cpp
 
+CoComtypesDispSafearrayParamTest.obj : CoComtypesDispSafearrayParamTest.cpp \
+		CoComtypesDispSafearrayParamTest.h iface.h registry.h CUnknown.h
+	cl $(CPP_FLAGS) CoComtypesDispSafearrayParamTest.cpp
+
 #
 # Helper classes
 #
@@ -76,6 +80,7 @@ outproc.obj : outproc.cpp CFactory.h CUnknown.h
 
 SERVER_OBJS = Server.obj     \
               CoComtypesDispRecordParamTest.obj      \
+              CoComtypesDispSafearrayParamTest.obj      \
               Registry.obj   \
               Cfactory.obj   \
               Cunknown.obj   \

--- a/source/CppTestSrv/REGISTRY.CPP
+++ b/source/CppTestSrv/REGISTRY.CPP
@@ -152,7 +152,8 @@ HRESULT RegisterServer(HMODULE hModule,        // DLL module handle
 //
 LONG UnregisterServer(const CLSID& clsid,         // Class ID
                       LPCWSTR szVerIndProgID, // Programmatic
-                      LPCWSTR szProgID)       //   IDs
+                      LPCWSTR szProgID,       //   IDs
+					  const GUID* libid)      // Library ID
 {
 	// Convert the CLSID into a char.
 	wchar_t szCLSID[GUID_STRING_SIZE] ;
@@ -190,12 +191,15 @@ LONG UnregisterServer(const CLSID& clsid,         // Class ID
 		       (lResult == ERROR_FILE_NOT_FOUND)) ; // Subkey may not exist.
 	}
 
-	// Unregister the Type Library.
-	HRESULT hr = UnRegisterTypeLib(LIBID_ComtypesCppTestSrvLib, 
-									1, 0, // Major/Minor version numbers
-									0x00, 
-									SYS_WIN64) ;
-	assert(hr == S_OK) ;
+	// Unregister the Type Library if it's still registered.
+	if (libid != NULL)
+	{
+		HRESULT hr = UnRegisterTypeLib(*libid,
+										1, 0, // Major/Minor version numbers
+										0x00,
+										SYS_WIN64) ;
+		assert(hr == S_OK) ;
+	}
 
 	return S_OK ;
 }

--- a/source/CppTestSrv/REGISTRY.H
+++ b/source/CppTestSrv/REGISTRY.H
@@ -26,6 +26,7 @@ HRESULT RegisterServer(HMODULE hModule,
 // call this function from their DllUnregisterServer function.
 HRESULT UnregisterServer(const CLSID& clsid,
                          LPCWSTR szVerIndProgID,
-                         LPCWSTR szProgID) ;
+                         LPCWSTR szProgID,
+                         const GUID* libid) ;
 
 #endif

--- a/source/CppTestSrv/SERVER.CPP
+++ b/source/CppTestSrv/SERVER.CPP
@@ -9,6 +9,7 @@
 #include "CFactory.h"
 #include "Iface.h"
 #include "CoComtypesDispRecordParamTest.h"
+#include "CoComtypesDispSafearrayParamTest.h"
 
 
 ///////////////////////////////////////////////////////////
@@ -35,11 +36,17 @@
 //
 CFactoryData g_FactoryDataArray[] =
 {
-	{&CLSID_CoComtypesDispRecordParamTest, CA::CreateInstance, 
+	{&CLSID_CoComtypesDispRecordParamTest, CA::CreateInstance,
 		L"Comtypes component for dispinterface record parameter tests",	// Friendly Name
-		L"Comtypes.DispRecordParamTest.1",									// ProgID
-		L"Comtypes.DispRecordParamTest",										// Version-independent ProgID
-		&LIBID_ComtypesCppTestSrvLib,												// Type Library ID
+		L"Comtypes.DispRecordParamTest.1",								// ProgID
+		L"Comtypes.DispRecordParamTest",								// Version-independent ProgID
+		&LIBID_ComtypesCppTestSrvLib,									// Type Library ID
+		NULL, 0},
+	{&CLSID_CoComtypesDispSafearrayParamTest, CB::CreateInstance,
+		L"Comtypes component for dispinterface Safearray parameter tests",	// Friendly Name
+		L"Comtypes.DispSafearrayParamTest.1",								// ProgID
+		L"Comtypes.DispSafearrayParamTest",								// Version-independent ProgID
+		&LIBID_ComtypesCppTestSrvLib,									// Type Library ID
 		NULL, 0}
 } ;
 int g_cFactoryDataEntries

--- a/source/CppTestSrv/SERVER.IDL
+++ b/source/CppTestSrv/SERVER.IDL
@@ -46,6 +46,36 @@ dispinterface IDispRecordParamTest
 } ;
 
 
+// Interface IDualSafearrayParamTest
+[
+	odl,
+	uuid(1F4F3B8B-D07E-4BB6-8D2C-D79B375696DA),
+	dual,
+	helpstring("IDualSafearrayParamTest Interface"),
+	nonextensible,
+	oleautomation
+]
+interface IDualSafearrayParamTest : IDispatch
+{
+	[id(0x00000001)]
+	HRESULT InitArray([in, out] SAFEARRAY(double)* test_array) ;
+	[id(0x00000002)]
+	HRESULT VerifyArray(
+					[in] SAFEARRAY(double) test_array,
+					[out, retval] VARIANT_BOOL* result);
+} ;
+
+
+// Interface IDispSafearrayParamTest
+[
+	uuid(4097A6D0-A111-40E2-BD0B-177B775A9496)
+]
+dispinterface IDispSafearrayParamTest
+{
+	interface IDualSafearrayParamTest;
+} ;
+
+
 //
 // Component and type library descriptions
 //
@@ -69,5 +99,18 @@ library ComtypesCppTestSrvLib
 	{
 		interface IDualRecordParamTest ;
 		dispinterface IDispRecordParamTest ;
+	} ;
+
+
+	// CoComtypesDispSafearrayParamTest
+	// Component that implements interfaces used for dispinterface Safearray parameter tests.
+	[
+		uuid(091D762E-FF4B-4532-8B24-23807FE873C3),
+		helpstring("Comtypes component for dispinterface Safearray parameter tests.")
+	]
+	coclass CoComtypesDispSafearrayParamTest
+	{
+		interface IDualSafearrayParamTest ;
+		dispinterface IDispSafearrayParamTest ;
 	} ;
 } ;


### PR DESCRIPTION
With a COM Dual Interface it is possible to get server side changes to SAFEARRAYs marshaled back to the client.
However, for a pure IDispatch interface this is currently not implemented.

This pull request adds handling of SAFEARRAYs to the implementation of the automation interface.

A unittest and a new COM test interface for the C++ COM test server are also added.

I have to apologize for a mistake I made in [#535](https://github.com/enthought/comtypes/pull/535).
Back at the time I did favor the implementation of several related interfaces in a single component.
Unfortunately I didn't realize that this is a problem when the interfaces inherit from the same interface but require different implementations for this interface as is the case for IDispatch (see [Multiple Dual Interfaces](https://learn.microsoft.com/en-us/cpp/atl/multiple-dual-interfaces)).

While adding another component to the C++ COM test server was not a big deal, the component naming scheme for which I had advocated in [#535](https://github.com/enthought/comtypes/pull/535) is inadequate for this setup.

So I was wrong and therefore have now also changed the name of the component that implements the interface for record parameter testing to reflect its limited scope.

In the future, adding additional interfaces and components implementing them will be more straight forward.