### PR TITLE
fix importing `_encode_idl` in `_comobject`

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -38,7 +38,6 @@ else:
 from comtypes.GUID import GUID
 from comtypes import patcher  # noqa
 from comtypes._npsupport import interop as npsupport  # noqa
-from comtypes._memberspec import _encode_idl  # noqa
 from comtypes._tlib_version_checker import _check_version  # noqa
 from comtypes._bstr import BSTR  # noqa
 from comtypes._py_instance_method import instancemethod  # noqa

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -16,7 +16,8 @@ import os
 import queue
 import sys
 
-from comtypes import COMError, ReturnHRESULT, instancemethod, _encode_idl
+from comtypes import COMError, ReturnHRESULT, instancemethod
+from comtypes._memberspec import _encode_idl
 from comtypes.errorinfo import ISupportErrorInfo, ReportException, ReportError
 from comtypes import IPersist
 from comtypes.hresult import (


### PR DESCRIPTION
I noticed that the relationship between `_DispMemberSpec` and `automation` in #561 also applies to `_encode_idl` and `_comobject`, so I will make corrections.