### PR TITLE
Make the `numpy` version installed in the CI workflow lower than `2.0.0`

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -30,7 +30,7 @@ jobs:
       - name: unittest comtypes
         run: |
           if ("${{ matrix.npsupport }}" -eq "with npsupport") {
-            pip install numpy
+            pip install 'numpy<2'
           }
           python -m unittest discover -v -s ./comtypes/test -t comtypes\test
       - name: Unregister the OutProc COM server


### PR DESCRIPTION
ref: #573