### PR TITLE
Name change of component implementing record parameter testing.

### DIFF
--- a/comtypes/test/test_dispifc_records.py
+++ b/comtypes/test/test_dispifc_records.py
@@ -26,7 +26,7 @@ class Test_DispMethods(unittest.TestCase):
     def _create_dispifc(self) -> "ComtypesCppTestSrvLib.IDispRecordParamTest":
         # Explicitely ask for the dispinterface of the component.
         return CreateObject(
-            "Comtypes.DispIfcParamTests",
+            "Comtypes.DispRecordParamTest",
             clsctx=CLSCTX_LOCAL_SERVER,
             interface=ComtypesCppTestSrvLib.IDispRecordParamTest,
         )

--- a/source/CppTestSrv/CoComtypesDispRecordParamTest.cpp
+++ b/source/CppTestSrv/CoComtypesDispRecordParamTest.cpp
@@ -7,7 +7,7 @@
 */
 
 //
-// CoComtypesDispIfcParamTests.cpp - Component
+// CoComtypesDispRecordParamTest.cpp - Component
 //
 #include <objbase.h>
 #include <string.h>
@@ -18,7 +18,7 @@
 #include "Util.h"
 #include "CUnknown.h"
 #include "CFactory.h" // Needed for module handle
-#include "CoComtypesDispIfcParamTests.h"
+#include "CoComtypesDispRecordParamTest.h"
 
 // We need to put this declaration here because we explicitely expose a dispinterface
 // in parallel to the dual interface but dispinterfaces don't appear in the
@@ -26,9 +26,9 @@
 EXTERN_C const IID DIID_IDispRecordParamTest;
 
 static inline void trace(const char* msg)
-	{ Util::Trace("Component", msg, S_OK) ;}
+	{ Util::Trace("CoComtypesDispRecordParamTest", msg, S_OK) ;}
 static inline void trace(const char* msg, HRESULT hr)
-	{ Util::Trace("Component", msg, hr) ;}
+	{ Util::Trace("CoComtypesDispRecordParamTest", msg, hr) ;}
 
 ///////////////////////////////////////////////////////////
 //

--- a/source/CppTestSrv/CoComtypesDispRecordParamTest.h
+++ b/source/CppTestSrv/CoComtypesDispRecordParamTest.h
@@ -7,7 +7,7 @@
 */
 
 //
-// CoComtypesDispIfcParamTests.cpp - Component
+// CoComtypesDispRecordParamTest.cpp - Component
 //
 
 #include "Iface.h"

--- a/source/CppTestSrv/MAKEFILE
+++ b/source/CppTestSrv/MAKEFILE
@@ -44,9 +44,9 @@ guids.obj : guids.c
 server.obj : server.cpp cunknown.h cfactory.h iface.h
 	cl $(CPP_FLAGS) server.cpp
 
-CoComtypesDispIfcParamTests.obj : CoComtypesDispIfcParamTests.cpp CoComtypesDispIfcParamTests.h iface.h \
-		registry.h CUnknown.h
-	cl $(CPP_FLAGS) CoComtypesDispIfcParamTests.cpp
+CoComtypesDispRecordParamTest.obj : CoComtypesDispRecordParamTest.cpp \
+		CoComtypesDispRecordParamTest.h iface.h registry.h CUnknown.h
+	cl $(CPP_FLAGS) CoComtypesDispRecordParamTest.cpp
 
 #
 # Helper classes
@@ -75,7 +75,7 @@ outproc.obj : outproc.cpp CFactory.h CUnknown.h
 #
 
 SERVER_OBJS = Server.obj     \
-              CoComtypesDispIfcParamTests.obj      \
+              CoComtypesDispRecordParamTest.obj      \
               Registry.obj   \
               Cfactory.obj   \
               Cunknown.obj   \

--- a/source/CppTestSrv/SERVER.CPP
+++ b/source/CppTestSrv/SERVER.CPP
@@ -8,7 +8,7 @@
 
 #include "CFactory.h"
 #include "Iface.h"
-#include "CoComtypesDispIfcParamTests.h"
+#include "CoComtypesDispRecordParamTest.h"
 
 
 ///////////////////////////////////////////////////////////
@@ -35,10 +35,10 @@
 //
 CFactoryData g_FactoryDataArray[] =
 {
-	{&CLSID_CoComtypesDispIfcParamTests, CA::CreateInstance, 
-		L"Comtypes component for dispinterface parameter tests",	// Friendly Name
-		L"Comtypes.DispIfcParamTests.1",									// ProgID
-		L"Comtypes.DispIfcParamTests",										// Version-independent ProgID
+	{&CLSID_CoComtypesDispRecordParamTest, CA::CreateInstance, 
+		L"Comtypes component for dispinterface record parameter tests",	// Friendly Name
+		L"Comtypes.DispRecordParamTest.1",									// ProgID
+		L"Comtypes.DispRecordParamTest",										// Version-independent ProgID
 		&LIBID_ComtypesCppTestSrvLib,												// Type Library ID
 		NULL, 0}
 } ;

--- a/source/CppTestSrv/SERVER.IDL
+++ b/source/CppTestSrv/SERVER.IDL
@@ -59,13 +59,13 @@ library ComtypesCppTestSrvLib
 	// TLib : OLE Automation : {00020430-0000-0000-C000-000000000046}
 	importlib("stdole2.tlb") ;
 
-	// CoComtypesDispIfcParamTests
-	// Component that implements interfaces used for dispinterface parameter tests.
+	// CoComtypesDispRecordParamTest
+	// Component that implements interfaces used for dispinterface record parameter tests.
 	[
-		uuid(06571915-2431-4CA3-9C01-53002B060DAB),
-		helpstring("Comtypes component for dispinterface parameter tests.")
+		uuid(5E78C9A8-4C19-4285-BCD6-3FFBBA5B17A8),
+		helpstring("Comtypes component for dispinterface record parameter tests.")
 	]
-	coclass CoComtypesDispIfcParamTests
+	coclass CoComtypesDispRecordParamTest
 	{
 		interface IDualRecordParamTest ;
 		dispinterface IDispRecordParamTest ;


### PR DESCRIPTION
Background: Implementing several related interfaces in a single component is a problem when the interfaces inherit from the same interface but require different implementations for this interface as is the case for IDispatch. Therefore additional interfaces will be implemented in separate components.

The name change reflects the limited scope of the component.