### PR TITLE
Change the default value of the 'extra' parameter in the 'create' method of tagSAFEARRAY subtypes.

### DIFF
--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -109,7 +109,7 @@ def _make_safearray_type(itemtype):
         _needsfree = False
 
         @classmethod
-        def create(cls, value, extra=None):
+        def create(cls, value, extra=extra):
             """Create a POINTER(SAFEARRAY_...) instance of the correct
             type; value is an object containing the items to store.
 

--- a/comtypes/test/test_midl_safearray_create.py
+++ b/comtypes/test/test_midl_safearray_create.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+
+from ctypes import byref, c_int, pointer, POINTER
+import unittest
+
+import comtypes
+import comtypes.safearray
+from comtypes import CLSCTX_INPROC_SERVER
+from comtypes.client import CreateObject, GetModule
+import comtypes.typeinfo
+
+GetModule("UIAutomationCore.dll")
+from comtypes.gen.UIAutomationClient import CUIAutomation, IUIAutomation
+
+GetModule("scrrun.dll")
+from comtypes.gen.Scripting import Dictionary, IDictionary
+
+ComtypesCppTestSrvLib_GUID = "{07D2AEE5-1DF8-4D2C-953A-554ADFD25F99}"
+
+try:
+    GetModule((ComtypesCppTestSrvLib_GUID, 1, 0, 0))
+    from comtypes.gen.ComtypesCppTestSrvLib import StructRecordParamTest
+
+    IMPORT_FAILED = False
+except (ImportError, OSError):
+    IMPORT_FAILED = True
+
+
+class Test_midlSAFEARRAY_create(unittest.TestCase):
+    def test_iunk(self):
+        extra = pointer(IUIAutomation._iid_)
+        iuia = CreateObject(
+            CUIAutomation().IPersist_GetClassID(),
+            interface=IUIAutomation,
+            clsctx=CLSCTX_INPROC_SERVER,
+        )
+        sa_type = comtypes.safearray._midlSAFEARRAY(POINTER(IUIAutomation))
+        for ptn, sa in [
+            ("with extra", sa_type.create([iuia], extra=extra)),
+            ("without extra", sa_type.create([iuia])),
+        ]:
+            with self.subTest(ptn=ptn):
+                (unpacked,) = sa.unpack()
+                self.assertIsInstance(unpacked, POINTER(IUIAutomation))
+
+    def test_idisp(self):
+        extra = pointer(IDictionary._iid_)
+        idic = CreateObject(Dictionary, interface=IDictionary)
+        idic["foo"] = "bar"
+        sa_type = comtypes.safearray._midlSAFEARRAY(POINTER(IDictionary))
+        for ptn, sa in [
+            ("with extra", sa_type.create([idic], extra=extra)),
+            ("without extra", sa_type.create([idic])),
+        ]:
+            with self.subTest(ptn=ptn):
+                (unpacked,) = sa.unpack()
+                self.assertIsInstance(unpacked, POINTER(IDictionary))
+                self.assertEqual(unpacked["foo"], "bar")
+
+    @unittest.skipIf(IMPORT_FAILED, "This depends on the out of process COM-server.")
+    def test_record(self):
+        extra = comtypes.typeinfo.GetRecordInfoFromGuids(
+            *StructRecordParamTest._recordinfo_
+        )
+        record = StructRecordParamTest()
+        record.answer = 42
+        sa_type = comtypes.safearray._midlSAFEARRAY(StructRecordParamTest)
+        for ptn, sa in [
+            ("with extra", sa_type.create([record], extra=extra)),
+            ("without extra", sa_type.create([record])),
+        ]:
+            with self.subTest(ptn=ptn):
+                (unpacked,) = sa.unpack()
+                self.assertIsInstance(unpacked, StructRecordParamTest)
+                self.assertEqual(unpacked.answer, 42)
+
+    def test_ctype(self):
+        extra = None
+        cdata = c_int(1)
+        sa_type = comtypes.safearray._midlSAFEARRAY(c_int)
+        for ptn, sa in [
+            ("with extra", sa_type.create([cdata], extra=extra)),
+            ("without extra", sa_type.create([cdata])),
+        ]:
+            with self.subTest(ptn=ptn):
+                (unpacked,) = sa.unpack()
+                self.assertIsInstance(unpacked, int)
+                self.assertEqual(unpacked, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comtypes/test/test_midl_safearray_create.py
+++ b/comtypes/test/test_midl_safearray_create.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from ctypes import byref, c_int, pointer, POINTER
+from ctypes import c_int, pointer, POINTER
 import unittest
 
 import comtypes
@@ -64,7 +64,9 @@ class Test_midlSAFEARRAY_create(unittest.TestCase):
             *StructRecordParamTest._recordinfo_
         )
         record = StructRecordParamTest()
+        record.question = "The meaning of life, the universe and everything?"
         record.answer = 42
+        record.needs_clarification = True
         sa_type = comtypes.safearray._midlSAFEARRAY(StructRecordParamTest)
         for ptn, sa in [
             ("with extra", sa_type.create([record], extra=extra)),
@@ -73,7 +75,12 @@ class Test_midlSAFEARRAY_create(unittest.TestCase):
             with self.subTest(ptn=ptn):
                 (unpacked,) = sa.unpack()
                 self.assertIsInstance(unpacked, StructRecordParamTest)
+                self.assertEqual(
+                    unpacked.question,
+                    "The meaning of life, the universe and everything?",
+                )
                 self.assertEqual(unpacked.answer, 42)
+                self.assertEqual(unpacked.needs_clarification, True)
 
     def test_ctype(self):
         extra = None

--- a/source/CppTestSrv/SERVER.IDL
+++ b/source/CppTestSrv/SERVER.IDL
@@ -7,6 +7,8 @@
 
 import "oaidl.idl" ;
 
+// Simple structure used for tests related to IRecordInfo or GetRecordInfoFromGuids functionality.
+// If a new test would require other fields do NOT modify this structure but add a new structure instead.
 typedef [uuid(00FABB0F-5691-41A6-B7C1-11606671F8E5)]
 struct StructRecordParamTest {
 	BSTR question ;


### PR DESCRIPTION
With the current setting of [extra=None](https://github.com/enthought/comtypes/blob/11d7651e5ed04100ca0388e9617395cfc24092cf/comtypes/safearray.py#L112) you need to go through the following steps to create a SAFEARRAY of e.g. VT_RECORDs:
```
import comtypes
from comtypes.gen import SomeTypeLib

record_list = [SomeTypeLib.T_SOME_RECORD(), SomeTypeLib.T_SOME_RECORD()]
record_info = comtypes.typeinfo.GetRecordInfoFromGuids(*SomeTypeLib.T_SOME_RECORD._recordinfo_)
safearray_of_records = comtypes.safearray._midlSAFEARRAY(SomeTypeLib.T_SOME_RECORD).create(record_list , extra=record_info )
 ```
As the comment following [line 124 in safearray.py](https://github.com/enthought/comtypes/blob/11d7651e5ed04100ca0388e9617395cfc24092cf/comtypes/safearray.py#L124) says:
```
# For VT_UNKNOWN or VT_DISPATCH, extra must be a pointer to
# the GUID of the interface.
#
# For VT_RECORD, extra must be a pointer to an IRecordInfo
# describing the record.
 ```
Admittedly, some of the code in _safearray.py_ is deep Python black magic.
However, the _extra_ value required for the creation of SAFEARRAYs with VT_RECORD, VT_DISPATCH or VT_UNKNOWN elements is already identified at the time when the associated tagSAFEARRAY subtype is created in the [_make_safearray_type](https://github.com/enthought/comtypes/blob/11d7651e5ed04100ca0388e9617395cfc24092cf/comtypes/safearray.py#L81) method.

As far as I understand the code, the value of the local identifier _extra_ in __make_safearray_type_ is preserved in the closure of the _POINTER(sa_type)_. This can be seen in action e.g. in the [from_param ](https://github.com/enthought/comtypes/blob/11d7651e5ed04100ca0388e9617395cfc24092cf/comtypes/safearray.py#L212)method:
 ```
        @classmethod
        def from_param(cls, value):
            if not isinstance(value, cls):
                value = cls.create(value, extra)
                value._needsfree = True
            return value
```
To be quite frank, I don't understand why the _extra_ parameter in the _create_ method is required at all because the method has access to the same closure value. Maybe it's just to keep some flexibility or do I miss something?

Even less do I understand why the default setting is `None` because it requires the user code to perform the same procedure of getting a pointer to the IRecordInfo or the GUID of the VT_UNKNOWN or VT_DISPATCH interface again.

With the suggested change, the steps to create a SAFEARRAY of e.g. VT_RECORDs are reduced to:
```
import comtypes
from comtypes.gen import SomeTypeLib

record_list = [SomeTypeLib.T_SOME_RECORD(), SomeTypeLib.T_SOME_RECORD()]
safearray_of_records = comtypes.safearray._midlSAFEARRAY(SomeTypeLib.T_SOME_RECORD).create(record_list)
 ```
while the flexibility to pass a different value for the _extra_ parameter to the _create_ method is maintained.