### PR TITLE
add static typing for `_midlSAFEARRAY`

### DIFF
--- a/comtypes/_safearray.py
+++ b/comtypes/_safearray.py
@@ -1,7 +1,8 @@
 """SAFEARRAY api functions, data types, and constants."""
 
-from ctypes import *
-from ctypes.wintypes import *
+from ctypes import c_uint, c_ushort, c_void_p, POINTER, Structure, WinDLL
+from ctypes.wintypes import DWORD, LONG, UINT
+
 from comtypes import HRESULT, GUID
 
 ################################################################

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -26,13 +26,14 @@ import comtypes
 
 if TYPE_CHECKING:
     from comtypes import hints  # type: ignore
-
-try:
     from comtypes import _safearray
-except (ImportError, AttributeError):
+else:
+    try:
+        from comtypes import _safearray
+    except (ImportError, AttributeError):
 
-    class _safearray(object):
-        tagSAFEARRAY = None
+        class _safearray(object):
+            tagSAFEARRAY = None
 
 
 LCID = DWORD

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -40,6 +40,7 @@ else:
     from typing_extensions import Self
 
 import comtypes
+from comtypes import IUnknown as IUnknown, GUID as GUID
 from comtypes.automation import IDispatch as IDispatch, VARIANT as VARIANT
 from comtypes.server import IClassFactory as IClassFactory
 from comtypes.typeinfo import ITypeInfo as ITypeInfo
@@ -56,6 +57,7 @@ arguments and with `HRESULT` as its return type in its COM method definition.
 """
 
 _CT = TypeVar("_CT", bound=ctypes._CData)
+_T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
 
 class LP_SAFEARRAY(ctypes._Pointer[tagSAFEARRAY], Generic[_CT]):
     contents: tagSAFEARRAY
@@ -63,8 +65,21 @@ class LP_SAFEARRAY(ctypes._Pointer[tagSAFEARRAY], Generic[_CT]):
     _vartype_: ClassVar[int]
     _needsfree: ClassVar[bool]
 
+    @overload
+    @classmethod
+    def create(
+        cls: Type[LP_SAFEARRAY[ctypes._Pointer[_T_IUnknown]]],
+        value: Sequence[_T_IUnknown],
+        extra: ctypes._Pointer[GUID] = ...,
+    ) -> LP_SAFEARRAY[ctypes._Pointer[_T_IUnknown]]: ...
+    @overload
     @classmethod
     def create(cls, value: Sequence[_CT], extra: Any = ...) -> LP_SAFEARRAY[_CT]: ...
+    @overload
+    def unpack(
+        self: LP_SAFEARRAY[ctypes._Pointer[_T_IUnknown]],
+    ) -> Sequence[_T_IUnknown]: ...
+    @overload
     def unpack(self) -> Sequence[Any]: ...
 
 _T_coclass = TypeVar("_T_coclass", bound=comtypes.CoClass)

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -58,6 +58,7 @@ arguments and with `HRESULT` as its return type in its COM method definition.
 
 _CT = TypeVar("_CT", bound=ctypes._CData)
 _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
+_T_Struct = TypeVar("_T_Struct", bound=ctypes.Structure)
 
 class LP_SAFEARRAY(ctypes._Pointer[tagSAFEARRAY], Generic[_CT]):
     contents: tagSAFEARRAY
@@ -79,6 +80,8 @@ class LP_SAFEARRAY(ctypes._Pointer[tagSAFEARRAY], Generic[_CT]):
     def unpack(
         self: LP_SAFEARRAY[ctypes._Pointer[_T_IUnknown]],
     ) -> Sequence[_T_IUnknown]: ...
+    @overload
+    def unpack(self: LP_SAFEARRAY[_T_Struct]) -> Sequence[_T_Struct]: ...
     @overload
     def unpack(self) -> Sequence[Any]: ...
 

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -1,14 +1,17 @@
 # This stub contains...
 # - symbols those what might occur recursive imports in runtime.
 # - utilities for type hints.
+import ctypes
 import sys
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Generic,
     Iterator,
     List,
     NoReturn,
+    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -40,6 +43,7 @@ import comtypes
 from comtypes.automation import IDispatch as IDispatch, VARIANT as VARIANT
 from comtypes.server import IClassFactory as IClassFactory
 from comtypes.typeinfo import ITypeInfo as ITypeInfo
+from comtypes._safearray import tagSAFEARRAY as tagSAFEARRAY
 
 Incomplete: TypeAlias = Any
 """The type symbol is used temporarily until the COM library parsers or
@@ -50,6 +54,18 @@ Hresult: TypeAlias = int
 """The value returned when calling a method with no `[out]` or `[out, retval]`
 arguments and with `HRESULT` as its return type in its COM method definition.
 """
+
+_CT = TypeVar("_CT", bound=ctypes._CData)
+
+class LP_SAFEARRAY(ctypes._Pointer[tagSAFEARRAY], Generic[_CT]):
+    contents: tagSAFEARRAY
+    _itemtype_: ClassVar[_CT]  # type: ignore
+    _vartype_: ClassVar[int]
+    _needsfree: ClassVar[bool]
+
+    @classmethod
+    def create(cls, value: Sequence[_CT], extra: Any = ...) -> LP_SAFEARRAY[_CT]: ...
+    def unpack(self) -> Sequence[Any]: ...
 
 _T_coclass = TypeVar("_T_coclass", bound=comtypes.CoClass)
 

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -101,7 +101,7 @@ def _make_safearray_type(itemtype):
         else:
             raise TypeError(itemtype)
 
-    @Patch(POINTER(sa_type))
+    @Patch(POINTER(sa_type))  # type: ignore
     class _(object):
         # Should explain the ideas how SAFEARRAY is used in comtypes
         _itemtype_ = itemtype  # a ctypes type
@@ -362,7 +362,7 @@ def _make_safearray_type(itemtype):
             indices[dim] = restore
             return tuple(result)  # for compatibility with pywin32.
 
-    @Patch(POINTER(POINTER(sa_type)))
+    @Patch(POINTER(POINTER(sa_type)))  # type: ignore
     class __(object):
         @classmethod
         def from_param(cls, value):

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -1,9 +1,16 @@
 import threading
 import array
+from typing import TYPE_CHECKING
 import comtypes
 from ctypes import POINTER, Structure, byref, cast, c_long, memmove, pointer, sizeof
 from comtypes import _safearray, IUnknown, com_interface_registry
 from comtypes.patcher import Patch
+
+if TYPE_CHECKING:
+    from typing import Type, TypeVar
+    from comtypes import hints  # type: ignore
+
+    _CT = TypeVar("_CT", bound=comtypes._CData)
 
 _safearray_type_cache = {}
 
@@ -49,18 +56,18 @@ safearray_as_ndarray = _SafeArrayAsNdArrayContextManager()
 
 ################################################################
 # This is THE PUBLIC function: the gateway to the SAFEARRAY functionality.
-def _midlSAFEARRAY(itemtype):
+def _midlSAFEARRAY(itemtype: "Type[_CT]") -> "Type[hints.LP_SAFEARRAY[_CT]]":
     """This function mimics the 'SAFEARRAY(aType)' IDL idiom.  It
     returns a subtype of SAFEARRAY, instances will be built with a
     typecode VT_...  corresponding to the aType, which must be one of
     the supported ctypes.
     """
     try:
-        return POINTER(_safearray_type_cache[itemtype])
+        return POINTER(_safearray_type_cache[itemtype])  # type: ignore
     except KeyError:
         sa_type = _make_safearray_type(itemtype)
         _safearray_type_cache[itemtype] = sa_type
-        return POINTER(sa_type)
+        return POINTER(sa_type)  # type: ignore
 
 
 def _make_safearray_type(itemtype):
@@ -101,7 +108,7 @@ def _make_safearray_type(itemtype):
         else:
             raise TypeError(itemtype)
 
-    @Patch(POINTER(sa_type))  # type: ignore
+    @Patch(POINTER(sa_type))
     class _(object):
         # Should explain the ideas how SAFEARRAY is used in comtypes
         _itemtype_ = itemtype  # a ctypes type
@@ -362,7 +369,7 @@ def _make_safearray_type(itemtype):
             indices[dim] = restore
             return tuple(result)  # for compatibility with pywin32.
 
-    @Patch(POINTER(POINTER(sa_type)))  # type: ignore
+    @Patch(POINTER(POINTER(sa_type)))
     class __(object):
         @classmethod
         def from_param(cls, value):


### PR DESCRIPTION
Thanks to @geppi’s contribution, I’ve come to understand the behavior of `SAFEARRAY` and `_midlSAFEARRAY`.

I realized that `_midlSAFEARRAY` is a factory function that generates a new class, something that cannot be expressed in Python’s usual static type system.
Therefore, I added the `LP_SAFEARRAY` special typing symbol into `hints`.

Of course, it is not possible to express all runtime behaviors in the current stub, but since `create` and `unpack` will no longer result in static type errors, it should reduce noise during coding.