### PR TITLE
Add tests and method annotations for `IRecordInfo`

### DIFF
--- a/comtypes/test/test_recordinfo.py
+++ b/comtypes/test/test_recordinfo.py
@@ -1,0 +1,79 @@
+# coding: utf-8
+
+import unittest
+
+from comtypes import typeinfo
+from comtypes.client import GetModule
+from ctypes import byref, pointer, sizeof
+
+ComtypesCppTestSrvLib_GUID = "{07D2AEE5-1DF8-4D2C-953A-554ADFD25F99}"
+
+try:
+    GetModule((ComtypesCppTestSrvLib_GUID, 1, 0, 0))
+    from comtypes.gen.ComtypesCppTestSrvLib import StructRecordParamTest
+
+    IMPORT_FAILED = False
+except (ImportError, OSError):
+    IMPORT_FAILED = True
+
+
+def _create_recordinfo() -> typeinfo.IRecordInfo:
+    return typeinfo.GetRecordInfoFromGuids(*StructRecordParamTest._recordinfo_)
+
+
+def _create_record(
+    question: str, answer: int, needs_clarification: bool
+) -> "StructRecordParamTest":
+    record = StructRecordParamTest()
+    record.question = question
+    record.answer = answer
+    record.needs_clarification = needs_clarification
+    return record
+
+
+@unittest.skipIf(IMPORT_FAILED, "This depends on the out of process COM-server.")
+class Test_IRecordInfo(unittest.TestCase):
+    def test_RecordCopy(self):
+        dst_rec = StructRecordParamTest()
+        ri = _create_recordinfo()
+        ri.RecordCopy(pointer(_create_record("foo", 3, True)), byref(dst_rec))
+        self.assertEqual(dst_rec.question, "foo")
+        self.assertEqual(dst_rec.answer, 3)
+        self.assertEqual(dst_rec.needs_clarification, True)
+
+    def test_GetGuid(self):
+        *_, expected_guid = StructRecordParamTest._recordinfo_
+        self.assertEqual(str(_create_recordinfo().GetGuid()), expected_guid)
+
+    def test_GetName(self):
+        self.assertEqual(
+            _create_recordinfo().GetName(),
+            StructRecordParamTest.__qualname__,
+        )
+
+    def test_GetSize(self):
+        self.assertEqual(
+            _create_recordinfo().GetSize(),
+            sizeof(StructRecordParamTest),
+        )
+
+    def test_GetTypeInfo(self):
+        ta = _create_recordinfo().GetTypeInfo().GetTypeAttr()
+        *_, expected_guid = StructRecordParamTest._recordinfo_
+        self.assertEqual(str(ta.guid), expected_guid)
+
+    def test_IsMatchingType(self):
+        ri = _create_recordinfo()
+        ti = ri.GetTypeInfo()
+        self.assertTrue(typeinfo.GetRecordInfoFromTypeInfo(ti).IsMatchingType(ri))
+
+    def test_RecordCreateCopy(self):
+        ri = _create_recordinfo()
+        actual = ri.RecordCreateCopy(byref(_create_record("foo", 3, True)))
+        self.assertIsInstance(actual, int)
+        dst_rec = StructRecordParamTest()
+        ri.RecordCopy(actual, byref(dst_rec))
+        ri.RecordDestroy(actual)
+        self.assertEqual(dst_rec.question, "foo")
+        self.assertEqual(dst_rec.answer, 3)
+        self.assertEqual(dst_rec.needs_clarification, True)

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -45,6 +45,10 @@ from comtypes.automation import (
     tagVARIANT,
 )
 
+if TYPE_CHECKING:
+    from comtypes import hints  # type: ignore
+
+
 _CT = TypeVar("_CT", bound=_CData)
 _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
 
@@ -499,6 +503,27 @@ class IRecordInfo(IUnknown):
         result = array[:]
         # XXX Should SysFreeString the array contents. How to?
         return result
+
+    if TYPE_CHECKING:
+        # fmt: off
+        # def RecordInit
+        # def RecordClear
+        def RecordCopy(  # noqa
+            self, pvExisting: hints.Incomplete, pvNew: hints.Incomplete
+        ) -> hints.Hresult: ...
+        def GetGuid(self) -> GUID: ...  # noqa
+        def GetName(self) -> str: ...  # noqa
+        def GetSize(self) -> int: ...  # noqa
+        def GetTypeInfo(self) -> ITypeInfo: ...  # noqa
+        # def GetField
+        # def GetFieldNoCopy
+        # def PutField
+        # def PutFieldNoCopy
+        def IsMatchingType(self, value: "IRecordInfo") -> bool: ...  # noqa
+        # def RecordCreate
+        def RecordCreateCopy(self, pvSource: hints.Incomplete) -> int: ...  # noqa
+        def RecordDestroy(self, pvRecord: hints.Incomplete) -> hints.Hresult: ...  # noqa
+        # fmt: on
 
 
 IRecordInfo._methods_ = [


### PR DESCRIPTION
I made changes to the parts where the use cases were clear and it was easy to add tests and static typing.

Conversely, the parts that were not tested this time are the areas where the use cases are not yet understood.
I hope that future contributors will add those parts.