### PR TITLE
Refer to `Any` and `Tuple` from the `hints` stub instead of directly importing them in generated modules.

### DIFF
--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -3,9 +3,9 @@
 # - utilities for type hints.
 import ctypes
 import sys
-from typing import Any, ClassVar, Generic, NoReturn, TypeVar, overload
+from typing import Any as Any, ClassVar, Generic, NoReturn, TypeVar, overload
 from typing import Optional, Union as _UnionT
-from typing import List, Tuple, Type
+from typing import List, Tuple as Tuple, Type
 from typing import Callable, Iterator, Sequence
 
 if sys.version_info >= (3, 8):

--- a/comtypes/tools/codegenerator/codegenerator.py
+++ b/comtypes/tools/codegenerator/codegenerator.py
@@ -196,7 +196,6 @@ class CodeGenerator(object):
         print("from typing import TYPE_CHECKING", file=output)
         print(file=output)
         print("if TYPE_CHECKING:", file=output)
-        print("    from typing import Any, Tuple", file=output)
         print("    from comtypes import hints", file=output)
         print(file=output)
         print(file=output)

--- a/comtypes/tools/codegenerator/typeannotator.py
+++ b/comtypes/tools/codegenerator/typeannotator.py
@@ -232,14 +232,14 @@ class ComMethodAnnotator(_MethodAnnotator[typedesc.ComMethod]):
         has_optional = False
         for _, argname, default in self.inarg_specs:
             if keyword.iskeyword(argname):
-                inargs = ["*args: Any", "**kwargs: Any"]
+                inargs = ["*args: hints.Any", "**kwargs: hints.Any"]
                 break
             if default is None:
                 if has_optional:
                     # probably propput or propputref
                     # HACK: Something that goes into this conditional branch
                     #       should be a special callback.
-                    inargs.append("**kwargs: Any")
+                    inargs.append("**kwargs: hints.Any")
                     break
                 inargs.append(f"{argname}: hints.Incomplete")
             else:
@@ -251,7 +251,7 @@ class ComMethodAnnotator(_MethodAnnotator[typedesc.ComMethod]):
         elif len(outargs) == 1:
             out = outargs[0]
         else:
-            out = "Tuple[" + ", ".join(outargs) + "]"
+            out = "hints.Tuple[" + ", ".join(outargs) + "]"
         in_ = ("self, " + ", ".join(inargs)) if inargs else "self"
         return f"def {name}({in_}) -> {out}: ..."
 
@@ -275,14 +275,14 @@ class DispMethodAnnotator(_MethodAnnotator[typedesc.DispMethod]):
         has_optional = False
         for _, argname, default in self.inarg_specs:
             if keyword.iskeyword(argname):
-                inargs = ["*args: Any", "**kwargs: Any"]
+                inargs = ["*args: hints.Any", "**kwargs: hints.Any"]
                 break
             if default is None:
                 if has_optional:
                     # probably propput or propputref
                     # HACK: Something that goes into this conditional branch
                     #       should be a special callback.
-                    inargs.append("**kwargs: Any")
+                    inargs.append("**kwargs: hints.Any")
                     break
                 inargs.append(f"{argname}: hints.Incomplete")
             else:


### PR DESCRIPTION
To prevent confusion with interfaces and components, static typing symbols like `Any` and `Tuple` in the generated module will be referred to from the `hints` module.