### PR TITLE
Improve member defining parts of `ParseInterface` and `ParseDispatch`

### DIFF
--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -309,10 +309,11 @@ class Parser(object):
                 elemdesc = fd.lprgelemdescParam[j]
                 typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[j + 1]
-                flags = elemdesc._.paramdesc.wParamFlags
+                paramdesc = elemdesc._.paramdesc
+                flags = paramdesc.wParamFlags
                 if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
-                    var = elemdesc._.paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
+                    var = paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
                     default: Any = var.value
                 else:
                     default = None
@@ -395,10 +396,11 @@ class Parser(object):
                 elemdesc = fd.lprgelemdescParam[j]
                 typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[j + 1]
-                flags = elemdesc._.paramdesc.wParamFlags
+                paramdesc = elemdesc._.paramdesc
+                flags = paramdesc.wParamFlags
                 if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
-                    var = elemdesc._.paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
+                    var = paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
                     default: Any = var.value
                 else:
                     default = None

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -310,14 +310,14 @@ class Parser(object):
                 typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[j + 1]
                 paramdesc = elemdesc._.paramdesc
-                flags = paramdesc.wParamFlags
-                if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
+                paramflags = paramdesc.wParamFlags
+                if paramflags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
                     var = paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
                     default: Any = var.value
                 else:
                     default = None
-                mth.add_argument(typ, name, self.param_flags(flags), default)
+                mth.add_argument(typ, name, self.param_flags(paramflags), default)
             members.append((fd.oVft, mth))
         # Sort the methods by oVft (VTable offset): Some typeinfo
         # don't list methods in VTable order.
@@ -397,14 +397,14 @@ class Parser(object):
                 typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[j + 1]
                 paramdesc = elemdesc._.paramdesc
-                flags = paramdesc.wParamFlags
-                if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
+                paramflags = paramdesc.wParamFlags
+                if paramflags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
                     var = paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
                     default: Any = var.value
                 else:
                     default = None
-                mth.add_argument(typ, name, self.param_flags(flags), default)
+                mth.add_argument(typ, name, self.param_flags(paramflags), default)
             itf.add_member(mth)
         return itf
 

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -298,6 +298,7 @@ class Parser(object):
             names = tinfo.GetNames(fd.memid, fd.cParams + 1)
             names.append("rhs")
             names = names[: fd.cParams + 1]
+            # function name first, then parameter names
             assert len(names) == fd.cParams + 1
             flags = self.func_flags(fd.wFuncFlags)
             flags += self.inv_kind(fd.invkind)
@@ -305,16 +306,13 @@ class Parser(object):
                 fd.invkind, fd.memid, func_name, returns, flags, func_doc
             )
             for p in range(fd.cParams):
-                typ = self.make_type(fd.lprgelemdescParam[p].tdesc, tinfo)
+                elemdesc = fd.lprgelemdescParam[p]
+                typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[p + 1]
-                flags = fd.lprgelemdescParam[p]._.paramdesc.wParamFlags
+                flags = elemdesc._.paramdesc.wParamFlags
                 if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
-                    var = (
-                        fd.lprgelemdescParam[p]
-                        ._.paramdesc.pparamdescex[0]
-                        .varDefaultValue
-                    )
+                    var = elemdesc._.paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
                     default: Any = var.value
                 else:
                     default = None
@@ -386,21 +384,21 @@ class Parser(object):
             names = tinfo.GetNames(fd.memid, fd.cParams + 1)
             names.append("rhs")
             names = names[: fd.cParams + 1]
-            assert (
-                len(names) == fd.cParams + 1
-            )  # function name first, then parameter names
+            # function name first, then parameter names
+            assert len(names) == fd.cParams + 1
             flags = self.func_flags(fd.wFuncFlags)
             flags += self.inv_kind(fd.invkind)
             mth = typedesc.DispMethod(
                 fd.memid, fd.invkind, func_name, returns, flags, func_doc
             )
             for p in range(fd.cParams):
-                descparam = fd.lprgelemdescParam[p]
-                typ = self.make_type(descparam.tdesc, tinfo)
+                elemdesc = fd.lprgelemdescParam[p]
+                typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[p + 1]
-                flags = descparam._.paramdesc.wParamFlags
+                flags = elemdesc._.paramdesc.wParamFlags
                 if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
-                    var = descparam._.paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
+                    # XXX should be handled by VARIANT itself
+                    var = elemdesc._.paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
                     default: Any = var.value
                 else:
                     default = None

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -310,14 +310,13 @@ class Parser(object):
                 typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[j + 1]
                 paramdesc = elemdesc._.paramdesc
-                paramflags = paramdesc.wParamFlags
-                if paramflags & typeinfo.PARAMFLAG_FHASDEFAULT:
+                if paramdesc.wParamFlags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
-                    var = paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
-                    default: Any = var.value
+                    default: Any = paramdesc.pparamdescex[0].varDefaultValue.value
                 else:
                     default = None
-                mth.add_argument(typ, name, self.param_flags(paramflags), default)
+                param_flags = self.param_flags(paramdesc.wParamFlags)
+                mth.add_argument(typ, name, param_flags, default)
             members.append((fd.oVft, mth))
         # Sort the methods by oVft (VTable offset): Some typeinfo
         # don't list methods in VTable order.
@@ -397,14 +396,13 @@ class Parser(object):
                 typ = self.make_type(elemdesc.tdesc, tinfo)
                 name = names[j + 1]
                 paramdesc = elemdesc._.paramdesc
-                paramflags = paramdesc.wParamFlags
-                if paramflags & typeinfo.PARAMFLAG_FHASDEFAULT:
+                if paramdesc.wParamFlags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
-                    var = paramdesc.pparamdescex[0].varDefaultValue  # type: ignore
-                    default: Any = var.value
+                    default: Any = paramdesc.pparamdescex[0].varDefaultValue.value
                 else:
                     default = None
-                mth.add_argument(typ, name, self.param_flags(paramflags), default)
+                param_flags = self.param_flags(paramdesc.wParamFlags)
+                mth.add_argument(typ, name, param_flags, default)
             itf.add_member(mth)
         return itf
 

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -305,10 +305,10 @@ class Parser(object):
             mth = typedesc.ComMethod(
                 fd.invkind, fd.memid, func_name, returns, flags, func_doc
             )
-            for p in range(fd.cParams):
-                elemdesc = fd.lprgelemdescParam[p]
+            for j in range(fd.cParams):
+                elemdesc = fd.lprgelemdescParam[j]
                 typ = self.make_type(elemdesc.tdesc, tinfo)
-                name = names[p + 1]
+                name = names[j + 1]
                 flags = elemdesc._.paramdesc.wParamFlags
                 if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself
@@ -391,10 +391,10 @@ class Parser(object):
             mth = typedesc.DispMethod(
                 fd.memid, fd.invkind, func_name, returns, flags, func_doc
             )
-            for p in range(fd.cParams):
-                elemdesc = fd.lprgelemdescParam[p]
+            for j in range(fd.cParams):
+                elemdesc = fd.lprgelemdescParam[j]
                 typ = self.make_type(elemdesc.tdesc, tinfo)
-                name = names[p + 1]
+                name = names[j + 1]
                 flags = elemdesc._.paramdesc.wParamFlags
                 if flags & typeinfo.PARAMFLAG_FHASDEFAULT:
                     # XXX should be handled by VARIANT itself

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -1199,7 +1199,7 @@ class N11tagELEMDESC5DOLLAR_204E(ctypes.Union):
 class tagPARAMDESC(ctypes.Structure):
     # C:/Programme/gccxml/bin/Vc71/PlatformSDK/oaidl.h 609
     if TYPE_CHECKING:
-        pparamdescex: "tagPARAMDESCEX"
+        pparamdescex: "_Pointer[tagPARAMDESCEX]"
         wParamFlags: int
 
 


### PR DESCRIPTION
Since there were parts of `ParseDispatch` and `ParseInterface` that performed almost the same processing, I unified the style.

While further code reduction might be possible in the future, this patch is limited to the processing within the `range(fd.cParams)` loop.