### PR TITLE
Improve `_CArrayType` alias import.

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -4,7 +4,7 @@ import datetime
 import decimal
 import sys
 from ctypes import *
-from ctypes import _Pointer
+from ctypes import _Pointer, Array as _CArrayType
 from _ctypes import CopyComPointer
 from ctypes.wintypes import DWORD, LONG, UINT, VARIANT_BOOL, WCHAR, WORD
 from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING, Type
@@ -610,7 +610,6 @@ v._.VT_I4 = 0x80020004
 del v
 
 _carg_obj = type(byref(c_int()))
-from ctypes import Array as _CArrayType
 
 
 @comtypes.patcher.Patch(POINTER(VARIANT))

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -750,7 +750,7 @@ EXCEPINFO = tagEXCEPINFO
 
 class tagDISPPARAMS(Structure):
     if TYPE_CHECKING:
-        rgvarg: Array[VARIANT]
+        rgvarg: _CArrayType[VARIANT]
         rgdispidNamedArgs: _Pointer[DISPID]
         cArgs: int
         cNamedArgs: int


### PR DESCRIPTION
By making the linter settings stricter, a warning was issued because `_CArrayType` was imported in the middle of the module.

To resolve this, I moved the import line to the top of the module.

Additionally, for static typing, it is better to use explicitly defined symbols rather than those imported with a wildcard.
Therefore, I changed the parts that were previously typed with `Array` to be typed with `_CArrayType`.