### PR TITLE
Rename `_byref_type` and `_carg_obj` to `_CArgObject`.

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -16,9 +16,11 @@ import comtypes.patcher
 import comtypes
 
 if TYPE_CHECKING:
+    from ctypes import _CArgObject
     from comtypes import hints  # type: ignore
     from comtypes import _safearray
 else:
+    _CArgObject = type(byref(c_int()))
     try:
         from comtypes import _safearray
     except (ImportError, AttributeError):
@@ -609,8 +611,6 @@ v.vt = VT_ERROR
 v._.VT_I4 = 0x80020004
 del v
 
-_carg_obj = type(byref(c_int()))
-
 
 @comtypes.patcher.Patch(POINTER(VARIANT))
 class _(object):
@@ -625,7 +625,7 @@ class _(object):
         if isinstance(arg, POINTER(VARIANT)):
             return arg
         # accept byref(VARIANT) instance
-        if isinstance(arg, _carg_obj) and isinstance(arg._obj, VARIANT):
+        if isinstance(arg, _CArgObject) and isinstance(arg._obj, VARIANT):
             return arg
         # accept VARIANT instance
         if isinstance(arg, VARIANT):

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -52,7 +52,6 @@ INVOKEKIND = tagINVOKEKIND
 # helpers
 IID_NULL = GUID()
 riid_null = byref(IID_NULL)
-_byref_type = type(byref(c_int()))
 
 # 30. December 1899, midnight.  For VT_DATE.
 _com_null_date = datetime.datetime(1899, 12, 30, 0, 0, 0)
@@ -384,7 +383,7 @@ class tagVARIANT(Structure):
         elif isinstance(value, c_uint64):
             self.vt = VT_UI8
             self._.VT_UI8 = value
-        elif isinstance(value, _byref_type):
+        elif isinstance(value, _CArgObject):
             ref = value._obj
             self._.c_void_p = addressof(ref)
             self.__keepref = value


### PR DESCRIPTION
I noticed that `_carg_obj` and `_byref_type` in the `automation` module refer to the same type.
Additionally, in `typeshed`, the `_CArgObject` symbol is defined to refer to this same type.