### PR TITLE
Add `test_msvidctl`.

### DIFF
--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -81,8 +81,10 @@ class Test_GetModule(ut.TestCase):
         with contextlib.redirect_stdout(None):  # supress warnings
             mod = comtypes.client.GetModule("msvidctl.dll")
         from comtypes.persist import IPersist
+        from comtypes.typeinfo import IRecordInfo
 
         self.assertIs(mod.IPersist, IPersist)
+        self.assertIs(mod.IRecordInfo, IRecordInfo)
 
     def test_no_replacing_Patch_namespace(self):
         # NOTE: An object named `Patch` is defined in some dll.

--- a/comtypes/test/test_client.py
+++ b/comtypes/test/test_client.py
@@ -77,6 +77,13 @@ class Test_GetModule(ut.TestCase):
 
         self.assertTrue(issubclass(mod.IStream, ISequentialStream))
 
+    def test_msvidctl(self):
+        with contextlib.redirect_stdout(None):  # supress warnings
+            mod = comtypes.client.GetModule("msvidctl.dll")
+        from comtypes.persist import IPersist
+
+        self.assertIs(mod.IPersist, IPersist)
+
     def test_no_replacing_Patch_namespace(self):
         # NOTE: An object named `Patch` is defined in some dll.
         # Depending on how the namespace is defined in the static module,


### PR DESCRIPTION
We didn't have any tests to check whether the interfaces defined in `comtypes.persist` and `comtypes.typeinfo` were imported into the actually generated wrapper modules.
The wrapper module generated from `msvidctl.dll` imports those interfaces, so it is ideal for testing them.