### PR TITLE
Add `test_persist`.

### DIFF
--- a/comtypes/test/test_persist.py
+++ b/comtypes/test/test_persist.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import tempfile
+import unittest as ut
+
+from comtypes import CoCreateInstance, GUID, IPersist
+from comtypes import persist
+
+
+CLSID_ShellLink = GUID("{00021401-0000-0000-C000-000000000046}")
+
+
+class Test_IPersist(ut.TestCase):
+    def test_GetClassID(self):
+        p = CoCreateInstance(CLSID_ShellLink).QueryInterface(IPersist)
+        self.assertEqual(p.GetClassID(), CLSID_ShellLink)
+
+
+class Test_IPersistFile(ut.TestCase):
+    def setUp(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        self.tmp_dir = Path(td.name)
+
+    def _create_pf(self) -> persist.IPersistFile:
+        return CoCreateInstance(CLSID_ShellLink).QueryInterface(persist.IPersistFile)
+
+    def test_load(self):
+        pf = self._create_pf()
+        tgt_file = (self.tmp_dir / "tgt.txt").resolve()
+        tgt_file.touch()
+        pf.Load(str(tgt_file), persist.STGM_DIRECT)
+        self.assertEqual(pf.GetCurFile(), str(tgt_file))
+
+    def test_save(self):
+        pf = self._create_pf()
+        tgt_file = self.tmp_dir / "tgt.txt"
+        self.assertFalse(tgt_file.exists())
+        pf.Save(str(tgt_file), True)
+        self.assertEqual(pf.GetCurFile(), str(tgt_file))
+        self.assertTrue(tgt_file.exists())


### PR DESCRIPTION
The `persist` module has not been tested until now.

First, I added unit tests for `IPersist`, which serves as the base for the interfaces defined in the `persist` module.

Next, I added test cases for `IPersistFile`. It was easy to write them since its use cases are documented in `shelllink`.
To test `IPersistFile::IsDirty`, methods implemented in interfaces other than `IPersistFile` need to be called. These are already covered in the `shelllink` tests, so they are not included here.

I have not included tests for other interfaces, as their use cases are not yet clear.
I hope that tests for these interfaces will be expanded in the future with the community’s help.