### PR TITLE
Remove Python 3.7 from `python-version` in CI pipelines.

### DIFF
--- a/.github/workflows/autofmt.yml
+++ b/.github/workflows/autofmt.yml
@@ -12,7 +12,7 @@ jobs:
           - name: Set up Python
             uses: actions/setup-python@v5
             with:
-              python-version: 3.7
+              python-version: 3.8
           - name: Install black
             run: pip install black==22.12.0
           # PRs from the forked repo will trigger format-checking only.

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         architecture: ['x86', 'x64']
         npsupport: ['with npsupport', 'without npsupport']
     steps:


### PR DESCRIPTION
See also #613.