### PR TITLE
Modernize `tools.tlbparser.get_tlib_filename`.

### DIFF
--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -732,7 +732,7 @@ class TypeLibParser(Parser):
 # path = r"c:\vc98\include\activscp.tlb"
 
 
-def get_tlib_filename(tlib):
+def get_tlib_filename(tlib: typeinfo.ITypeLib) -> Optional[str]:
     # seems if the typelib is not registered, there's no way to
     # determine the filename.
     la = tlib.GetLibAttr()

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -737,11 +737,6 @@ def get_tlib_filename(tlib: typeinfo.ITypeLib) -> Optional[str]:
     # determine the filename.
     la = tlib.GetLibAttr()
     name = BSTR()
-    try:
-        windll.oleaut32.QueryPathOfRegTypeLib
-    except AttributeError:
-        # Windows CE doesn't have this function
-        return None
     if 0 == windll.oleaut32.QueryPathOfRegTypeLib(
         byref(la.guid), la.wMajorVerNum, la.wMinorVerNum, 0, byref(name)  # lcid
     ):


### PR DESCRIPTION
The support for Windows CE was discussed in #211 and dropped in [version 1.1.8](https://github.com/enthought/comtypes/releases/tag/1.1.8).

Recently, there was another discussion in #554.

While looking the codebase, I noticed a workaround for Windows CE still remained, so I'm removing it here. 

Other than that, it's the usual addition of type annotations.