### PR TITLE
Improve patching classes in `_compointer_meta`.

### DIFF
--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -96,7 +96,7 @@ class _cominterface_meta(type):
             {"__com_interface__": new_cls, "_needs_com_addref_": None},
         )
 
-        from ctypes import _pointer_type_cache
+        from ctypes import _pointer_type_cache  # type: ignore
 
         _pointer_type_cache[new_cls] = p
 

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -101,6 +101,15 @@ class _cominterface_meta(type):
         _pointer_type_cache[new_cls] = p
 
         if new_cls._case_insensitive_:
+            new_cls._patch_to_ptr_type(p, True)
+        else:
+            new_cls._patch_to_ptr_type(p, False)
+
+        return new_cls
+
+    @staticmethod
+    def _patch_to_ptr_type(p, case_insensitive) -> None:
+        if case_insensitive:
 
             @patcher.Patch(p)
             class CaseInsensitive(object):
@@ -154,8 +163,6 @@ class _cominterface_meta(type):
                 from _ctypes import CopyComPointer
 
                 CopyComPointer(value, self)
-
-        return new_cls
 
     def __setattr__(self, name, value):
         if name == "_methods_":


### PR DESCRIPTION
While experimenting with #618, I noticed that `_compointer_meta.__new__` has quite a large number of lines.
Most of these lines come from patching multiple classes with `patcher.Patch`, so I refactored them into a separate method to reduce the number of lines in `__new__` itself.

I considered that it could cause confusion if the separated method were an instance method with `self` as the first argument, as the `self` of the class's instance methods which are defined inside the method, could get mixed up.
Therefore, I defined the refactored method as a private `staticmethod`.