### PR TITLE
Split `_cominterface_meta._patch_to_ptr_type`.

### DIFF
--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -157,11 +157,11 @@ class _cominterface_meta(type):
                     # CopyComPointer should do if index != 0.
                     if bool(value):
                         value.AddRef()
-                    super(POINTER(p), self).__setitem__(index, value)
+                    super(POINTER(p), self).__setitem__(index, value)  # type: ignore
                     return
                 from _ctypes import CopyComPointer
 
-                CopyComPointer(value, self)
+                CopyComPointer(value, self)  # type: ignore
 
     def __setattr__(self, name, value):
         if name == "_methods_":


### PR DESCRIPTION
A continuation of #624.

I also added comments about [Exception Chaining](https://docs.python.org/3/tutorial/errors.html#exception-chaining).