### PR TITLE
Improve static typing for `CoGetClassObject` and `GetClassObject`.

### DIFF
--- a/comtypes/_post_coinit/misc.py
+++ b/comtypes/_post_coinit/misc.py
@@ -153,14 +153,22 @@ def CoCreateInstance(
 if TYPE_CHECKING:
 
     @overload
-    def CoGetClassObject(clsid, clsctx=None, pServerInfo=None, interface=None):
-        # type: (GUID, Optional[int], Optional[COSERVERINFO], None) -> hints.IClassFactory
-        pass
+    def CoGetClassObject(
+        clsid: GUID,
+        clsctx: Optional[int] = None,
+        pServerInfo: "Optional[COSERVERINFO]" = None,
+        interface: None = None,
+    ) -> hints.IClassFactory:
+        ...
 
     @overload
-    def CoGetClassObject(clsid, clsctx=None, pServerInfo=None, interface=None):
-        # type: (GUID, Optional[int], Optional[COSERVERINFO], Type[_T_IUnknown]) -> _T_IUnknown
-        pass
+    def CoGetClassObject(
+        clsid: GUID,
+        clsctx: Optional[int] = None,
+        pServerInfo: "Optional[COSERVERINFO]" = None,
+        interface: Type[_T_IUnknown] = hints.IClassFactory,
+    ) -> _T_IUnknown:
+        ...
 
 
 def CoGetClassObject(clsid, clsctx=None, pServerInfo=None, interface=None):

--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -193,14 +193,22 @@ def _manage(
 if TYPE_CHECKING:
 
     @overload
-    def GetClassObject(progid, clsctx=None, pServerInfo=None):
-        # type: (_UnionT[str, CoClass, GUID], Optional[int], Optional[comtypes.COSERVERINFO]) -> hints.IClassFactory
-        pass
+    def GetClassObject(
+        progid: _UnionT[str, CoClass, GUID],
+        clsctx: Optional[int] = None,
+        pServerInfo: Optional[comtypes.COSERVERINFO] = None,
+        interface: None = None,
+    ) -> hints.IClassFactory:
+        ...
 
     @overload
-    def GetClassObject(progid, clsctx=None, pServerInfo=None, interface=None):
-        # type: (_UnionT[str, CoClass, GUID], Optional[int], Optional[comtypes.COSERVERINFO], Optional[Type[_T_IUnknown]]) -> _T_IUnknown
-        pass
+    def GetClassObject(
+        progid: _UnionT[str, CoClass, GUID],
+        clsctx: Optional[int] = None,
+        pServerInfo: Optional[comtypes.COSERVERINFO] = None,
+        interface: Type[_T_IUnknown] = hints.IClassFactory,
+    ) -> _T_IUnknown:
+        ...
 
 
 def GetClassObject(progid, clsctx=None, pServerInfo=None, interface=None):


### PR DESCRIPTION
I modernized the type annotations from comment-based to inline annotations.

Since they are under the `if TYPE_CHECKING` block, they don't affect runtime behavior.

I plan to make changes to the runtime code after adding tests.