### PR TITLE
Use `self` instead of `klass`/`new_cls` in the `__new__` of metaclasses.

### DIFF
--- a/comtypes/_meta.py
+++ b/comtypes/_meta.py
@@ -58,7 +58,7 @@ class _coclass_meta(type):
                 "from_param": classmethod(_coclass_from_param),
             },
         )
-        from ctypes import _pointer_type_cache
+        from ctypes import _pointer_type_cache  # type: ignore
 
         _pointer_type_cache[self] = PTR
 

--- a/comtypes/_meta.py
+++ b/comtypes/_meta.py
@@ -51,7 +51,7 @@ class _coclass_meta(type):
             clsid = namespace["_reg_clsid_"]
             comtypes.com_coclass_registry[str(clsid)] = self
         PTR = _coclass_pointer_meta(
-            "POINTER(%s)" % self.__name__,
+            f"POINTER({self.__name__})",
             (self, c_void_p),
             {
                 "__ctypes_from_outparam__": _wrap_coclass,

--- a/comtypes/_meta.py
+++ b/comtypes/_meta.py
@@ -43,16 +43,16 @@ class _coclass_meta(type):
     # will QueryInterface for the default interface: the first one on
     # the coclass' _com_interfaces_ list.
     def __new__(cls, name, bases, namespace):
-        klass = type.__new__(cls, name, bases, namespace)
+        self = type.__new__(cls, name, bases, namespace)
         if bases == (object,):
-            return klass
+            return self
         # XXX We should insist that a _reg_clsid_ is present.
         if "_reg_clsid_" in namespace:
             clsid = namespace["_reg_clsid_"]
-            comtypes.com_coclass_registry[str(clsid)] = klass
+            comtypes.com_coclass_registry[str(clsid)] = self
         PTR = _coclass_pointer_meta(
-            "POINTER(%s)" % klass.__name__,
-            (klass, c_void_p),
+            "POINTER(%s)" % self.__name__,
+            (self, c_void_p),
             {
                 "__ctypes_from_outparam__": _wrap_coclass,
                 "from_param": classmethod(_coclass_from_param),
@@ -60,9 +60,9 @@ class _coclass_meta(type):
         )
         from ctypes import _pointer_type_cache
 
-        _pointer_type_cache[klass] = PTR
+        _pointer_type_cache[self] = PTR
 
-        return klass
+        return self
 
 
 # will not work if we change the order of the two base classes!

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -69,12 +69,12 @@ class _cominterface_meta(type):
     def __new__(cls, name, bases, namespace):
         methods = namespace.pop("_methods_", None)
         dispmethods = namespace.pop("_disp_methods_", None)
-        new_cls = type.__new__(cls, name, bases, namespace)
+        self = type.__new__(cls, name, bases, namespace)
 
         if methods is not None:
-            new_cls._methods_ = methods
+            self._methods_ = methods
         if dispmethods is not None:
-            new_cls._disp_methods_ = dispmethods
+            self._disp_methods_ = dispmethods
 
         # If we sublass a COM interface, for example:
         #
@@ -85,26 +85,26 @@ class _cominterface_meta(type):
         # subclass of POINTER(IUnknown) because of the way ctypes
         # typechecks work.
         if bases == (object,):
-            _ptr_bases = (new_cls, _compointer_base)
+            _ptr_bases = (self, _compointer_base)
         else:
-            _ptr_bases = (new_cls, POINTER(bases[0]))
+            _ptr_bases = (self, POINTER(bases[0]))
 
-        # The interface 'new_cls' is used as a mixin.
+        # The interface 'self' is used as a mixin.
         p = type(_compointer_base)(
-            "POINTER(%s)" % new_cls.__name__,
+            "POINTER(%s)" % self.__name__,
             _ptr_bases,
-            {"__com_interface__": new_cls, "_needs_com_addref_": None},
+            {"__com_interface__": self, "_needs_com_addref_": None},
         )
 
         from ctypes import _pointer_type_cache  # type: ignore
 
-        _pointer_type_cache[new_cls] = p
+        _pointer_type_cache[self] = p
 
-        if new_cls._case_insensitive_:
-            new_cls._patch_case_insensitive_to_ptr_type(p)
-        new_cls._patch_reference_fix_to_ptrptr_type(p)
+        if self._case_insensitive_:
+            self._patch_case_insensitive_to_ptr_type(p)
+        self._patch_reference_fix_to_ptrptr_type(p)
 
-        return new_cls
+        return self
 
     @staticmethod
     def _patch_case_insensitive_to_ptr_type(p: Type) -> None:

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -91,7 +91,7 @@ class _cominterface_meta(type):
 
         # The interface 'self' is used as a mixin.
         p = type(_compointer_base)(
-            "POINTER(%s)" % self.__name__,
+            f"POINTER({self.__name__})",
             _ptr_bases,
             {"__com_interface__": self, "_needs_com_addref_": None},
         )


### PR DESCRIPTION
I changed the variable names assigned to the return value of calling the equivalent of `super().__new__` within the `__new__` method of metaclasses from `klass`/`new_cls` to `self`.

This seems to be universal in recent modern code, and it can also reduce the differences when adding version bridges for Python 3.13 support.