### PR TITLE
Add comments to metaclasses.

### DIFF
--- a/comtypes/_meta.py
+++ b/comtypes/_meta.py
@@ -67,4 +67,6 @@ class _coclass_meta(type):
 
 # will not work if we change the order of the two base classes!
 class _coclass_pointer_meta(type(c_void_p), _coclass_meta):
-    pass
+    # metaclass for CoClass pointer
+
+    pass  # no functionality, but needed to avoid a metaclass conflict

--- a/comtypes/_meta.py
+++ b/comtypes/_meta.py
@@ -47,11 +47,11 @@ class _coclass_meta(type):
         if bases == (object,):
             # HACK: Could this conditional branch be removed since it is never reached?
             # Since definition is `class CoClass(COMObject, metaclass=_coclass_meta)`,
-            # the `bases` parameter passed to `_coclass_meta.__new__` would be
+            # the `bases` parameter passed to the `_coclass_meta.__new__` would be
             # `(COMObject,)`.
-            # Moreover, since `COMObject` derives from `object` and does not specify
+            # Moreover, since the `COMObject` derives from `object` and does not specify
             # a metaclass, `(object,)` will not be passed as the `bases` parameter
-            # to `_coclass_meta.__new__`.
+            # to the `_coclass_meta.__new__`.
             # The reason for this implementation might be a remnant of the differences
             # in how metaclasses work between Python 3.x and Python 2.x.
             # If there are no problems with the versions of Python that `comtypes`

--- a/comtypes/_meta.py
+++ b/comtypes/_meta.py
@@ -45,6 +45,17 @@ class _coclass_meta(type):
     def __new__(cls, name, bases, namespace):
         self = type.__new__(cls, name, bases, namespace)
         if bases == (object,):
+            # HACK: Could this conditional branch be removed since it is never reached?
+            # Since definition is `class CoClass(COMObject, metaclass=_coclass_meta)`,
+            # the `bases` parameter passed to `_coclass_meta.__new__` would be
+            # `(COMObject,)`.
+            # Moreover, since `COMObject` derives from `object` and does not specify
+            # a metaclass, `(object,)` will not be passed as the `bases` parameter
+            # to `_coclass_meta.__new__`.
+            # The reason for this implementation might be a remnant of the differences
+            # in how metaclasses work between Python 3.x and Python 2.x.
+            # If there are no problems with the versions of Python that `comtypes`
+            # supports, this removal could make the process flow easier to understand.
             return self
         # XXX We should insist that a _reg_clsid_ is present.
         if "_reg_clsid_" in namespace:

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -90,6 +90,14 @@ class _cominterface_meta(type):
             _ptr_bases = (self, POINTER(bases[0]))
 
         # The interface 'self' is used as a mixin.
+        # HACK: Could `type(_compointer_base)` be replaced with `_compointer_meta`?
+        # `type(klass)` returns its metaclass.
+        # Since this specification, `type(_compointer_base)` will return
+        # `_compointer_meta` as per the class definition.
+        # The reason for this implementation might be a remnant of the differences in
+        # how metaclasses work between Python 3.x and Python 2.x.
+        # If there are no problems with the versions of Python that `comtypes`
+        # supports, this replacement could make the process flow easier to understand.
         p = type(_compointer_base)(
             f"POINTER({self.__name__})",
             _ptr_bases,

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -369,10 +369,11 @@ class _cominterface_meta(type):
 ################################################################
 
 
+# will not work if we change the order of the two base classes!
 class _compointer_meta(type(c_void_p), _cominterface_meta):
-    "metaclass for COM interface pointer classes"
+    """metaclass for COM interface pointer classes"""
 
-    # no functionality, but needed to avoid a metaclass conflict
+    pass  # no functionality, but needed to avoid a metaclass conflict
 
 
 class _compointer_base(c_void_p, metaclass=_compointer_meta):

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -85,8 +85,10 @@ class _cominterface_meta(type):
         # subclass of POINTER(IUnknown) because of the way ctypes
         # typechecks work.
         if bases == (object,):
+            # `self` is `IUnknown` type.
             _ptr_bases = (self, _compointer_base)
         else:
+            # `self` is an interface type derived from `IUnknown`.
             _ptr_bases = (self, POINTER(bases[0]))
 
         # The interface 'self' is used as a mixin.

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -85,7 +85,7 @@ class _cominterface_meta(type):
         # subclass of POINTER(IUnknown) because of the way ctypes
         # typechecks work.
         if bases == (object,):
-            # `self` is `IUnknown` type.
+            # `self` is the `IUnknown` type.
             _ptr_bases = (self, _compointer_base)
         else:
             # `self` is an interface type derived from `IUnknown`.
@@ -94,8 +94,8 @@ class _cominterface_meta(type):
         # The interface 'self' is used as a mixin.
         # HACK: Could `type(_compointer_base)` be replaced with `_compointer_meta`?
         # `type(klass)` returns its metaclass.
-        # Since this specification, `type(_compointer_base)` will return
-        # `_compointer_meta` as per the class definition.
+        # Since this specification, `type(_compointer_base)` will return the
+        # `_compointer_meta` type as per the class definition.
         # The reason for this implementation might be a remnant of the differences in
         # how metaclasses work between Python 3.x and Python 2.x.
         # If there are no problems with the versions of Python that `comtypes`


### PR DESCRIPTION
During the investigation for #618, I noticed that one metaclass had comments while the other didn't, so I added the missing comments.

Additionally, I found some implementations that seem to be remnants from the time when Python 2.x was supported, so I added `# HACK` comments.
I plan to open issues regarding these matters soon.