### PR TITLE
Modify the metaclasses to ensure compatibility with Python 3.13 and earlier versions.

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         architecture: ['x86', 'x64']
         npsupport: ['with npsupport', 'without npsupport']
     steps:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, windows-2019]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         architecture: ['x86', 'x64']
     steps:
       - uses: actions/checkout@v4

--- a/comtypes/_meta.py
+++ b/comtypes/_meta.py
@@ -61,6 +61,18 @@ class _coclass_meta(type):
         if "_reg_clsid_" in namespace:
             clsid = namespace["_reg_clsid_"]
             comtypes.com_coclass_registry[str(clsid)] = self
+
+        # `_coclass_pointer_meta` is a subclass inherited from `_coclass_meta`.
+        # In other words, when the `__new__` method of this metaclass is called, an
+        # instance of `_coclass_pointer_meta` might be created and assigned to `self`.
+        if isinstance(self, _coclass_pointer_meta):
+            # `self` is the `_coclass_pointer_meta` type or a `POINTER(coclass)` type.
+            # Prevent creating/registering a pointer to a pointer (to a pointer...),
+            # or specifying the metaclass type instance in the `bases` parameter when
+            # instantiating it, which would lead to infinite recursion.
+            # Depending on a version or revision of Python, this may be essential.
+            return self
+
         PTR = _coclass_pointer_meta(
             f"POINTER({self.__name__})",
             (self, c_void_p),

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -81,9 +81,7 @@ def _make_safearray_type(itemtype):
     )
 
     meta = type(_safearray.tagSAFEARRAY)
-    sa_type = meta.__new__(
-        meta, "SAFEARRAY_%s" % itemtype.__name__, (_safearray.tagSAFEARRAY,), {}
-    )
+    sa_type = meta(f"SAFEARRAY_{itemtype.__name__}", (_safearray.tagSAFEARRAY,), {})
 
     try:
         vartype = _ctype_to_vartype[itemtype]


### PR DESCRIPTION
Related to #618.

To support Python 3.13, changes are required in the codebase of the `_coclass_meta`, `_cominterface_meta`, and `_make_safearray_type`.

This is due to changes in the implementation of `ctypes` starting from Python 3.13, which introduced breaking changes to metaclass initialization.
I posted about this in python/cpython#124520 and arrived at this implementation after receiving advice from the `ctypes` maintainer.
Please see also https://docs.python.org/3.13/whatsnew/3.13.html#ctypes.

I would like to hear from the community and other maintainers whether the codebases are reasonable and the comments will be helpful for future readers.

Any feedback is welcome.

If there are no objections, I plan to merge this after October 21st and release it as `comtypes==1.4.8`.