### PR TITLE
Deleted `__cmp__` function.

### DIFF
--- a/comtypes/client/lazybind.py
+++ b/comtypes/client/lazybind.py
@@ -126,11 +126,6 @@ class Dispatch(object):
         "QueryInterface is forwarded to the real com object."
         return self._comobj.QueryInterface(*args)
 
-    def __cmp__(self, other):
-        if not isinstance(other, Dispatch):
-            return 1
-        return cmp(self._comobj, other._comobj)
-
     def __eq__(self, other):
         return isinstance(other, Dispatch) and self._comobj == other._comobj
 


### PR DESCRIPTION
Related to https://github.com/enthought/comtypes/issues/512.

Since the other PRs seemed to have been neglected, I removed the remaining `__cmp__` methods.

Using ruff on the file.