### PR TITLE
Removed the `from __future__ import print_function` unnecessary import statements

### DIFF
--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ctypes
 import traceback
 import comtypes

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ctypes
 import importlib
 import inspect

--- a/comtypes/shelllink.py
+++ b/comtypes/shelllink.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from ctypes import c_char_p, c_int, c_short, c_wchar_p
 from ctypes import POINTER
 from ctypes import byref, create_string_buffer, create_unicode_buffer

--- a/comtypes/test/__init__.py
+++ b/comtypes/test/__init__.py
@@ -1,6 +1,5 @@
 # comtypes.test package.
 
-from __future__ import print_function
 import ctypes
 import getopt
 import os

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest, gc
 from ctypes import *
 from ctypes.wintypes import *

--- a/comtypes/test/test_agilent.py
+++ b/comtypes/test/test_agilent.py
@@ -2,7 +2,6 @@
 # is installed.  It is not requires to have a physical instrument
 # connected, the driver is used in simulation mode.
 
-from __future__ import print_function
 import unittest
 from comtypes.test import ResourceDenied
 from comtypes.client import CreateObject

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import glob
 import os
 import unittest

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -1,5 +1,4 @@
 # -*- coding: latin-1 -*-
-from __future__ import print_function
 
 import datetime
 import sys

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import datetime
 import decimal
 import sys


### PR DESCRIPTION
Related to https://github.com/enthought/comtypes/issues/464.

Since the other PRs seemed to have been neglected, I removed the unnecessary `print_function`  import statements.
Using ruff on the file.


##  Supported for the following files
```
$ git grep -l "print_function"
comtypes/client/_events.py
comtypes/client/_generate.py
comtypes/shelllink.py
comtypes/test/__init__.py
comtypes/test/find_memleak.py
comtypes/test/test_agilent.py
comtypes/test/test_createwrappers.py
comtypes/test/test_excel.py
comtypes/test/test_variant.py
```