### PR TITLE
Removed __cmp__ method

### DIFF
--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -403,21 +403,6 @@ class _compointer_base(c_void_p, metaclass=_compointer_meta):
                 _debug("Release %s", self)
                 self.Release()
 
-    def __cmp__(self, other):
-        """Compare pointers to COM interfaces."""
-        # COM identity rule
-        #
-        # XXX To compare COM interface pointers, should we
-        # automatically QueryInterface for IUnknown on both items, and
-        # compare the pointer values?
-        if not isinstance(other, _compointer_base):
-            return 1
-
-        # get the value property of the c_void_p baseclass, this is the pointer value
-        return cmp(
-            super(_compointer_base, self).value, super(_compointer_base, other).value
-        )
-
     def __eq__(self, other):
         if not isinstance(other, _compointer_base):
             return False


### PR DESCRIPTION
## Related to under the issue. 
- #512 
- https://github.com/enthought/comtypes/pull/637#pullrequestreview-2362657952

## 
The retained `__cmp__ `method has been deleted
https://github.com/enthought/comtypes/blob/0256434b2b42e6d67305cf7753a3360d8e3bc345/comtypes/_post_coinit/unknwn.py#L406-L414
