### PR TITLE
Refactored `itf.__dict__` to `vars(itf)`

### DIFF
--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -324,16 +324,13 @@ class _cominterface_meta(type):
 
     def __get_baseinterface_methodcount(self):
         "Return the number of com methods in the base interfaces"
-        try:
-            result = 0
-            for itf in self.mro()[1:-1]:
-                result += len(itf.__dict__["_methods_"])
-            return result
-        except KeyError as err:
-            (name,) = err.args
-            if name == "_methods_":
-                raise TypeError("baseinterface '%s' has no _methods_" % itf.__name__)
-            raise
+        result = 0
+        for itf in self.mro()[1:-1]:
+            if "_methods_" in vars(itf):
+                result += len(vars(itf)["_methods_"])
+            else:
+                raise TypeError(f"baseinterface '{itf.__name__}' has no _methods_")
+        return result
 
     def _make_methods(self, methods: List[_ComMemberSpec]) -> None:
         if self._case_insensitive_:


### PR DESCRIPTION
# Proposal

Related to #472

I chose to use `vars` function  because dunder/magic methods serve as the implementation, while invoking functions/methods acts as the API. 

# note 
https://stackoverflow.com/questions/21297203/use-dict-or-vars 

