### PR TITLE
Allow the definition of the `_midlSAFEARRAY(HRESULT)` type.

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -956,6 +956,7 @@ _ctype_to_vartype: Dict[Type[_CData], int] = {
     c_ulonglong: VT_UI8,
     VARIANT_BOOL: VT_BOOL,
     BSTR: VT_BSTR,
+    HRESULT: VT_HRESULT,
     VARIANT: VT_VARIANT,
     # SAFEARRAY(VARIANT *)
     #

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -131,7 +131,7 @@ def _make_safearray_type(itemtype):
                     # safearray pointer instance does not work.
                     # See also: https://github.com/enthought/comtypes/issues/668
                     "Cannot create SAFEARRAY type VT_HRESULT."
-                    )
+                )
 
             if comtypes.npsupport.isndarray(value):
                 return cls.create_from_ndarray(value, extra)

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -78,6 +78,7 @@ def _make_safearray_type(itemtype):
         VT_UNKNOWN,
         IDispatch,
         VT_DISPATCH,
+        VT_HRESULT,
     )
 
     meta = type(_safearray.tagSAFEARRAY)
@@ -123,6 +124,15 @@ def _make_safearray_type(itemtype):
             one-dimensional arrays.  To create multidimensional arrys,
             numpy arrays must be passed.
             """
+            if cls._vartype_ == VT_HRESULT:
+                raise TypeError(
+                    # There are COM type libraries that define the
+                    # `_midlSAFEARRAY(HRESULT)` type; however, creating `HRESULT`
+                    # safearray pointer instance does not work.
+                    # See also: https://github.com/enthought/comtypes/issues/668
+                    "Cannot create SAFEARRAY type VT_HRESULT."
+                    )
+
             if comtypes.npsupport.isndarray(value):
                 return cls.create_from_ndarray(value, extra)
 

--- a/comtypes/test/test_midl_safearray_create.py
+++ b/comtypes/test/test_midl_safearray_create.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from ctypes import c_int, pointer, POINTER
+from ctypes import c_int, pointer, HRESULT, POINTER
 import unittest
 
 import comtypes
@@ -81,6 +81,14 @@ class Test_midlSAFEARRAY_create(unittest.TestCase):
                 )
                 self.assertEqual(unpacked.answer, 42)
                 self.assertEqual(unpacked.needs_clarification, True)
+
+    def test_HRESULT(self):
+        hr = HRESULT(1)
+        sa_type = comtypes.safearray._midlSAFEARRAY(HRESULT)
+        with self.assertRaises(TypeError):
+            sa_type.create([hr], extra=None)
+        with self.assertRaises(TypeError):
+            sa_type.create([hr])
 
     def test_ctype(self):
         extra = None


### PR DESCRIPTION
Pull request for changes described in https://github.com/enthought/comtypes/issues/668