### PR TITLE
Fix broken unregistration of 64bit type libraries

### DIFF
--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -632,7 +632,7 @@ def LoadTypeLib(szFile: str) -> ITypeLib:
 
 
 def UnRegisterTypeLib(
-    libID: str, wVerMajor: int, wVerMinor: int, lcid: int = 0, syskind: int = SYS_WIN32
+    libID: str, wVerMajor: int, wVerMinor: int, lcid: int = 0, syskind: int = SYS_WIN64
 ) -> int:
     """Unregister a registered type library"""
     return _oleaut32.UnRegisterTypeLib(


### PR DESCRIPTION
The `UnRegisterTypeLib` function currently assume 32bit type libraries (`SYS_WIN32`) if called _without_ explicit `syskind` argument. This is the case when UnRegisterTypeLib is called implicitly from `comtypes.server.register.UseCommandLine`, since the `_reg_typelib_` field only contains the first 3 `libID` , `wVerMajor` and `wVerMinor` arguments.

Propose to fix the problem by updating the hardcoding to 64bit Windows with `SYS_WIN64`. This will fix the problem in 64bit at the expense of breaking unregistration of 32bit type libraries.

## Alternative approach
It would also be possible to instead extend the [GetLibAttr()](https://learn.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-itypelib-getlibattr) parsing to also capture the `lcid` and `syskind` parameters from the [TLIBATTR](https://learn.microsoft.com/en-us/windows/win32/api/oaidl/ns-oaidl-tlibattr) struct, so that they can be forwarded to `UnRegisterTypeLib` without having to rely on default values.
I assume that such a change will need to be implemented in [tlbparser.py](https://github.com/enthought/comtypes/blob/main/comtypes/tools/tlbparser.py). However, I don't really know the codebase myself, so I don't feel comfortable with coming up with a concrete proposal.

## Example of impact
The https://github.com/forderud/ComSamples/blob/main/MyServerPy/MyServerPy.py project is experiencing this problem and have implemented a work-around for it.