### PR TITLE
Fix broken unregistration of 64bit type libraries (second attempt)

### DIFF
--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -632,7 +632,11 @@ def LoadTypeLib(szFile: str) -> ITypeLib:
 
 
 def UnRegisterTypeLib(
-    libID: str, wVerMajor: int, wVerMinor: int, lcid: int = 0, syskind: int = (SYS_WIN64 if is_64_bit else SYS_WIN32)
+    libID: str,
+    wVerMajor: int,
+    wVerMinor: int,
+    lcid: int = 0,
+    syskind: int = (SYS_WIN64 if is_64_bit else SYS_WIN32),
 ) -> int:
     """Unregister a registered type library"""
     return _oleaut32.UnRegisterTypeLib(

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -632,7 +632,7 @@ def LoadTypeLib(szFile: str) -> ITypeLib:
 
 
 def UnRegisterTypeLib(
-    libID: str, wVerMajor: int, wVerMinor: int, lcid: int = 0, syskind: int = SYS_WIN32
+    libID: str, wVerMajor: int, wVerMinor: int, lcid: int = 0, syskind: int = (SYS_WIN64 if is_64_bit else SYS_WIN32)
 ) -> int:
     """Unregister a registered type library"""
     return _oleaut32.UnRegisterTypeLib(


### PR DESCRIPTION
The `UnRegisterTypeLib` function currently always assume 32bit type libraries (`SYS_WIN32`) if called without explicit `syskind` argument. This is currently the case when `UnRegisterTypeLib` is called implicitly from `comtypes.server.register.UseCommandLine`, since the `_reg_typelib_` field only contains the first 3 `libID` , `wVerMajor` and `wVerMinor` arguments.

Propose to fix the problem by updating the hardcoding to `SYS_WIN64` for 64bit Python and `SYS_WIN32` for 32bit Python installations. This ensures that existing 32bit COM servers continue to function on 32bit Python installations.