### PR TITLE
Revive `test_comserver`.

### DIFF
--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -1,7 +1,10 @@
+import doctest
 import sys
 import unittest
+from ctypes import pointer
 
 import comtypes.test.TestComServer
+from comtypes import BSTR
 from comtypes.client import CreateObject
 from comtypes.server.register import register  # , unregister
 from comtypes.test import is_resource_enabled
@@ -33,9 +36,6 @@ class TestInproc(unittest.TestCase):
         self.assertEqual(o.MixedInOut(2, 4), (3, 5))
 
     def test_getname(self):
-        from ctypes import pointer
-        from comtypes import BSTR
-
         # This tests a tricky bug, introduced with this patch:
         # http://www.python.org/sf/1643874
         #
@@ -142,12 +142,10 @@ else:
                 )
 
 
-import doctest
-import comtypes.test.test_comserver
-
-
 class TestCase(unittest.TestCase):
     def test(self):
+        import comtypes.test.test_comserver
+
         doctest.testmod(comtypes.test.test_comserver, optionflags=doctest.ELLIPSIS)
 
     # The following functions are never called, they only contain doctests:

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -6,19 +6,25 @@ from ctypes import pointer
 import comtypes.test.TestComServer
 from comtypes import BSTR
 from comtypes.client import CreateObject
-from comtypes.server.register import register  # , unregister
+from comtypes.server.register import register, unregister
 from comtypes.test import is_resource_enabled
 from comtypes.test.find_memleak import find_memleak
 
 
 def setUpModule():
-    raise unittest.SkipTest(
-        "This test requires the tests to be run as admin since it tries to "
-        "register the test COM server.  Is this a good idea?"
-    )
+    try:
+        register(comtypes.test.TestComServer.TestComServer)
+    except WindowsError as e:
+        if e.winerror != 5:  # [Error 5] Access is denied
+            raise e
+        raise unittest.SkipTest(
+            "This test requires the tests to be run as admin since it tries to "
+            "register the test COM server."
+        )
 
-    # If this test is ever NOT skipped, then this line needs to run.  Keeping it here for posterity.
-    register(comtypes.test.TestComServer.TestComServer)
+
+def tearDownModule():
+    unregister(comtypes.test.TestComServer.TestComServer)
 
 
 class TestInproc(unittest.TestCase):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -156,41 +156,21 @@ class TestCase(unittest.TestCase):
 
     # The following functions are never called, they only contain doctests:
 
-    if sys.version_info >= (3, 0):
-
-        def ShowEvents(self):
-            """
-            >>> from comtypes.client import CreateObject, ShowEvents
-            >>>
-            >>> o = CreateObject("TestComServerLib.TestComServer")
-            >>> con = ShowEvents(o)
-            # event found: ITestComServerEvents_EvalStarted
-            # event found: ITestComServerEvents_EvalCompleted
-            >>> result = o.eval("10. / 4")
-            Event ITestComServerEvents_EvalStarted(None, '10. / 4')
-            Event ITestComServerEvents_EvalCompleted(None, '10. / 4', VARIANT(vt=0x5, 2.5))
-            >>> result
-            2.5
-            >>>
-            """
-
-    else:
-
-        def ShowEvents(self):
-            """
-            >>> from comtypes.client import CreateObject, ShowEvents
-            >>>
-            >>> o = CreateObject("TestComServerLib.TestComServer")
-            >>> con = ShowEvents(o)
-            # event found: ITestComServerEvents_EvalStarted
-            # event found: ITestComServerEvents_EvalCompleted
-            >>> result = o.eval("10. / 4")
-            Event ITestComServerEvents_EvalStarted(None, u'10. / 4')
-            Event ITestComServerEvents_EvalCompleted(None, u'10. / 4', VARIANT(vt=0x5, 2.5))
-            >>> result
-            2.5
-            >>>
-            """
+    def ShowEvents(self):
+        """
+        >>> from comtypes.client import CreateObject, ShowEvents
+        >>>
+        >>> o = CreateObject("TestComServerLib.TestComServer")
+        >>> con = ShowEvents(o)
+        # event found: ITestComServerEvents_EvalStarted
+        # event found: ITestComServerEvents_EvalCompleted
+        >>> result = o.eval("10. / 4")
+        Event ITestComServerEvents_EvalStarted(None, '10. / 4')
+        Event ITestComServerEvents_EvalCompleted(None, '10. / 4', VARIANT(vt=0x5, 2.5))
+        >>> result
+        2.5
+        >>>
+        """
 
         # The following test, if enabled, works but the testsuit
         # crashes elsewhere.  Is there s problem with SAFEARRAYs?

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -158,7 +158,7 @@ class TestCase(unittest.TestCase):
 
     # The following functions are never called, they only contain doctests:
 
-    def ShowEvents(self):
+    def ShowEventsFloat(self):
         """
         >>> from comtypes.client import CreateObject, ShowEvents
         >>>
@@ -174,26 +174,26 @@ class TestCase(unittest.TestCase):
         >>>
         """
 
-        # The following test, if enabled, works but the testsuit
-        # crashes elsewhere.  Is there s problem with SAFEARRAYs?
+    # # The following test, if enabled, works but the testsuit
+    # # crashes elsewhere.  Is there s problem with SAFEARRAYs?
 
-    if is_resource_enabled("CRASHES"):
+    # if is_resource_enabled("CRASHES"):
 
-        def Fails(self):
-            """
-            >>> from comtypes.client import CreateObject, ShowEvents
-            >>>
-            >>> o = CreateObject("TestComServerLib.TestComServer")
-            >>> con = ShowEvents(o)
-            # event found: ITestComServerEvents_EvalStarted
-            # event found: ITestComServerEvents_EvalCompleted
-            >>> result = o.eval("['32'] * 2")
-            Event ITestComServerEvents_EvalStarted(None, u"['32'] * 2")
-            Event ITestComServerEvents_EvalCompleted(None, u"['32'] * 2", VARIANT(vt=0x200c, (u'32', u'32')))
-            >>> result
-            (u'32', u'32')
-            >>>
-            """
+    #     def Fails(self):
+    #         """
+    #         >>> from comtypes.client import CreateObject, ShowEvents
+    #         >>>
+    #         >>> o = CreateObject("TestComServerLib.TestComServer")
+    #         >>> con = ShowEvents(o)
+    #         # event found: ITestComServerEvents_EvalStarted
+    #         # event found: ITestComServerEvents_EvalCompleted
+    #         >>> result = o.eval("['32'] * 2")
+    #         Event ITestComServerEvents_EvalStarted(None, u"['32'] * 2")
+    #         Event ITestComServerEvents_EvalCompleted(None, u"['32'] * 2", VARIANT(vt=0x200c, (u'32', u'32')))
+    #         >>> result
+    #         (u'32', u'32')
+    #         >>>
+    #         """
 
     def GetEvents(self):
         """

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -1,5 +1,4 @@
 import doctest
-import sys
 import unittest
 from ctypes import pointer
 

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -60,50 +60,48 @@ class TestInproc(unittest.TestCase):
         # Make sure the pointer is still valid:
         self.assertEqual(pb[0], name)
 
-    if is_resource_enabled("memleaks"):
+    def test_get_id(self):
+        obj = self.create_object()
+        self._find_memleak(lambda: obj.id)
 
-        def test_get_id(self):
-            obj = self.create_object()
-            self._find_memleak(lambda: obj.id)
+    def test_get_name(self):
+        obj = self.create_object()
+        self._find_memleak(lambda: obj.name)
 
-        def test_get_name(self):
-            obj = self.create_object()
-            self._find_memleak(lambda: obj.name)
+    def test_set_name(self):
+        obj = self.create_object()
 
-        def test_set_name(self):
-            obj = self.create_object()
+        def func():
+            obj.name = "abcde"
 
-            def func():
-                obj.name = "abcde"
+        self._find_memleak(func)
 
-            self._find_memleak(func)
+    def test_SetName(self):
+        obj = self.create_object()
 
-        def test_SetName(self):
-            obj = self.create_object()
+        def func():
+            obj.SetName("abcde")
 
-            def func():
-                obj.SetName("abcde")
+        self._find_memleak(func)
 
-            self._find_memleak(func)
+    def test_eval(self):
+        obj = self.create_object()
 
-        def test_eval(self):
-            obj = self.create_object()
+        def func():
+            return obj.eval("(1, 2, 3)")
 
-            def func():
-                return obj.eval("(1, 2, 3)")
+        self.assertEqual(func(), (1, 2, 3))
+        self._find_memleak(func)
 
-            self.assertEqual(func(), (1, 2, 3))
-            self._find_memleak(func)
+    def test_get_typeinfo(self):
+        obj = self.create_object()
 
-        def test_get_typeinfo(self):
-            obj = self.create_object()
+        def func():
+            obj.GetTypeInfo(0)
+            obj.GetTypeInfoCount()
+            obj.QueryInterface(comtypes.IUnknown)
 
-            def func():
-                obj.GetTypeInfo(0)
-                obj.GetTypeInfoCount()
-                obj.QueryInterface(comtypes.IUnknown)
-
-            self._find_memleak(func)
+        self._find_memleak(func)
 
 
 class TestLocalServer(TestInproc):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -106,13 +106,11 @@ class TestInproc(unittest.TestCase):
             self._find_memleak(func)
 
 
-if is_resource_enabled("ui"):
-
-    class TestLocalServer(TestInproc):
-        def create_object(self):
-            return CreateObject(
-                "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
-            )
+class TestLocalServer(TestInproc):
+    def create_object(self):
+        return CreateObject(
+            "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
+        )
 
 
 try:

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -115,6 +115,12 @@ class TestLocalServer(BaseServerTest, unittest.TestCase):
             "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
         )
 
+    @unittest.skip("This fails. Why?")
+    def test_get_typeinfo(self):
+        # Calling `GetTypeInfo` occurs;
+        # OSError: exception: access violation reading 0x0000000000000000
+        pass
+
 
 try:
     from win32com.client import Dispatch

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -122,6 +122,7 @@ except ImportError:
     pass
 else:
 
+    @unittest.skip("This depends on 'pywin32'.")
     class TestInproc_win32com(TestInproc):
         def create_object(self):
             return Dispatch("TestComServerLib.TestComServer")
@@ -140,6 +141,7 @@ else:
 
     if is_resource_enabled("ui"):
 
+        @unittest.skip("This depends on 'pywin32'.")
         class TestLocalServer_win32com(TestInproc_win32com):
             def create_object(self):
                 return Dispatch(


### PR DESCRIPTION
Recent discussions and fixes related to the COM server have made it possible to revive some of the tests.

While some tests remain skipped, investigating the causes of their failures and restoring them is outside the current scope.
For now, we should focus on reviving the tests that can be restored.