### PR TITLE
Remove `SixDocChecker` from `test_showevents`.

### DIFF
--- a/comtypes/test/test_showevents.py
+++ b/comtypes/test/test_showevents.py
@@ -1,24 +1,11 @@
 import doctest
-import sys
-import re
 import unittest
-
-
-class SixDocChecker(doctest.OutputChecker):
-    # see https://dirkjan.ochtman.nl/writing/2014/07/06/single-source-python-23-doctests.html
-    def check_output(self, want, got, optionflags):
-        if sys.version_info >= (3, 0):
-            want = re.sub(r"u'(.*?)'", r"'\1'", want)
-            want = re.sub(r'u"(.*?)"', r'"\1"', want)
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 
 def load_tests(loader, tests, ignore):
     import comtypes.test.test_showevents
 
-    tests.addTests(
-        doctest.DocTestSuite(comtypes.test.test_showevents, checker=SixDocChecker())
-    )
+    tests.addTests(doctest.DocTestSuite(comtypes.test.test_showevents))
     return tests
 
 
@@ -32,9 +19,9 @@ class ShowEventsExamples:
         >>> conn = ShowEvents(font)
         # event found: FontEvents_FontChanged
         >>> font.Name = 'Arial'
-        Event FontEvents_FontChanged(None, u'Name')
+        Event FontEvents_FontChanged(None, 'Name')
         >>> font.Italic = True
-        Event FontEvents_FontChanged(None, u'Italic')
+        Event FontEvents_FontChanged(None, 'Italic')
         >>> PumpEvents(0.01)  # just calling. assertion does in `test_pump_events.py`
         >>> conn.disconnect()
         """

--- a/comtypes/test/test_showevents.py
+++ b/comtypes/test/test_showevents.py
@@ -1,8 +1,11 @@
 import doctest
 import unittest
+from typing import Optional
 
 
-def load_tests(loader, tests, ignore):
+def load_tests(
+    loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: Optional[str]
+) -> unittest.TestSuite:
     import comtypes.test.test_showevents
 
     tests.addTests(doctest.DocTestSuite(comtypes.test.test_showevents))


### PR DESCRIPTION
The `SixDocChecker`, which existed for compatibility between Python 2.x and 3.x, is now outdated.