### PR TITLE
Set `verbose=False` into `doctest.testmod` to suppress the output.

### DIFF
--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -156,7 +156,7 @@ else:
                 )
 
 
-class TestCase(unittest.TestCase):
+class TestEvents(unittest.TestCase):
     def test(self):
         import comtypes.test.test_comserver
 
@@ -164,6 +164,8 @@ class TestCase(unittest.TestCase):
             comtypes.test.test_comserver, verbose=False, optionflags=doctest.ELLIPSIS
         )
 
+
+class ShowEventsExamples:
     # The following functions are never called, they only contain doctests:
 
     def ShowEventsFloat(self):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -160,7 +160,9 @@ class TestCase(unittest.TestCase):
     def test(self):
         import comtypes.test.test_comserver
 
-        doctest.testmod(comtypes.test.test_comserver, optionflags=doctest.ELLIPSIS)
+        doctest.testmod(
+            comtypes.test.test_comserver, verbose=False, optionflags=doctest.ELLIPSIS
+        )
 
     # The following functions are never called, they only contain doctests:
 


### PR DESCRIPTION
The test approach using `doctest.testmod` outputs information equivalent to running `doctest` with the `-v` option.

While this is useful for running tests individually, it can become confusing when mixed with the results of discovering and running unit tests.
Therefore, we explicitly set `verbose=False` to suppress this output.