### PR TITLE
Remove `is_resource_enabled` and `requires` from tests.

### DIFF
--- a/comtypes/test/test_BSTR.py
+++ b/comtypes/test/test_BSTR.py
@@ -1,10 +1,7 @@
-import unittest, os
-from ctypes import *
+import unittest
+from ctypes import WINFUNCTYPE, c_uint, c_void_p, oledll, windll
+
 from comtypes import BSTR
-from comtypes.test import requires
-
-##requires("memleaks")
-
 from comtypes.test.find_memleak import find_memleak
 
 

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -7,7 +7,6 @@ import comtypes.test.TestComServer
 from comtypes import BSTR
 from comtypes.client import CreateObject
 from comtypes.server.register import register, unregister
-from comtypes.test import is_resource_enabled
 from comtypes.test.find_memleak import find_memleak
 
 
@@ -145,15 +144,12 @@ else:
             # Is mixed [in], [out] args not compatible with IDispatch???
             pass
 
-    if is_resource_enabled("ui"):
-
-        @unittest.skip("This depends on 'pywin32'.")
-        class TestLocalServer_win32com(TestInproc_win32com):
-            def create_object(self):
-                return Dispatch(
-                    "TestComServerLib.TestComServer",
-                    clsctx=comtypes.CLSCTX_LOCAL_SERVER,
-                )
+    @unittest.skip("This depends on 'pywin32'.")
+    class TestLocalServer_win32com(TestInproc_win32com):
+        def create_object(self):
+            return Dispatch(
+                "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
+            )
 
 
 class TestEvents(unittest.TestCase):
@@ -187,23 +183,21 @@ class ShowEventsExamples:
     # # The following test, if enabled, works but the testsuit
     # # crashes elsewhere.  Is there s problem with SAFEARRAYs?
 
-    # if is_resource_enabled("CRASHES"):
-
-    #     def Fails(self):
-    #         """
-    #         >>> from comtypes.client import CreateObject, ShowEvents
-    #         >>>
-    #         >>> o = CreateObject("TestComServerLib.TestComServer")
-    #         >>> con = ShowEvents(o)
-    #         # event found: ITestComServerEvents_EvalStarted
-    #         # event found: ITestComServerEvents_EvalCompleted
-    #         >>> result = o.eval("['32'] * 2")
-    #         Event ITestComServerEvents_EvalStarted(None, u"['32'] * 2")
-    #         Event ITestComServerEvents_EvalCompleted(None, u"['32'] * 2", VARIANT(vt=0x200c, (u'32', u'32')))
-    #         >>> result
-    #         (u'32', u'32')
-    #         >>>
-    #         """
+    # def Fails(self):
+    #     """
+    #     >>> from comtypes.client import CreateObject, ShowEvents
+    #     >>>
+    #     >>> o = CreateObject("TestComServerLib.TestComServer")
+    #     >>> con = ShowEvents(o)
+    #     # event found: ITestComServerEvents_EvalStarted
+    #     # event found: ITestComServerEvents_EvalCompleted
+    #     >>> result = o.eval("['32'] * 2")
+    #     Event ITestComServerEvents_EvalStarted(None, u"['32'] * 2")
+    #     Event ITestComServerEvents_EvalCompleted(None, u"['32'] * 2", VARIANT(vt=0x200c, (u'32', u'32')))
+    #     >>> result
+    #     (u'32', u'32')
+    #     >>>
+    #     """
 
     def GetEvents(self):
         """

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -15,8 +15,6 @@ def setUpModule():
     )
 
 
-# requires("typelibs")
-
 # filter warnings about interfaces without a base interface; they will
 # be skipped in the code generation.
 warnings.filterwarnings(

--- a/comtypes/test/test_ie.py
+++ b/comtypes/test/test_ie.py
@@ -1,10 +1,7 @@
 import unittest as ut
-from ctypes import *
+from ctypes import Structure, c_long, c_uint, c_ulong
 
-import comtypes.test
 from comtypes.client import CreateObject, GetEvents
-
-comtypes.test.requires("ui")
 
 
 def setUpModule():
@@ -61,7 +58,7 @@ class MSG(Structure):
 
 
 def PumpWaitingMessages():
-    from ctypes import windll, byref
+    from ctypes import byref, windll
 
     user32 = windll.user32
     msg = MSG()

--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -1,18 +1,25 @@
-import sys
 import unittest
-from ctypes import *
+from ctypes import (
+    POINTER,
+    byref,
+    c_int,
+    c_ulong,
+    c_void_p,
+    c_wchar,
+    c_wchar_p,
+    cast,
+    memmove,
+    oledll,
+    sizeof,
+    windll,
+    wstring_at,
+)
 from unittest.mock import patch
 
-import comtypes.test
+from comtypes import COMMETHOD, GUID, IUnknown
 
-comtypes.test.requires("devel")
 
-from comtypes import IUnknown, GUID, COMMETHOD
-
-if sys.version_info >= (3, 0):
-    text_type = str
-else:
-    text_type = unicode
+text_type = str
 
 
 class IMalloc(IUnknown):

--- a/comtypes/test/test_win32com_interop.py
+++ b/comtypes/test/test_win32com_interop.py
@@ -1,14 +1,11 @@
 import unittest
-
-from ctypes import PyDLL, py_object, c_void_p, byref, POINTER
+from ctypes import POINTER, PyDLL, byref, c_void_p, py_object
 from ctypes.wintypes import BOOL
 
 from comtypes import IUnknown
-from comtypes.client import CreateObject
 from comtypes.automation import IDispatch
-from comtypes.test import requires
+from comtypes.client import CreateObject
 
-requires("pythoncom")
 try:
     import pythoncom
     import win32com.client

--- a/comtypes/test/test_wmi.py
+++ b/comtypes/test/test_wmi.py
@@ -1,9 +1,6 @@
 import unittest as ut
 
 from comtypes.client import CoGetObject
-from comtypes.test import requires
-
-requires("time")
 
 
 # WMI has dual interfaces.


### PR DESCRIPTION
The `requires` and `is_resource_enabled` functions found in the tests were only meaningful when using the `test` command in `setup.py`.

Currently, unit tests can be executed by: `unittest discover -v -s ./comtypes/test -t comtypes\test`.

In most cases, `requires` and `is_resource_enabled` are effectively dead code.
Therefore, they will be removed here and replaced with the standard skipping mechanisms provided by `unittest` if necessary.

If displaying missing resources or handling complex skip conditions becomes necessary, we can consider introducing `unittest` plugins or adopting `pytest`. IMO, such measures would be excessive at this stage.

The removal of these function definitions from `test/__init__.py` would also affect `setup.py`, so those changes are not included in the scope of this PR.