### PR TITLE
Add `IMPORT_PYWIN32_FAILED` flags to `test_dispinterface` and `test_comserver`.

### DIFF
--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -129,7 +129,7 @@ class TestLocalServer(BaseServerTest, unittest.TestCase):
 
 
 @unittest.skipIf(IMPORT_PYWIN32_FAILED, "This depends on 'pywin32'.")
-class TestInproc_win32com(TestInproc):
+class TestInproc_win32com(BaseServerTest, unittest.TestCase):
     def create_object(self):
         return Dispatch("TestComServerLib.TestComServer")
 
@@ -150,13 +150,13 @@ class TestInproc_win32com(TestInproc):
 
 
 @unittest.skipIf(IMPORT_PYWIN32_FAILED, "This depends on 'pywin32'.")
-class TestLocalServer_win32com(TestInproc_win32com):
+class TestLocalServer_win32com(BaseServerTest, unittest.TestCase):
     def create_object(self):
         return Dispatch(
             "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
         )
 
-    # These tests are skipped for the same reason as `TestLocalServer_win32com`.
+    # These tests are skipped for the same reason as `TestInproc_win32com`.
     @unittest.skip("This test make no sense with win32com.")
     def test_get_typeinfo(self):
         pass

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -10,6 +10,14 @@ from comtypes.server.register import register, unregister
 from comtypes.test.find_memleak import find_memleak
 
 
+try:
+    from win32com.client import Dispatch
+
+    IMPORT_PYWIN32_FAILED = False
+except ImportError:
+    IMPORT_PYWIN32_FAILED = True
+
+
 def setUpModule():
     try:
         register(comtypes.test.TestComServer.TestComServer)
@@ -121,35 +129,30 @@ class TestLocalServer(BaseServerTest, unittest.TestCase):
         pass
 
 
-try:
-    from win32com.client import Dispatch
-except ImportError:
-    pass
-else:
+@unittest.skip("This depends on 'pywin32'.")
+class TestInproc_win32com(TestInproc):
+    def create_object(self):
+        return Dispatch("TestComServerLib.TestComServer")
 
-    @unittest.skip("This depends on 'pywin32'.")
-    class TestInproc_win32com(TestInproc):
-        def create_object(self):
-            return Dispatch("TestComServerLib.TestComServer")
+    # These tests make no sense with win32com, override to disable them:
+    def test_get_typeinfo(self):
+        pass
 
-        # These tests make no sense with win32com, override to disable them:
-        def test_get_typeinfo(self):
-            pass
+    def test_getname(self):
+        pass
 
-        def test_getname(self):
-            pass
+    def test_mixedinout(self):
+        # Not sure about this; it raise 'Invalid Number of parameters'
+        # Is mixed [in], [out] args not compatible with IDispatch???
+        pass
 
-        def test_mixedinout(self):
-            # Not sure about this; it raise 'Invalid Number of parameters'
-            # Is mixed [in], [out] args not compatible with IDispatch???
-            pass
 
-    @unittest.skip("This depends on 'pywin32'.")
-    class TestLocalServer_win32com(TestInproc_win32com):
-        def create_object(self):
-            return Dispatch(
-                "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
-            )
+@unittest.skip("This depends on 'pywin32'.")
+class TestLocalServer_win32com(TestInproc_win32com):
+    def create_object(self):
+        return Dispatch(
+            "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
+        )
 
 
 class TestEvents(unittest.TestCase):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -9,7 +9,6 @@ from comtypes.client import CreateObject
 from comtypes.server.register import register, unregister
 from comtypes.test.find_memleak import find_memleak
 
-
 try:
     from win32com.client import Dispatch
 
@@ -129,30 +128,46 @@ class TestLocalServer(BaseServerTest, unittest.TestCase):
         pass
 
 
-@unittest.skip("This depends on 'pywin32'.")
+@unittest.skipIf(IMPORT_PYWIN32_FAILED, "This depends on 'pywin32'.")
 class TestInproc_win32com(TestInproc):
     def create_object(self):
         return Dispatch("TestComServerLib.TestComServer")
 
     # These tests make no sense with win32com, override to disable them:
+    @unittest.skip("This test make no sense with win32com.")
     def test_get_typeinfo(self):
         pass
 
+    @unittest.skip("This test make no sense with win32com.")
     def test_getname(self):
         pass
 
+    @unittest.skip("This test make no sense with win32com.")
     def test_mixedinout(self):
         # Not sure about this; it raise 'Invalid Number of parameters'
         # Is mixed [in], [out] args not compatible with IDispatch???
         pass
 
 
-@unittest.skip("This depends on 'pywin32'.")
+@unittest.skipIf(IMPORT_PYWIN32_FAILED, "This depends on 'pywin32'.")
 class TestLocalServer_win32com(TestInproc_win32com):
     def create_object(self):
         return Dispatch(
             "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_LOCAL_SERVER
         )
+
+    # These tests are skipped for the same reason as `TestLocalServer_win32com`.
+    @unittest.skip("This test make no sense with win32com.")
+    def test_get_typeinfo(self):
+        pass
+
+    @unittest.skip("This test make no sense with win32com.")
+    def test_getname(self):
+        pass
+
+    @unittest.skip("This test make no sense with win32com.")
+    def test_mixedinout(self):
+        pass
 
 
 class TestEvents(unittest.TestCase):

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -4,6 +4,14 @@ import unittest
 import comtypes.test.TestDispServer
 from comtypes.server.register import register, unregister
 
+try:
+    from win32com.client import Dispatch
+    from win32com.client.gencache import EnsureDispatch
+
+    IMPORT_PYWIN32_FAILED = False
+except ImportError:
+    IMPORT_PYWIN32_FAILED = True
+
 
 def setUpModule():
     try:
@@ -25,8 +33,6 @@ def tearDownModule():
 class Test_win32com(unittest.TestCase):
     def test_win32com(self):
         # EnsureDispatch is case-sensitive
-        from win32com.client.gencache import EnsureDispatch
-
         d = EnsureDispatch("TestDispServerLib.TestDispServer")
 
         self.assertEqual(d.eval("3.14"), 3.14)
@@ -54,8 +60,6 @@ class Test_win32com(unittest.TestCase):
 
     def test_win32com_dyndispatch(self):
         # dynamic Dispatch is case-IN-sensitive
-        from win32com.client.dynamic import Dispatch
-
         d = Dispatch("TestDispServerLib.TestDispServer")
 
         self.assertEqual(d.eval("3.14"), 3.14)

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -31,6 +31,10 @@ def tearDownModule():
 
 @unittest.skipIf(IMPORT_PYWIN32_FAILED, "This depends on 'pywin32'.")
 class Test_win32com(unittest.TestCase):
+    @unittest.skip(
+        "It likely fails due to bugs in `GenerateChildFromTypeLibSpec` "
+        "or `GetModuleForCLSID`."
+    )
     def test_win32com_ensure_dispatch(self):
         # EnsureDispatch is case-sensitive
         d = EnsureDispatch("TestDispServerLib.TestDispServer")

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -29,9 +29,9 @@ def tearDownModule():
     unregister(comtypes.test.TestDispServer.TestDispServer)
 
 
-@unittest.skip("This depends on 'pywin32'.")
+@unittest.skipIf(IMPORT_PYWIN32_FAILED, "This depends on 'pywin32'.")
 class Test_win32com(unittest.TestCase):
-    def test_win32com(self):
+    def test_win32com_ensure_dispatch(self):
         # EnsureDispatch is case-sensitive
         d = EnsureDispatch("TestDispServerLib.TestDispServer")
 
@@ -58,7 +58,7 @@ class Test_win32com(unittest.TestCase):
         d.name = "blah"
         self.assertEqual(d.name, "blah")
 
-    def test_win32com_dyndispatch(self):
+    def test_win32com_dynamic_dispatch(self):
         # dynamic Dispatch is case-IN-sensitive
         d = Dispatch("TestDispServerLib.TestDispServer")
 


### PR DESCRIPTION
See #688.