### PR TITLE
Replace alias definitions with ctypes.wintypes imports for #662

### DIFF
--- a/comtypes/GUID.py
+++ b/comtypes/GUID.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 def binary(obj: "GUID") -> bytes:
     return bytes(obj)
 
+
 _ole32 = oledll.ole32
 
 _StringFromCLSID = _ole32.StringFromCLSID

--- a/comtypes/GUID.py
+++ b/comtypes/GUID.py
@@ -1,7 +1,8 @@
 """comtypes.GUID module"""
 
 from ctypes import oledll, windll
-from ctypes import byref, c_byte, c_ushort, c_ulong, c_wchar_p, Structure
+from ctypes import byref, c_wchar_p, Structure
+from ctypes.wintypes import BYTE, WORD, DWORD
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,11 +11,6 @@ if TYPE_CHECKING:
 
 def binary(obj: "GUID") -> bytes:
     return bytes(obj)
-
-
-BYTE = c_byte
-WORD = c_ushort
-DWORD = c_ulong
 
 _ole32 = oledll.ole32
 

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -25,6 +25,7 @@ from ctypes import *  # noqa
 from ctypes import HRESULT  # noqa
 from ctypes import _Pointer, _SimpleCData  # noqa
 from ctypes import c_int, c_ulong, oledll, windll
+from ctypes.wintypes import DWORD
 import logging
 import sys
 from typing import TYPE_CHECKING
@@ -72,7 +73,6 @@ class ReturnHRESULT(Exception):
 
 _GUID = GUID
 IID = GUID
-DWORD = c_ulong
 
 wireHWND = c_ulong
 

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -25,7 +25,7 @@ from ctypes import *  # noqa
 from ctypes import HRESULT  # noqa
 from ctypes import _Pointer, _SimpleCData  # noqa
 from ctypes import c_int, c_ulong, oledll, windll
-from ctypes.wintypes import DWORD
+from ctypes.wintypes import DWORD #noqa
 import logging
 import sys
 from typing import TYPE_CHECKING

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -25,7 +25,7 @@ from ctypes import *  # noqa
 from ctypes import HRESULT  # noqa
 from ctypes import _Pointer, _SimpleCData  # noqa
 from ctypes import c_int, c_ulong, oledll, windll
-from ctypes.wintypes import DWORD #noqa
+from ctypes.wintypes import DWORD # noqa
 import logging
 import sys
 from typing import TYPE_CHECKING

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -25,7 +25,7 @@ from ctypes import *  # noqa
 from ctypes import HRESULT  # noqa
 from ctypes import _Pointer, _SimpleCData  # noqa
 from ctypes import c_int, c_ulong, oledll, windll
-from ctypes.wintypes import DWORD # noqa
+from ctypes.wintypes import DWORD  # noqa
 import logging
 import sys
 from typing import TYPE_CHECKING

--- a/comtypes/_safearray.py
+++ b/comtypes/_safearray.py
@@ -1,7 +1,7 @@
 """SAFEARRAY api functions, data types, and constants."""
 
 from ctypes import c_uint, c_ushort, c_void_p, POINTER, Structure, WinDLL
-from ctypes.wintypes import DWORD, LONG, UINT
+from ctypes.wintypes import DWORD, LONG, UINT, USHORT
 
 from comtypes import HRESULT, GUID
 
@@ -19,7 +19,6 @@ from comtypes import HRESULT, GUID
 
 VARTYPE = c_ushort
 PVOID = c_void_p
-USHORT = c_ushort
 
 _oleaut32 = WinDLL("oleaut32")
 

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -1,10 +1,10 @@
 import sys
 from ctypes import *
+from ctypes.wintypes import DWORD
 from comtypes import IUnknown, HRESULT, COMMETHOD, GUID, BSTR
 from comtypes.hresult import *
 
 LPCOLESTR = c_wchar_p
-DWORD = c_ulong
 
 
 class ICreateErrorInfo(IUnknown):

--- a/comtypes/git.py
+++ b/comtypes/git.py
@@ -17,7 +17,6 @@ from comtypes import (
 )
 
 
-
 class IGlobalInterfaceTable(IUnknown):
     _iid_ = GUID("{00000146-0000-0000-C000-000000000046}")
     _methods_ = [

--- a/comtypes/git.py
+++ b/comtypes/git.py
@@ -5,6 +5,7 @@ between different threading appartments.
 """
 
 from ctypes import *
+from ctypes.wintypes import DWORD
 from comtypes import (
     IUnknown,
     STDMETHOD,
@@ -15,7 +16,6 @@ from comtypes import (
     CLSCTX_INPROC_SERVER,
 )
 
-DWORD = c_ulong
 
 
 class IGlobalInterfaceTable(IUnknown):

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -12,7 +12,7 @@ import weakref
 
 import ctypes
 from ctypes import HRESULT, POINTER, _Pointer, byref, c_int, c_void_p, c_wchar_p
-from ctypes.wintypes import DWORD, LONG, UINT, ULONG, WCHAR, WORD
+from ctypes.wintypes import DWORD, LONG, UINT, ULONG, WCHAR, WORD, INT, SHORT, USHORT
 from comtypes import BSTR, _CData, COMMETHOD, GUID, IID, IUnknown, STDMETHOD
 from comtypes.automation import DISPID, LCID, SCODE
 from comtypes.automation import DISPPARAMS, EXCEPINFO, VARIANT, VARIANTARG, VARTYPE
@@ -28,15 +28,12 @@ is_64_bit = sys.maxsize > 2**32
 
 BOOL = c_int
 HREFTYPE = DWORD
-INT = c_int
 MEMBERID = DISPID
 OLECHAR = WCHAR
 PVOID = c_void_p
-SHORT = ctypes.c_short
 # See https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx#ULONG_PTR  # noqa
 ULONG_PTR = ctypes.c_uint64 if is_64_bit else ctypes.c_ulong
 
-USHORT = ctypes.c_ushort
 LPOLESTR = POINTER(OLECHAR)
 
 ################################################################


### PR DESCRIPTION
Removes alias definitions and replaces them with imports from ctypes.wintypes where possible for #662 