### PR TITLE
Add tests for `RegistryEntries`.

### DIFF
--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -233,3 +233,39 @@ class Test_RegistryEntries_NonFrozen(ut.TestCase):
             (HKCR, rf"{clsid_sub}\Typelib", "", libid),
         ]
         self.assertEqual(expected, list(RegistryEntries(Cls)))
+
+
+class Test_RegistryEntries_Frozen(ut.TestCase):
+    @mock.patch.object(register, "sys")
+    def test_local_dll(self, _sys):
+        _sys.mock_add_spec(["executable", "frozen"])
+        _sys.executable = sys.executable
+        _sys.frozen = "dll"
+        reg_clsid = GUID.create_new()
+        reg_clsctx = comtypes.CLSCTX_LOCAL_SERVER
+
+        class Cls:
+            _reg_clsid_ = reg_clsid
+            _reg_clsctx_ = reg_clsctx
+
+        clsid_sub = rf"CLSID\{reg_clsid}"
+        expected = [
+            (HKCR, clsid_sub, "", ""),
+            (HKCR, rf"{clsid_sub}\LocalServer32", "", sys.executable),
+        ]
+        self.assertEqual(expected, list(RegistryEntries(Cls)))
+
+    @mock.patch.object(register, "sys")
+    def test_local_frozendllhandle(self, _sys):
+        _sys.mock_add_spec(["frozen", "frozendllhandle"])
+        _sys.frozen = "dll"
+        _sys.frozendllhandle = 1234
+        reg_clsid = GUID.create_new()
+        reg_clsctx = comtypes.CLSCTX_LOCAL_SERVER
+
+        class Cls:
+            _reg_clsid_ = reg_clsid
+            _reg_clsctx_ = reg_clsctx
+
+        expected = [(HKCR, rf"CLSID\{reg_clsid}", "", "")]
+        self.assertEqual(expected, list(RegistryEntries(Cls)))

--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -33,7 +33,7 @@ class Test_get_serverdll(ut.TestCase):
                 self.assertEqual(260, nSize)
 
 
-class Test_RegistryEntries_NonFrozen(ut.TestCase):
+class Test_NonFrozen_RegistryEntries(ut.TestCase):
     def test_reg_clsid(self):
         reg_clsid = GUID.create_new()
 
@@ -236,7 +236,7 @@ class Test_RegistryEntries_NonFrozen(ut.TestCase):
         self.assertEqual(expected, list(RegistryEntries(Cls)))
 
 
-class Test_RegistryEntries_Frozen(ut.TestCase):
+class Test_Frozen_RegistryEntries(ut.TestCase):
     @mock.patch.object(register, "sys")
     def test_local_dll(self, _sys):
         _sys.mock_add_spec(["executable", "frozen"])


### PR DESCRIPTION
Frozen server tests are added.
See also #697.