### PR TITLE
Replaced by fstring

### DIFF
--- a/comtypes/test/test_BSTR.py
+++ b/comtypes/test/test_BSTR.py
@@ -8,7 +8,7 @@ from comtypes.test.find_memleak import find_memleak
 class Test(unittest.TestCase):
     def check_leaks(self, func, limit=0):
         bytes = find_memleak(func)
-        self.assertFalse(bytes > limit, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes > limit, f"Leaks {bytes} bytes")
 
     def test_creation(self):
         def doit():

--- a/comtypes/test/test_avmc.py
+++ b/comtypes/test/test_avmc.py
@@ -37,7 +37,7 @@ class Test(unittest.TestCase):
 
     def check_leaks(self, func, limit=0):
         bytes = find_memleak(func)
-        self.assertFalse(bytes > limit, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes > limit, f"Leaks {bytes} bytes")
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_casesensitivity.py
+++ b/comtypes/test/test_casesensitivity.py
@@ -31,13 +31,11 @@ class TestCase(unittest.TestCase):
         # names in the base class __map_case__ must also appear in the
         # subclass.
         for name in iem.IWebBrowser.__map_case__:
-            self.assertTrue(
-                name in iem.IWebBrowserApp.__map_case__, "%s missing" % name
-            )
-            self.assertTrue(name in iem.IWebBrowser2.__map_case__, "%s missing" % name)
+            self.assertTrue(name in iem.IWebBrowserApp.__map_case__, f"{name} missing")
+            self.assertTrue(name in iem.IWebBrowser2.__map_case__, f"{name} missing")
 
         for name in iem.IWebBrowserApp.__map_case__:
-            self.assertTrue(name in iem.IWebBrowser2.__map_case__, "%s missing" % name)
+            self.assertTrue(name in iem.IWebBrowser2.__map_case__, f"{name} missing")
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_collections.py
+++ b/comtypes/test/test_collections.py
@@ -74,7 +74,7 @@ class Test(unittest.TestCase):
                 item.ProcessImageFileName
 
         bytes = find_memleak(doit, (20, 20))
-        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, f"Leaks {bytes} bytes")
 
     @unittest.skip("This test takes a long time.  Do we need it? Can it be rewritten?")
     def test_leaks_2(self):
@@ -87,7 +87,7 @@ class Test(unittest.TestCase):
             iter(apps).Next(99)
 
         bytes = find_memleak(doit, (20, 20))
-        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, f"Leaks {bytes} bytes")
 
     @unittest.skip("This test takes a long time.  Do we need it? Can it be rewritten?")
     def test_leaks_3(self):
@@ -102,7 +102,7 @@ class Test(unittest.TestCase):
                     pass
 
         bytes = find_memleak(doit, (20, 20))
-        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, f"Leaks {bytes} bytes")
 
 
 class TestCollectionInterface(unittest.TestCase):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -39,7 +39,7 @@ class BaseServerTest(object):
 
     def _find_memleak(self, func):
         bytes = find_memleak(func)
-        self.assertFalse(bytes, "Leaks %d bytes" % bytes)  # type: ignore
+        self.assertFalse(bytes, f"Leaks {bytes} bytes")  # type: ignore
 
     def test_mixedinout(self):
         o = self.create_object()
@@ -186,7 +186,7 @@ class VariantTest(unittest.TestCase):
             return v.value
 
         bytes = find_memleak(func)
-        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, f"Leaks {bytes} bytes")  # type: ignore
 
 
 class SafeArrayTest(unittest.TestCase):
@@ -207,7 +207,7 @@ class SafeArrayTest(unittest.TestCase):
             t.from_param([MYCOLOR(0, 0, 0), MYCOLOR(1, 2, 3)])
 
         bytes = find_memleak(doit)
-        self.assertFalse(bytes, "Leaks %d bytes" % bytes)
+        self.assertFalse(bytes, f"Leaks {bytes} bytes")  # type: ignore
 
 
 class PropPutRefTest(unittest.TestCase):

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -55,8 +55,8 @@ def add_test(fname):
             return
         comtypes.client.GetModule(fname)
 
-    test.__doc__ = "test GetModule(%r)" % fname
-    setattr(Test, "test_%d" % number, test)
+    test.__doc__ = f"test GetModule({fname!r})"
+    setattr(Test, f"test_{number}", test)
     number += 1
 
 


### PR DESCRIPTION
Related to #657 

The `comtypes/tools/tlbparser.py` had already been replaced by fstring.


