### PR TITLE
Add type hints to `_comobject.py` (part 2).

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -15,9 +15,19 @@ from ctypes import (
     pointer,
     windll,
 )
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Tuple, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+)
 
-from comtypes import IPersist, IUnknown, ReturnHRESULT, instancemethod
+from comtypes import GUID, IPersist, IUnknown, ReturnHRESULT, instancemethod
 from comtypes._memberspec import _encode_idl
 from comtypes.errorinfo import ISupportErrorInfo, ReportError, ReportException
 from comtypes.hresult import (
@@ -429,7 +439,9 @@ class InprocServer(object):
 
 
 class COMObject(object):
-    _instances_ = {}
+    _instances_: ClassVar[Dict["COMObject", None]] = {}
+    _reg_clsid_: ClassVar[GUID]
+    __typelib: "hints.ITypeLib"
 
     def __new__(cls, *args, **kw):
         self = super(COMObject, cls).__new__(cls)

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -2,7 +2,7 @@ import logging
 import os
 import queue
 import sys
-from _ctypes import CopyComPointer
+from _ctypes import COMError, CopyComPointer
 from ctypes import (
     POINTER,
     WINFUNCTYPE,
@@ -17,7 +17,7 @@ from ctypes import (
 )
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
-from comtypes import COMError, IPersist, ReturnHRESULT, instancemethod
+from comtypes import IPersist, ReturnHRESULT, instancemethod
 from comtypes._memberspec import _encode_idl
 from comtypes.errorinfo import ISupportErrorInfo, ReportError, ReportException
 from comtypes.hresult import (

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -34,6 +34,8 @@ from comtypes.hresult import (
 from comtypes.typeinfo import IProvideClassInfo, IProvideClassInfo2
 
 if TYPE_CHECKING:
+    from ctypes import _FuncPointer
+
     from comtypes import hints  # type: ignore
     from comtypes._memberspec import _ParamFlagType
 
@@ -312,7 +314,9 @@ class _MethodFinder(object):
         return instancemethod(get, self.inst, type(self.inst))
 
 
-def _create_vtbl_type(fields, itf):
+def _create_vtbl_type(
+    fields: Tuple[Tuple[str, Type["_FuncPointer"]], ...], itf: Type[IUnknown]
+) -> Type[Structure]:
     try:
         return _vtbl_types[fields]
     except KeyError:

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -15,9 +15,9 @@ from ctypes import (
     pointer,
     windll,
 )
-from typing import TYPE_CHECKING, Callable, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Tuple, Type
 
-from comtypes import IPersist, ReturnHRESULT, instancemethod
+from comtypes import IPersist, IUnknown, ReturnHRESULT, instancemethod
 from comtypes._memberspec import _encode_idl
 from comtypes.errorinfo import ISupportErrorInfo, ReportError, ReportException
 from comtypes.hresult import (
@@ -35,6 +35,7 @@ from comtypes.typeinfo import IProvideClassInfo, IProvideClassInfo2
 
 if TYPE_CHECKING:
     from comtypes import hints  # type: ignore
+    from comtypes._memberspec import _ParamFlagType
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug
@@ -91,7 +92,13 @@ def _do_implement(interface_name: str, method_name: str) -> Callable[..., int]:
     return _not_implemented
 
 
-def catch_errors(obj, mth, paramflags, interface, mthname):
+def catch_errors(
+    obj: "COMObject",
+    mth: Callable[..., Any],
+    paramflags: Optional[Tuple["_ParamFlagType", ...]],
+    interface: Type[IUnknown],
+    mthname: str,
+) -> Callable[..., Any]:
     clsid = getattr(obj, "_reg_clsid_", None)
 
     def call_with_this(*args, **kw):

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -141,7 +141,13 @@ def catch_errors(
 ################################################################
 
 
-def hack(inst, mth, paramflags, interface, mthname):
+def hack(
+    inst: "COMObject",
+    mth: Callable[..., Any],
+    paramflags: Optional[Tuple["_ParamFlagType", ...]],
+    interface: Type[IUnknown],
+    mthname: str,
+) -> Callable[..., Any]:
     if paramflags is None:
         return catch_errors(inst, mth, paramflags, interface, mthname)
     code = mth.__code__

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -15,7 +15,7 @@ from ctypes import (
     pointer,
     windll,
 )
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Tuple, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Tuple, Type
 
 from comtypes import IPersist, IUnknown, ReturnHRESULT, instancemethod
 from comtypes._memberspec import _encode_idl
@@ -330,7 +330,7 @@ def _create_vtbl_type(
 
 
 # Ugh. Another type cache to avoid leaking types.
-_vtbl_types = {}
+_vtbl_types: Dict[Tuple[Tuple[str, Type["_FuncPointer"]], ...], Type[Structure]] = {}
 
 ################################################################
 

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -28,7 +28,7 @@ from comtypes import IUnknown as IUnknown, GUID as GUID
 from comtypes.automation import IDispatch as IDispatch, VARIANT as VARIANT
 from comtypes.server import IClassFactory as IClassFactory
 from comtypes.server import localserver as localserver
-from comtypes.typeinfo import ITypeInfo as ITypeInfo
+from comtypes.typeinfo import ITypeInfo as ITypeInfo, ITypeLib as ITypeLib
 from comtypes._safearray import tagSAFEARRAY as tagSAFEARRAY
 
 Incomplete: TypeAlias = Any


### PR DESCRIPTION
This is a follow-up to #703 and is related to python/cpython#127369.