### PR TITLE
Add type hints to `_comobject.py` (part 4).

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -623,7 +623,7 @@ class COMObject(object):
     __server__: Union[None, InprocServer, LocalServer] = None
 
     @staticmethod
-    def __run_inprocserver__():
+    def __run_inprocserver__() -> None:
         if COMObject.__server__ is None:
             COMObject.__server__ = InprocServer()
         elif isinstance(COMObject.__server__, InprocServer):
@@ -632,7 +632,9 @@ class COMObject(object):
             raise RuntimeError("Wrong server type")
 
     @staticmethod
-    def __run_localserver__(classobjects):
+    def __run_localserver__(
+        classobjects: Sequence["hints.localserver.ClassFactory"],
+    ) -> None:
         assert COMObject.__server__ is None
         # XXX Decide whether we are in STA or MTA
         server = COMObject.__server__ = LocalServer()
@@ -640,14 +642,14 @@ class COMObject(object):
         COMObject.__server__ = None
 
     @staticmethod
-    def __keep__(obj):
+    def __keep__(obj: "COMObject") -> None:
         COMObject._instances_[obj] = None
         _debug("%d active COM objects: Added   %r", len(COMObject._instances_), obj)
         if COMObject.__server__:
             COMObject.__server__.Lock()
 
     @staticmethod
-    def __unkeep__(obj):
+    def __unkeep__(obj: "COMObject") -> None:
         try:
             del COMObject._instances_[obj]
         except AttributeError:

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -471,7 +471,7 @@ class COMObject(object):
             self.__prepare_comobject()
         return self
 
-    def __prepare_comobject(self):
+    def __prepare_comobject(self) -> None:
         # When a CoClass instance is created, COM pointers to all
         # interfaces are created.  Also, the CoClass must be kept alive as
         # until the COM reference count drops to zero, even if no Python

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -666,8 +666,11 @@ class COMObject(object):
     #########################################################
     # IUnknown methods implementations
     def IUnknown_AddRef(
-        self, this, __InterlockedIncrement=_InterlockedIncrement, _debug=_debug
-    ):
+        self,
+        this: Any,
+        __InterlockedIncrement: Callable[[c_long], int] = _InterlockedIncrement,
+        _debug=_debug,
+    ) -> int:
         result = __InterlockedIncrement(self._refcnt)
         if result == 1:
             self.__keep__(self)

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -614,9 +614,8 @@ class COMObject(object):
         if invkind in (1, 2):
             self._dispimpl_[(dispid, 3)] = impl  # type: ignore
 
-    def _get_method_finder_(self, itf):
-        # This method can be overridden to customize how methods are
-        # found.
+    def _get_method_finder_(self, itf: Type[IUnknown]) -> _MethodFinder:
+        # This method can be overridden to customize how methods are found.
         return _MethodFinder(self)
 
     ################################################################

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -701,7 +701,9 @@ class COMObject(object):
             self._com_pointers_ = {}
         return result
 
-    def IUnknown_QueryInterface(self, this, riid, ppvObj, _debug=_debug):
+    def IUnknown_QueryInterface(
+        self, this: Any, riid: "_Pointer[GUID]", ppvObj: c_void_p, _debug=_debug
+    ) -> int:
         # XXX This is probably too slow.
         # riid[0].hashcode() alone takes 33 us!
         iid = riid[0]

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -677,7 +677,7 @@ class COMObject(object):
         _debug("%r.AddRef() -> %s", self, result)
         return result
 
-    def _final_release_(self):
+    def _final_release_(self) -> None:
         """This method may be overridden in subclasses
         to free allocated resources or so."""
         pass

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -26,6 +26,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -452,6 +453,9 @@ class InprocServer(object):
         return S_OK
 
 
+_T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
+
+
 class COMObject(object):
     _com_interfaces_: ClassVar[List[Type[IUnknown]]]
     _instances_: ClassVar[Dict["COMObject", None]] = {}
@@ -715,7 +719,7 @@ class COMObject(object):
         _debug("%r.QueryInterface(%s) -> E_NOINTERFACE", self, iid)
         return E_NOINTERFACE
 
-    def QueryInterface(self, interface):
+    def QueryInterface(self, interface: Type[_T_IUnknown]) -> _T_IUnknown:
         "Query the object for an interface pointer"
         # This method is NOT the implementation of
         # IUnknown::QueryInterface, instead it is supposed to be

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -893,7 +893,7 @@ class COMObject(object):
 
     ################################################################
     # IPersist interface
-    def IPersist_GetClassID(self):
+    def IPersist_GetClassID(self) -> GUID:
         return self._reg_clsid_
 
 

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -512,10 +512,10 @@ class COMObject(object):
         for itf in interfaces[::-1]:
             self.__make_interface_pointer(itf)
 
-    def __make_interface_pointer(self, itf):
-        methods = []  # method implementations
-        fields = []  # (name, prototype) for virtual function table
-        iids = []  # interface identifiers.
+    def __make_interface_pointer(self, itf: Type[IUnknown]) -> None:
+        methods: List[Callable[..., Any]] = []  # method implementations
+        fields: List[Tuple[str, Type["_FuncPointer"]]] = []  # virtual function table
+        iids: List[GUID] = []  # interface identifiers.
         # iterate over interface inheritance in reverse order to build the
         # virtual function table, and leave out the 'object' base class.
         finder = self._get_method_finder_(itf)

--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -683,8 +683,11 @@ class COMObject(object):
         pass
 
     def IUnknown_Release(
-        self, this, __InterlockedDecrement=_InterlockedDecrement, _debug=_debug
-    ):
+        self,
+        this: Any,
+        __InterlockedDecrement: Callable[[c_long], int] = _InterlockedDecrement,
+        _debug=_debug,
+    ) -> int:
         # If this is called at COM shutdown, _InterlockedDecrement()
         # must still be available, although module level variables may
         # have been deleted already - so we supply it as default


### PR DESCRIPTION
This is a follow-up to #705 and is related to python/cpython#127369.