### PR TITLE
Add type hints to `server/__init__.py`.

### DIFF
--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,5 +1,5 @@
 import ctypes
-from ctypes import HRESULT, POINTER
+from ctypes import HRESULT, POINTER, byref
 
 import comtypes
 import comtypes.client
@@ -29,7 +29,7 @@ class IClassFactory(IUnknown):
         else:
             realInterface = interface
         obj = POINTER(realInterface)()
-        self.__com_CreateInstance(punkouter, realInterface._iid_, ctypes.byref(obj))
+        self.__com_CreateInstance(punkouter, realInterface._iid_, byref(obj))
         if dynamic:
             return comtypes.client.dynamic.Dispatch(obj)
         elif interface is None:
@@ -61,9 +61,7 @@ def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
     else:
         flags = ACTIVEOBJECT_STRONG
     handle = ctypes.c_ulong()
-    oleaut32.RegisterActiveObject(
-        punk, ctypes.byref(clsid), flags, ctypes.byref(handle)
-    )
+    oleaut32.RegisterActiveObject(punk, byref(clsid), flags, byref(handle))
     return handle.value
 
 

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Type
 import comtypes
 import comtypes.client
 from comtypes import GUID, STDMETHOD, IUnknown
+from comtypes.automation import IDispatch
 
 if TYPE_CHECKING:
     from ctypes import _Pointer
@@ -34,7 +35,7 @@ class IClassFactory(IUnknown):
         if dynamic:
             if interface is not None:
                 raise ValueError("interface and dynamic are mutually exclusive")
-            realInterface = comtypes.automation.IDispatch
+            realInterface = IDispatch
         elif interface is None:
             realInterface = IUnknown
         else:

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Type
 
 import comtypes
 import comtypes.client
+import comtypes.client.dynamic
 from comtypes import GUID, STDMETHOD, IUnknown
 from comtypes.automation import IDispatch
 

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,5 +1,5 @@
 import ctypes
-from ctypes import HRESULT
+from ctypes import HRESULT, POINTER
 
 import comtypes
 import comtypes.client
@@ -14,11 +14,7 @@ class IClassFactory(IUnknown):
         STDMETHOD(
             HRESULT,
             "CreateInstance",
-            [
-                ctypes.POINTER(IUnknown),
-                ctypes.POINTER(GUID),
-                ctypes.POINTER(ctypes.c_void_p),
-            ],
+            [POINTER(IUnknown), POINTER(GUID), POINTER(ctypes.c_void_p)],
         ),
         STDMETHOD(HRESULT, "LockServer", [ctypes.c_int]),
     ]
@@ -32,7 +28,7 @@ class IClassFactory(IUnknown):
             realInterface = IUnknown
         else:
             realInterface = interface
-        obj = ctypes.POINTER(realInterface)()
+        obj = POINTER(realInterface)()
         self.__com_CreateInstance(punkouter, realInterface._iid_, ctypes.byref(obj))
         if dynamic:
             return comtypes.client.dynamic.Dispatch(obj)

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -55,7 +55,7 @@ ACTIVEOBJECT_WEAK = 0x1
 oleaut32 = ctypes.oledll.oleaut32
 
 
-def RegisterActiveObject(comobj, weak=True):
+def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
     punk = comobj._com_pointers_[comtypes.IUnknown._iid_]
     clsid = comobj._reg_clsid_
     if weak:

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -36,13 +36,13 @@ class IClassFactory(IUnknown):
         if dynamic:
             if interface is not None:
                 raise ValueError("interface and dynamic are mutually exclusive")
-            realInterface = IDispatch
+            itf = IDispatch
         elif interface is None:
-            realInterface = IUnknown
+            itf = IUnknown
         else:
-            realInterface = interface
-        obj = POINTER(realInterface)()
-        self.__com_CreateInstance(punkouter, realInterface._iid_, byref(obj))
+            itf = interface
+        obj = POINTER(itf)()
+        self.__com_CreateInstance(punkouter, itf._iid_, byref(obj))  # type: ignore
         if dynamic:
             return comtypes.client.dynamic.Dispatch(obj)
         elif interface is None:

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -2,7 +2,7 @@ import ctypes
 
 import comtypes
 import comtypes.client
-from comtypes import GUID, IUnknown
+from comtypes import GUID, STDMETHOD, IUnknown
 
 
 ################################################################
@@ -10,7 +10,7 @@ from comtypes import GUID, IUnknown
 class IClassFactory(IUnknown):
     _iid_ = GUID("{00000001-0000-0000-C000-000000000046}")
     _methods_ = [
-        comtypes.STDMETHOD(
+        STDMETHOD(
             comtypes.HRESULT,
             "CreateInstance",
             [
@@ -19,7 +19,7 @@ class IClassFactory(IUnknown):
                 ctypes.POINTER(ctypes.c_void_p),
             ],
         ),
-        comtypes.STDMETHOD(comtypes.HRESULT, "LockServer", [ctypes.c_int]),
+        STDMETHOD(comtypes.HRESULT, "LockServer", [ctypes.c_int]),
     ]
 
     def CreateInstance(self, punkouter=None, interface=None, dynamic=False):

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -69,5 +69,5 @@ def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
     return handle.value
 
 
-def RevokeActiveObject(handle):
+def RevokeActiveObject(handle: int) -> None:
     oleaut32.RevokeActiveObject(handle, None)

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,4 +1,7 @@
-import comtypes.client, ctypes
+import ctypes
+
+import comtypes
+import comtypes.client
 
 
 ################################################################

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -2,20 +2,20 @@ import ctypes
 
 import comtypes
 import comtypes.client
-from comtypes import IUnknown
+from comtypes import GUID, IUnknown
 
 
 ################################################################
 # Interfaces
 class IClassFactory(IUnknown):
-    _iid_ = comtypes.GUID("{00000001-0000-0000-C000-000000000046}")
+    _iid_ = GUID("{00000001-0000-0000-C000-000000000046}")
     _methods_ = [
         comtypes.STDMETHOD(
             comtypes.HRESULT,
             "CreateInstance",
             [
                 ctypes.POINTER(IUnknown),
-                ctypes.POINTER(comtypes.GUID),
+                ctypes.POINTER(GUID),
                 ctypes.POINTER(ctypes.c_void_p),
             ],
         ),

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,12 +1,14 @@
 import ctypes
 from ctypes import HRESULT, POINTER, byref
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, Type
 
 import comtypes
 import comtypes.client
 from comtypes import GUID, STDMETHOD, IUnknown
 
 if TYPE_CHECKING:
+    from ctypes import _Pointer
+
     from comtypes import hints  # type: ignore
 
 
@@ -23,7 +25,12 @@ class IClassFactory(IUnknown):
         STDMETHOD(HRESULT, "LockServer", [ctypes.c_int]),
     ]
 
-    def CreateInstance(self, punkouter=None, interface=None, dynamic=False):
+    def CreateInstance(
+        self,
+        punkouter: Optional[Type["_Pointer[IUnknown]"]] = None,
+        interface: Optional[Type[IUnknown]] = None,
+        dynamic: bool = False,
+    ) -> Any:
         if dynamic:
             if interface is not None:
                 raise ValueError("interface and dynamic are mutually exclusive")

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -2,18 +2,19 @@ import ctypes
 
 import comtypes
 import comtypes.client
+from comtypes import IUnknown
 
 
 ################################################################
 # Interfaces
-class IClassFactory(comtypes.IUnknown):
+class IClassFactory(IUnknown):
     _iid_ = comtypes.GUID("{00000001-0000-0000-C000-000000000046}")
     _methods_ = [
         comtypes.STDMETHOD(
             comtypes.HRESULT,
             "CreateInstance",
             [
-                ctypes.POINTER(comtypes.IUnknown),
+                ctypes.POINTER(IUnknown),
                 ctypes.POINTER(comtypes.GUID),
                 ctypes.POINTER(ctypes.c_void_p),
             ],
@@ -27,7 +28,7 @@ class IClassFactory(comtypes.IUnknown):
                 raise ValueError("interface and dynamic are mutually exclusive")
             realInterface = comtypes.automation.IDispatch
         elif interface is None:
-            realInterface = comtypes.IUnknown
+            realInterface = IUnknown
         else:
             realInterface = interface
         obj = ctypes.POINTER(realInterface)()
@@ -56,7 +57,7 @@ oleaut32 = ctypes.oledll.oleaut32
 
 
 def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
-    punk = comobj._com_pointers_[comtypes.IUnknown._iid_]
+    punk = comobj._com_pointers_[IUnknown._iid_]
     clsid = comobj._reg_clsid_
     if weak:
         flags = ACTIVEOBJECT_WEAK

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,9 +1,13 @@
 import ctypes
 from ctypes import HRESULT, POINTER, byref
+from typing import TYPE_CHECKING
 
 import comtypes
 import comtypes.client
 from comtypes import GUID, STDMETHOD, IUnknown
+
+if TYPE_CHECKING:
+    from comtypes import hints  # type: ignore
 
 
 ################################################################
@@ -37,6 +41,10 @@ class IClassFactory(IUnknown):
             return comtypes.client.GetBestInterface(obj)
         # An interface was specified and obj is already that interface.
         return obj
+
+    if TYPE_CHECKING:
+
+        def LockServer(self, fLock: int) -> hints.Hresult: ...
 
 
 # class IExternalConnection(IUnknown):

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,4 +1,5 @@
 import ctypes
+from ctypes import HRESULT
 
 import comtypes
 import comtypes.client
@@ -11,7 +12,7 @@ class IClassFactory(IUnknown):
     _iid_ = GUID("{00000001-0000-0000-C000-000000000046}")
     _methods_ = [
         STDMETHOD(
-            comtypes.HRESULT,
+            HRESULT,
             "CreateInstance",
             [
                 ctypes.POINTER(IUnknown),
@@ -19,7 +20,7 @@ class IClassFactory(IUnknown):
                 ctypes.POINTER(ctypes.c_void_p),
             ],
         ),
-        STDMETHOD(comtypes.HRESULT, "LockServer", [ctypes.c_int]),
+        STDMETHOD(HRESULT, "LockServer", [ctypes.c_int]),
     ]
 
     def CreateInstance(self, punkouter=None, interface=None, dynamic=False):


### PR DESCRIPTION
This is a follow-up to #706 and is related to python/cpython#127369.