### PR TITLE
Add type hints to `server/inprocserver.py` and `server/localserver.py`.

### DIFF
--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -2,9 +2,9 @@ import ctypes
 import logging
 import sys
 import winreg
-from typing import Any, Literal, Type
+from typing import Any, Literal, Optional, Type
 
-from comtypes import GUID, COMObject
+from comtypes import GUID, COMObject, IUnknown
 from comtypes.hresult import *
 from comtypes.server import IClassFactory
 
@@ -22,7 +22,13 @@ class ClassFactory(COMObject):
         super(ClassFactory, self).__init__()
         self._cls = cls
 
-    def IClassFactory_CreateInstance(self, this, punkOuter, riid, ppv):
+    def IClassFactory_CreateInstance(
+        self,
+        this: Any,
+        punkOuter: Optional[Type["ctypes._Pointer[IUnknown]"]],
+        riid: "ctypes._Pointer[GUID]",
+        ppv: ctypes.c_void_p,
+    ) -> int:
         _debug("ClassFactory.CreateInstance(%s)", riid[0])
         result = self._cls().IUnknown_QueryInterface(None, riid, ppv)
         _debug("CreateInstance() -> %s", result)

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -70,7 +70,7 @@ def inproc_find_class(clsid):
 _logging_configured = False
 
 
-def _setup_logging(clsid):
+def _setup_logging(clsid: GUID) -> None:
     """Read from the registry, and configure the logging module.
 
     Currently, the handler (NTDebugHandler) is hardcoded.

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -2,6 +2,7 @@ import ctypes
 import logging
 import sys
 import winreg
+from typing import Literal
 
 from comtypes import GUID, COMObject
 from comtypes.hresult import *
@@ -138,7 +139,7 @@ def DllGetClassObject(rclsid, riid, ppv):
         return E_FAIL
 
 
-def DllCanUnloadNow():
+def DllCanUnloadNow() -> Literal[1]:  # S_FALSE
     COMObject.__run_inprocserver__()
     result = COMObject.__server__.DllCanUnloadNow()
     # To avoid a memory leak when PyInitialize()/PyUninitialize() are

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -2,7 +2,7 @@ import ctypes
 import logging
 import sys
 import winreg
-from typing import Literal
+from typing import Literal, Type
 
 from comtypes import GUID, COMObject
 from comtypes.hresult import *
@@ -40,7 +40,7 @@ class ClassFactory(COMObject):
 _clsid_to_class = {}
 
 
-def inproc_find_class(clsid):
+def inproc_find_class(clsid: GUID) -> Type[COMObject]:
     if _clsid_to_class:
         return _clsid_to_class[clsid]
 

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -109,7 +109,7 @@ def _setup_logging(clsid):
         logging.getLogger(name).setLevel(level)
 
 
-def DllGetClassObject(rclsid, riid, ppv):
+def DllGetClassObject(rclsid: int, riid: int, ppv: int) -> int:
     COMObject.__run_inprocserver__()
 
     iid = GUID.from_address(riid)

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -1,12 +1,11 @@
 import ctypes
-from comtypes import COMObject, GUID
-from comtypes.server import IClassFactory
-from comtypes.hresult import *
-
-import sys
 import logging
+import sys
 import winreg
 
+from comtypes import GUID, COMObject
+from comtypes.hresult import *
+from comtypes.server import IClassFactory
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -18,7 +18,7 @@ _critical = logger.critical
 class ClassFactory(COMObject):
     _com_interfaces_ = [IClassFactory]
 
-    def __init__(self, cls):
+    def __init__(self, cls: Type[COMObject]) -> None:
         super(ClassFactory, self).__init__()
         self._cls = cls
 

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -4,8 +4,7 @@ import sys
 import winreg
 from typing import Any, Literal, Optional, Type
 
-from comtypes import GUID, COMObject, IUnknown
-from comtypes.hresult import *
+from comtypes import GUID, COMObject, IUnknown, hresult
 from comtypes.server import IClassFactory
 
 logger = logging.getLogger(__name__)
@@ -39,7 +38,7 @@ class ClassFactory(COMObject):
             COMObject.__server__.Lock()
         else:
             COMObject.__server__.Unlock()
-        return S_OK
+        return hresult.S_OK
 
 
 # will be set by py2exe boot script 'from outside'
@@ -133,7 +132,7 @@ def DllGetClassObject(rclsid: int, riid: int, ppv: int) -> int:
 
         cls = inproc_find_class(clsid)
         if not cls:
-            return CLASS_E_CLASSNOTAVAILABLE
+            return hresult.CLASS_E_CLASSNOTAVAILABLE
 
         result = ClassFactory(cls).IUnknown_QueryInterface(
             None, ctypes.pointer(iid), ctypes.c_void_p(ppv)
@@ -142,7 +141,7 @@ def DllGetClassObject(rclsid: int, riid: int, ppv: int) -> int:
         return result
     except Exception:
         _critical("DllGetClassObject", exc_info=True)
-        return E_FAIL
+        return hresult.E_FAIL
 
 
 def DllCanUnloadNow() -> Literal[1]:  # S_FALSE
@@ -150,4 +149,4 @@ def DllCanUnloadNow() -> Literal[1]:  # S_FALSE
     result = COMObject.__server__.DllCanUnloadNow()
     # To avoid a memory leak when PyInitialize()/PyUninitialize() are
     # called several times, we refuse to unload the dll.
-    return S_FALSE
+    return hresult.S_FALSE

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -2,7 +2,7 @@ import ctypes
 import logging
 import sys
 import winreg
-from typing import Literal, Type
+from typing import Any, Literal, Type
 
 from comtypes import GUID, COMObject
 from comtypes.hresult import *
@@ -28,7 +28,7 @@ class ClassFactory(COMObject):
         _debug("CreateInstance() -> %s", result)
         return result
 
-    def IClassFactory_LockServer(self, this, fLock):
+    def IClassFactory_LockServer(self, this: Any, fLock: bool) -> Literal[0]:
         if fLock:
             COMObject.__server__.Lock()
         else:

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -39,7 +39,7 @@ class ClassFactory(comtypes.COMObject):
     def IUnknown_AddRef(self, this: Any) -> int:
         return 2
 
-    def IUnknown_Release(self, this):
+    def IUnknown_Release(self, this: Any) -> int:
         return 1
 
     def _register_class(self):

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -42,7 +42,7 @@ class ClassFactory(comtypes.COMObject):
     def IUnknown_Release(self, this: Any) -> int:
         return 1
 
-    def _register_class(self):
+    def _register_class(self) -> None:
         regcls = getattr(self._cls, "_regcls_", self.regcls)
         cookie = c_ulong()
         ptr = self._com_pointers_[comtypes.IUnknown._iid_]

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -57,7 +57,7 @@ class ClassFactory(comtypes.COMObject):
         )
         self.cookie = cookie
 
-    def _revoke_class(self):
+    def _revoke_class(self) -> None:
         oledll.ole32.CoRevokeClassObject(self.cookie)
 
     def CreateInstance(self, this, punkOuter, riid, ppv):

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -1,10 +1,11 @@
+import logging
+import queue
 import sys
 from ctypes import *
+
 import comtypes
 from comtypes.hresult import *
 from comtypes.server import IClassFactory
-import logging
-import queue
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -1,7 +1,7 @@
 import logging
 import queue
 import sys
-from ctypes import *
+from ctypes import byref, c_ulong, c_void_p, oledll
 from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Type
 
 import comtypes

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -5,7 +5,7 @@ from ctypes import *
 from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Type
 
 import comtypes
-from comtypes.hresult import *
+from comtypes import hresult
 from comtypes.server import IClassFactory
 
 if TYPE_CHECKING:
@@ -82,4 +82,4 @@ class ClassFactory(comtypes.COMObject):
             comtypes.COMObject.__server__.Lock()
         else:
             comtypes.COMObject.__server__.Unlock()
-        return S_OK
+        return hresult.S_OK

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -2,11 +2,15 @@ import logging
 import queue
 import sys
 from ctypes import *
-from typing import Any, Optional, Sequence, Type
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Type
 
 import comtypes
 from comtypes.hresult import *
 from comtypes.server import IClassFactory
+
+if TYPE_CHECKING:
+    from ctypes import _Pointer
+
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug
@@ -60,7 +64,13 @@ class ClassFactory(comtypes.COMObject):
     def _revoke_class(self) -> None:
         oledll.ole32.CoRevokeClassObject(self.cookie)
 
-    def CreateInstance(self, this, punkOuter, riid, ppv):
+    def CreateInstance(
+        self,
+        this: Any,
+        punkOuter: Optional[Type["_Pointer[comtypes.IUnknown]"]],
+        riid: "_Pointer[comtypes.GUID]",
+        ppv: c_void_p,
+    ) -> int:
         _debug("ClassFactory.CreateInstance(%s)", riid[0])
         obj = self._cls(*self._args, **self._kw)
         result = obj.IUnknown_QueryInterface(None, riid, ppv)

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -29,7 +29,7 @@ class ClassFactory(comtypes.COMObject):
     _queue: Optional[queue.Queue] = None
     regcls: int = REGCLS_MULTIPLEUSE
 
-    def __init__(self, cls, *args, **kw):
+    def __init__(self, cls: Type[comtypes.COMObject], *args, **kw) -> None:
         super(ClassFactory, self).__init__()
         self._cls = cls
         self._register_class()

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -2,7 +2,7 @@ import logging
 import queue
 import sys
 from ctypes import *
-from typing import Optional, Sequence, Type
+from typing import Any, Optional, Sequence, Type
 
 import comtypes
 from comtypes.hresult import *
@@ -36,7 +36,7 @@ class ClassFactory(comtypes.COMObject):
         self._args = args
         self._kw = kw
 
-    def IUnknown_AddRef(self, this):
+    def IUnknown_AddRef(self, this: Any) -> int:
         return 2
 
     def IUnknown_Release(self, this):

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -2,7 +2,7 @@ import logging
 import queue
 import sys
 from ctypes import *
-from typing import Sequence, Type
+from typing import Optional, Sequence, Type
 
 import comtypes
 from comtypes.hresult import *
@@ -25,9 +25,9 @@ def run(classes: Sequence[Type[comtypes.COMObject]]) -> None:
 
 class ClassFactory(comtypes.COMObject):
     _com_interfaces_ = [IClassFactory]
-    _locks = 0
-    _queue = None
-    regcls = REGCLS_MULTIPLEUSE
+    _locks: int = 0
+    _queue: Optional[queue.Queue] = None
+    regcls: int = REGCLS_MULTIPLEUSE
 
     def __init__(self, cls, *args, **kw):
         super(ClassFactory, self).__init__()

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -2,6 +2,7 @@ import logging
 import queue
 import sys
 from ctypes import *
+from typing import Sequence, Type
 
 import comtypes
 from comtypes.hresult import *
@@ -17,7 +18,7 @@ REGCLS_SUSPENDED = 4  # register it as suspended, will be activated
 REGCLS_SURROGATE = 8  # must be used when a surrogate process
 
 
-def run(classes):
+def run(classes: Sequence[Type[comtypes.COMObject]]) -> None:
     classobjects = [ClassFactory(cls) for cls in classes]
     comtypes.COMObject.__run_localserver__(classobjects)
 

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -2,7 +2,7 @@ import logging
 import queue
 import sys
 from ctypes import *
-from typing import TYPE_CHECKING, Any, Optional, Sequence, Type
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Type
 
 import comtypes
 from comtypes.hresult import *
@@ -77,7 +77,7 @@ class ClassFactory(comtypes.COMObject):
         _debug("CreateInstance() -> %s", result)
         return result
 
-    def LockServer(self, this, fLock):
+    def LockServer(self, this: Any, fLock: bool) -> Literal[0]:
         if fLock:
             comtypes.COMObject.__server__.Lock()
         else:


### PR DESCRIPTION
This is a follow-up to #707 and is related to python/cpython#127369.