### PR TITLE
Add `test_comobject`(part 1).

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -808,6 +808,10 @@ class IDispatch(IUnknown):
         ),
     ]
 
+    if TYPE_CHECKING:
+
+        def GetTypeInfoCount(self) -> int: ...
+
     def GetTypeInfo(self, index: int, lcid: int = 0) -> "hints.ITypeInfo":
         """Return type information.  Index 0 specifies typeinfo for IDispatch"""
         import comtypes.typeinfo

--- a/comtypes/test/test_comobject.py
+++ b/comtypes/test/test_comobject.py
@@ -1,0 +1,42 @@
+import unittest as ut
+
+import comtypes
+import comtypes.client
+from comtypes import IUnknown
+
+comtypes.client.GetModule("UIAutomationCore.dll")
+comtypes.client.GetModule("scrrun.dll")
+from comtypes.gen import Scripting as scrrun
+from comtypes.gen import UIAutomationClient as uiac
+
+
+class Test_QueryInterface(ut.TestCase):
+    def test_custom_interface(self):
+        iuia = uiac.CUIAutomation().QueryInterface(uiac.IUIAutomation)
+        self.assertTrue(bool(iuia))
+        self.assertEqual(iuia.AddRef(), 2)
+        punk = iuia.QueryInterface(IUnknown)
+        self.assertEqual(iuia.AddRef(), 4)
+        self.assertEqual(punk.AddRef(), 5)
+        self.assertEqual(iuia.Release(), 4)
+        del iuia
+        self.assertEqual(punk.Release(), 2)
+        self.assertEqual(punk.Release(), 1)
+
+    def test_dispatch_interface(self):
+        dic = scrrun.Dictionary().QueryInterface(scrrun.IDictionary)
+        self.assertTrue(bool(dic))
+        self.assertEqual(dic.GetTypeInfoCount(), 1)
+        self.assertEqual(
+            dic.GetTypeInfo(0).GetTypeAttr().guid,
+            scrrun.IDictionary._iid_,
+        )
+        self.assertEqual(dic.GetIDsOfNames("Add"), [1])
+
+
+class Test_IPersist_GetClassID(ut.TestCase):
+    def test(self):
+        self.assertEqual(
+            uiac.CUIAutomation().IPersist_GetClassID(),
+            uiac.CUIAutomation._reg_clsid_,
+        )


### PR DESCRIPTION
There are still many mysteries and untested parts in `COMObject`, so we will add unit tests for it going forward.