### PR TITLE
Add `test_comobject`(part 2).

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -47,7 +47,7 @@ from comtypes.hresult import (
 from comtypes.typeinfo import IProvideClassInfo, IProvideClassInfo2
 
 if TYPE_CHECKING:
-    from ctypes import _FuncPointer, _Pointer
+    from ctypes import _CArgObject, _FuncPointer, _Pointer
 
     from comtypes import hints  # type: ignore
     from comtypes._memberspec import _ArgSpecElmType, _ParamFlagType
@@ -706,7 +706,11 @@ class COMObject(object):
         return result
 
     def IUnknown_QueryInterface(
-        self, this: Any, riid: "_Pointer[GUID]", ppvObj: c_void_p, _debug=_debug
+        self,
+        this: Any,
+        riid: "_Pointer[GUID]",
+        ppvObj: Union[c_void_p, "_CArgObject"],
+        _debug=_debug,
     ) -> int:
         # XXX This is probably too slow.
         # riid[0].hashcode() alone takes 33 us!
@@ -733,7 +737,7 @@ class COMObject(object):
         # CopyComPointer(src, dst) calls AddRef!
         result = POINTER(interface)()
         CopyComPointer(ptr, byref(result))
-        return result
+        return result  # type: ignore
 
     ################################################################
     # ISupportErrorInfo::InterfaceSupportsErrorInfo implementation

--- a/comtypes/test/test_comobject.py
+++ b/comtypes/test/test_comobject.py
@@ -1,8 +1,11 @@
+import ctypes
 import unittest as ut
+from ctypes import POINTER, byref, pointer
 
 import comtypes
 import comtypes.client
-from comtypes import IUnknown
+from comtypes import IUnknown, hresult
+from comtypes.automation import IDispatch
 
 comtypes.client.GetModule("UIAutomationCore.dll")
 comtypes.client.GetModule("scrrun.dll")
@@ -32,6 +35,42 @@ class Test_QueryInterface(ut.TestCase):
             scrrun.IDictionary._iid_,
         )
         self.assertEqual(dic.GetIDsOfNames("Add"), [1])
+
+
+class Test_IUnknown_QueryInterface(ut.TestCase):
+    def test_e_pointer(self):
+        hr = scrrun.Dictionary().IUnknown_QueryInterface(
+            None, pointer(scrrun.IDictionary._iid_), ctypes.c_void_p()
+        )
+        self.assertEqual(hr, hresult.E_POINTER)
+
+    def test_e_no_interface(self):
+        hr = scrrun.Dictionary().IUnknown_QueryInterface(
+            None, pointer(uiac.IUIAutomation._iid_), ctypes.c_void_p()
+        )
+        self.assertEqual(hr, hresult.E_NOINTERFACE)
+
+    def test_valid_pointer(self):
+        ptr = ctypes.c_void_p()
+        ctypes.oledll.ole32.CoCreateInstance(
+            byref(scrrun.Dictionary._reg_clsid_),
+            None,
+            comtypes.CLSCTX_SERVER,
+            byref(scrrun.IDictionary._iid_),
+            byref(ptr),
+        )
+        hr = scrrun.Dictionary().IUnknown_QueryInterface(
+            None, pointer(scrrun.IDictionary._iid_), ptr
+        )
+        self.assertEqual(hr, hresult.S_OK)
+
+    def test_valid_interface(self):
+        dic = POINTER(IDispatch)()
+        hr = scrrun.Dictionary().IUnknown_QueryInterface(
+            None, pointer(scrrun.IDictionary._iid_), byref(dic)
+        )
+        self.assertEqual(hr, hresult.S_OK)
+        self.assertEqual(dic.GetTypeInfoCount(), 1)  # type: ignore
 
 
 class Test_IPersist_GetClassID(ut.TestCase):


### PR DESCRIPTION
This is a follow-up to #709.