### PR TITLE
Update server-side documentation.

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -73,6 +73,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r docs/requirements.txt
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Compile IDL
+        run: midl /out docs\source docs\source\mytypelib.idl
       - name: Run doctest
         run: sphinx-build -b doctest -d docs/build/doctrees docs/source docs/build/doctest
         working-directory: ./

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,8 +13,6 @@ for *dispatch based* COM interfaces, it is not possible to access
 The |comtypes| package makes it easy to access and implement both
 custom and dispatch based COM interfaces.
 
-NEW: The beginning of the documentation for implementing COM servers in
-|comtypes| is here: comtypes_server_
 
 .. contents::
 
@@ -785,6 +783,12 @@ XXX mention threading issues, message loops
 Other stuff
 +++++++++++
 
+.. toctree::
+    :maxdepth: 1
+
+    server
+
+
 XXX describe logging, gen_dir, wrap, _manage (?)
 
 Links
@@ -802,6 +806,7 @@ Downloads
 The |comtypes| project is hosted on github_. Releases can be downloaded from
 the github releases_ section.
 
+
 .. |comtypes| replace:: ``comtypes``
 
 .. |ctypes| replace:: ``ctypes``
@@ -817,7 +822,5 @@ the github releases_ section.
 .. _github: https://github.com/enthought/comtypes
 
 .. _releases: https://github.com/enthought/comtypes/releases
-
-.. _comtypes_server: server.html
 
 .. _implementing_COM_methods: server.html#implementing-com-methods

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -24,32 +24,33 @@ Define the COM interface
 Start writing an IDL file.  It is a good idea to define ``dual``
 interfaces, and only use automation compatible data types.
 
-.. sourcecode:: c
+.. sourcecode:: idl
 
-  import "oaidl.idl";
-  import "ocidl.idl";
+    import "oaidl.idl";
+    import "ocidl.idl";
 
-  [
-          uuid(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx),
-          dual,
-          oleautomation
-  ]
-  interface IMyInterface : IDispatch {
-          HRESULT MyMethod([in] INT a, [in] INT b, [out, retval] INT *presult);
-  }
+    [
+            uuid(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx),
+            dual,
+            oleautomation
+    ]
+    interface IMyInterface : IDispatch {
+            HRESULT MyMethod([in] INT a, [in] INT b, [out, retval] INT *presult);
+    }
 
-  [
-  	uuid(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
-  ]
-  library MyTypeLib
-  {
-          importlib("stdole2.tlb");
-  	
-          [uuid(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)]
-  		coclass MyObject {
-  		[default] interface IMyInterface;
-          };
-  };
+    [
+      uuid(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    ]
+    library MyTypeLib
+    {
+            importlib("stdole2.tlb");
+      
+            [uuid(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)]
+        coclass MyObject {
+        [default] interface IMyInterface;
+            };
+    };
+
 
 Please note that you must replace the 'xxxx' placeholders in the
 section above with separate GUIDs that you must generate yourself.

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -139,6 +139,7 @@ with the ``MyObjectImpl`` class:
         from comtypes.server.register import UseCommandLine
         UseCommandLine(MyObjectImpl)
 
+
 You should now run your script with a ``/regserver`` command line
 option, this will write information about your object into the Windows
 registry:
@@ -146,6 +147,7 @@ registry:
 .. sourcecode:: shell
 
     C:\> python myserver.py /regserver
+
 
 If you have the Microsoft ``OLEVIEW`` utility, you can now open the
 "All Objects" item, and look for the "Simple COM server for testing"
@@ -188,6 +190,7 @@ In the IDL file, the method signature is defined like this:
 .. sourcecode:: c
 
     HRESULT MyMethod([in] INT a, [in] INT b, [out, retval] INT *presult);
+
 
 So, this method takes two integers and returns a third one, writing
 the latter into a pointer.

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -236,7 +236,7 @@ native Python objects, if possible.  For [out] or [out, retval]
 parameters ctypes pointer instances are passed, you are required to
 put the result value into the pointer(s).
 
-A low level method implementation must return a numerical HRESULT
+A low level method implementation must return a numerical ``HRESULT``
 value, which specifies a success or failure code for the operation.
 The usual ``S_OK`` success code has a value of zero, but for
 convenience you can also return None instead.
@@ -286,13 +286,13 @@ Both implementation strategies have their own advantages and
 disadvantages, so you should choose between them on a case by case
 basis:
 
-Low-level makes it easy to return special HRESULT values in the case
-that your object requires it.
+Low-level makes it easy to return special ``HRESULT`` values in the
+case that your object requires it.
 
 High-level is usually easier to write, and is compatible with the
 normal calling convention that Python also chooses.  However, it is
-more difficult to specify the HRESULT value to return in case you want
-to communicate error codes to the caller.
+more difficult to specify the ``HRESULT`` value to return in case you
+want to communicate error codes to the caller.
 
 Run the object again and test the method
 ++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -213,10 +213,11 @@ would be welcomed).  |comtypes| uses different calling conventions for
 |comtypes| inspects the method for the name of the second parameter,
 just after the ``self`` parameter:
 
-  **If the second parameter is present and is named ``this`` then the
-  low level calling convention is used.  If the second parameter is
-  not present, or is not named ``this``, then the high level calling
-  convention is used.**
+- If the second parameter is present and is named ``this``, then the
+  low level calling convention is used.
+
+- If the second parameter is not present, or is not named ``this``,
+  then the high level calling convention is used.
 
 
 Low level implementation

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -58,9 +58,9 @@ windows console:
 
 .. sourcecode:: shell
 
-    C:\> python -c "from comtypes import GUID; print GUID.create_new()"
+    C:\> python -c "from comtypes import GUID; print(GUID.create_new())"
     {26F87CEB-603A-4FFE-8865-DB67A9E3A308}
-    C:\> 
+
 
 The IDL file should now be compiled with the Microsoft MIDL compiler to a
 TLB type library file.

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -2,14 +2,8 @@
 COM servers with comtypes
 #########################
 
-|comtypes| is a *pure Python* COM package based on the ctypes_ ffi
-foreign function library.  **ctypes** is included in Python 2.5 and
-later, it is also available for Python 2.4 as separate download.
-
 The |comtypes| package makes it easy to access and implement both
 custom and dispatch based COM interfaces.
-
-This document describes |comtypes| version 0.5.
 
 .. contents::
 

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -313,7 +313,3 @@ More details on COM objects
 To be written...
 
 .. |comtypes| replace:: ``comtypes``
-
-.. _`WMI monikers`: http://www.microsoft.com/technet/scriptcenter/guide/sas_wmi_jgfx.mspx?mfr=true
-
-.. _ctypes: http://starship.python.net/crew/theller/ctypes

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -16,7 +16,7 @@ This document describes |comtypes| version 0.5.
 Implementing a simple COM object
 ********************************
 
-To implement a COM server object in comtypes you need to write a type
+To implement a COM server object in |comtypes| you need to write a type
 library describing the coclass, the interface(s) that the object
 implements, and (optional) the event interface that the object
 supports.  Also you have to write a Python module that defines a class
@@ -123,7 +123,7 @@ The meaning of the attributes:
 
     The optional ``_regcls_`` constant is only used for com objects
     that run in their own process, see the MSDN docs for more info.
-    In comtypes, several REGCLS values are defined in the
+    In |comtypes|, several REGCLS values are defined in the
     ``comtyper.server.localserver`` module.
 
 You do not yet implement any methods on the class, because basic
@@ -158,7 +158,7 @@ object.  If everything works well, you can even create an instance of
 your COM object by double clicking the entry, and you will see that
 the object implements quite some interfaces already.
 
-You can also create an instance of the object with comtypes:
+You can also create an instance of the object with |comtypes|:
 
 .. sourcecode:: pycon
 
@@ -318,7 +318,7 @@ More details on COM objects
 
 To be written...
 
-.. |comtypes| replace:: **comtypes**
+.. |comtypes| replace:: ``comtypes``
 
 .. _`WMI monikers`: http://www.microsoft.com/technet/scriptcenter/guide/sas_wmi_jgfx.mspx?mfr=true
 

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -232,10 +232,10 @@ A low-level method implementation is called with the following arguments:
 
 - any other arguments listed in the IDL method signature.
 
-[in] parameters from the method signature are usually converted to
-native Python objects, if possible.  For [out] or [out, retval]
-parameters ctypes pointer instances are passed, you are required to
-put the result value into the pointer(s).
+``[in]`` parameters from the method signature are usually converted
+to native Python objects, if possible.  For ``[out]`` or
+``[out, retval]`` parameters ctypes pointer instances are passed,
+you are required to put the result value into the pointer(s).
 
 A low level method implementation must return a numerical ``HRESULT``
 value, which specifies a success or failure code for the operation.
@@ -243,7 +243,7 @@ The usual ``S_OK`` success code has a value of zero, but for
 convenience you can also return None instead.
 
 So, a sample low-level implementation for ``MyMethod`` for our object
-would be this, assuming we want to return the sum of the two [in]
+would be this, assuming we want to return the sum of the two ``[in]``
 parameters:
 
 .. sourcecode:: python
@@ -262,13 +262,14 @@ A high-level method implementation is called with the following parameters:
 
 - the usual ``self`` argument
 
-- the [in] parameters from the IDL method signature.
+- the ``[in]`` parameters from the IDL method signature.
 
-If there is a single [out] or [out, retval] parameter, then the method
-must return the result value; if there are more than one [out] or
-[out, retval] parameters, then a tuple containing the correct number
-must be returned.  If there are no [out] or [out, retval] parameters,
-the return value does not matter and is ignored.
+If there is a single ``[out]`` or ``[out, retval]`` parameter, then
+the method must return the result value; if there are more than one
+``[out]`` or ``[out, retval]`` parameters, then a tuple containing
+the correct number must be returned.  If there are no ``[out]`` or
+``[out, retval]`` parameters, the return value does not matter and
+is ignored.
 
 A sample high-level implementation for ``MyMethod`` is this:
 


### PR DESCRIPTION
See also #230.

Using the GHA workflow and Sphinx's doctest setup/teardown mechanisms, I enabled the build of `mytypelib.idl` and the registration of `myserver.py` so that the interactive mode snippets described in `server.rst` now pass doctests.

Given the ongoing discussions in the CPython community, I anticipate that future updates will involve addressing the differences between in-process servers and local servers.

However, this PR focuses on modernizing code snippets and styles.

Happy holidays!