### PR TITLE
Inject `sys.frozen` and `sys.frozendllhandle` as constructor arguments instead of referencing them directly in `RegistryEntries`.

### DIFF
--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -235,6 +235,7 @@ class RegistryEntries(object):
     def __init__(self, cls: Type, *, serverdll: Optional[str] = None) -> None:
         self._cls = cls
         self._serverdll = serverdll
+        self._frozen = getattr(sys, "frozen", None)
 
     def _get_full_classname(self, cls: Type) -> str:
         """Return <modulename>.<classname> for 'cls'."""
@@ -319,7 +320,7 @@ class RegistryEntries(object):
             exe = sys.executable
             if " " in exe:
                 exe = f'"{exe}"'
-            if not hasattr(sys, "frozen"):
+            if self._frozen is None:
                 if not __debug__:
                     exe = f"{exe} -O"
                 script = os.path.abspath(sys.modules[cls.__module__].__file__)  # type: ignore
@@ -331,7 +332,7 @@ class RegistryEntries(object):
 
         # Register InprocServer32 only when run from script or from
         # py2exe dll server, not from py2exe exe server.
-        if inprocsvr_ctx and getattr(sys, "frozen", None) in (None, "dll"):
+        if inprocsvr_ctx and self._frozen in (None, "dll"):
             if self._serverdll is None:
                 raise TypeError("'serverdll' is not specified.")
             yield (HKCR, rf"CLSID\{reg_clsid}\InprocServer32", "", self._serverdll)

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -246,6 +246,7 @@ class RegistryEntries(object):
         self._cls = cls
         self._serverdll = serverdll
         self._frozen = frozen
+        self._frozendllhandle = getattr(sys, "frozendllhandle", None)
 
     def _get_full_classname(self, cls: Type) -> str:
         """Return <modulename>.<classname> for 'cls'."""
@@ -326,7 +327,7 @@ class RegistryEntries(object):
         localsvr_ctx = bool(clsctx & comtypes.CLSCTX_LOCAL_SERVER)
         inprocsvr_ctx = bool(clsctx & comtypes.CLSCTX_INPROC_SERVER)
 
-        if localsvr_ctx and not hasattr(sys, "frozendllhandle"):
+        if localsvr_ctx and self._frozendllhandle is None:
             exe = sys.executable
             if " " in exe:
                 exe = f'"{exe}"'
@@ -348,7 +349,7 @@ class RegistryEntries(object):
             yield (HKCR, rf"CLSID\{reg_clsid}\InprocServer32", "", self._serverdll)
             # only for non-frozen inproc servers the PythonPath/PythonClass is needed.
             if (
-                not hasattr(sys, "frozendllhandle")
+                self._frozendllhandle is None
                 or not comtypes.server.inprocserver._clsid_to_class
             ):
                 yield (

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -232,6 +232,7 @@ def _get_serverdll() -> str:
 class RegistryEntries(object):
     def __init__(self, cls: Type) -> None:
         self._cls = cls
+        self._serverdll = _get_serverdll()
 
     def _get_full_classname(self, cls: Type) -> str:
         """Return <modulename>.<classname> for 'cls'."""
@@ -329,7 +330,7 @@ class RegistryEntries(object):
         # Register InprocServer32 only when run from script or from
         # py2exe dll server, not from py2exe exe server.
         if inprocsvr_ctx and getattr(sys, "frozen", None) in (None, "dll"):
-            yield (HKCR, rf"CLSID\{reg_clsid}\InprocServer32", "", _get_serverdll())
+            yield (HKCR, rf"CLSID\{reg_clsid}\InprocServer32", "", self._serverdll)
             # only for non-frozen inproc servers the PythonPath/PythonClass is needed.
             if (
                 not hasattr(sys, "frozendllhandle")

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -249,7 +249,7 @@ def _get_serverdll(handle: Optional[int]) -> str:
 class RegistryEntries(object):
     def __init__(
         self,
-        cls,
+        cls: Type,
         *,
         frozen: Optional[str] = None,
         frozendllhandle: Optional[int] = None,

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -176,13 +176,13 @@ class Registrar(object):
 
         tlib = getattr(cls, "_reg_typelib_", None)
         if tlib is not None:
-            if hasattr(sys, "frozendllhandle"):
+            if self._frozendllhandle is not None:
                 _debug("LoadTypeLibEx(%s, REGKIND_REGISTER)", self._serverdll)
                 LoadTypeLibEx(self._serverdll, REGKIND_REGISTER)
             else:
                 if executable:
                     path = executable
-                elif hasattr(sys, "frozen"):
+                elif self._frozen is not None:
                     path = sys.executable
                 else:
                     path = cls._typelib_path_

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -99,6 +99,9 @@ class Registrar(object):
     work.
     """
 
+    def __init__(self) -> None:
+        self._serverdll = _get_serverdll()
+
     def nodebug(self, cls: Type) -> None:
         """Delete logging entries from the registry."""
         clsid = cls._reg_clsid_
@@ -165,9 +168,8 @@ class Registrar(object):
         tlib = getattr(cls, "_reg_typelib_", None)
         if tlib is not None:
             if hasattr(sys, "frozendllhandle"):
-                dll = _get_serverdll()
-                _debug("LoadTypeLibEx(%s, REGKIND_REGISTER)", dll)
-                LoadTypeLibEx(dll, REGKIND_REGISTER)
+                _debug("LoadTypeLibEx(%s, REGKIND_REGISTER)", self._serverdll)
+                LoadTypeLibEx(self._serverdll, REGKIND_REGISTER)
             else:
                 if executable:
                     path = executable

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -102,6 +102,7 @@ class Registrar(object):
     def __init__(self) -> None:
         self._serverdll = _get_serverdll()
         self._frozen = getattr(sys, "frozen", None)
+        self._frozendllhandle = getattr(sys, "frozendllhandle", None)
 
     def nodebug(self, cls: Type) -> None:
         """Delete logging entries from the registry."""
@@ -159,7 +160,12 @@ class Registrar(object):
 
     def _register(self, cls: Type, executable: Optional[str] = None) -> None:
         table = sorted(
-            RegistryEntries(cls, serverdll=self._serverdll, frozen=self._frozen)
+            RegistryEntries(
+                cls,
+                serverdll=self._serverdll,
+                frozen=self._frozen,
+                frozendllhandle=self._frozendllhandle,
+            )
         )
         _debug("Registering %s", cls)
         for hkey, subkey, valuename, value in table:
@@ -198,7 +204,10 @@ class Registrar(object):
         table = [
             t[:2]
             for t in RegistryEntries(
-                cls, serverdll=self._serverdll, frozen=self._frozen
+                cls,
+                serverdll=self._serverdll,
+                frozen=self._frozen,
+                frozendllhandle=self._frozendllhandle,
             )
         ]
         # only unique entries
@@ -241,12 +250,17 @@ def _get_serverdll() -> str:
 
 class RegistryEntries(object):
     def __init__(
-        self, cls, *, serverdll: Optional[str] = None, frozen: Optional[str] = None
+        self,
+        cls,
+        *,
+        serverdll: Optional[str] = None,
+        frozen: Optional[str] = None,
+        frozendllhandle: Optional[int] = None,
     ) -> None:
         self._cls = cls
         self._serverdll = serverdll
         self._frozen = frozen
-        self._frozendllhandle = getattr(sys, "frozendllhandle", None)
+        self._frozendllhandle = frozendllhandle
 
     def _get_full_classname(self, cls: Type) -> str:
         """Return <modulename>.<classname> for 'cls'."""

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -230,9 +230,9 @@ def _get_serverdll() -> str:
 
 
 class RegistryEntries(object):
-    def __init__(self, cls: Type) -> None:
+    def __init__(self, cls: Type, *, serverdll: Optional[str] = None) -> None:
         self._cls = cls
-        self._serverdll = _get_serverdll()
+        self._serverdll = serverdll if serverdll else _get_serverdll()
 
     def _get_full_classname(self, cls: Type) -> str:
         """Return <modulename>.<classname> for 'cls'."""

--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -426,9 +426,8 @@ class Test_NonFrozen_RegistryEntries(ut.TestCase):
 class Test_Frozen_RegistryEntries(ut.TestCase):
     @mock.patch.object(register, "sys")
     def test_local_dll(self, _sys):
-        _sys.mock_add_spec(["executable", "frozen"])
+        _sys.mock_add_spec(["executable"])
         _sys.executable = sys.executable
-        _sys.frozen = "dll"
         reg_clsid = GUID.create_new()
         reg_clsctx = comtypes.CLSCTX_LOCAL_SERVER
 
@@ -441,12 +440,11 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
             (HKCR, clsid_sub, "", ""),
             (HKCR, rf"{clsid_sub}\LocalServer32", "", sys.executable),
         ]
-        self.assertEqual(expected, list(RegistryEntries(Cls)))
+        self.assertEqual(expected, list(RegistryEntries(Cls, frozen="dll")))
 
     @mock.patch.object(register, "sys")
     def test_local_frozendllhandle(self, _sys):
-        _sys.mock_add_spec(["frozen", "frozendllhandle"])
-        _sys.frozen = "dll"
+        _sys.mock_add_spec(["frozendllhandle"])
         _sys.frozendllhandle = 1234
         reg_clsid = GUID.create_new()
         reg_clsctx = comtypes.CLSCTX_LOCAL_SERVER
@@ -456,12 +454,11 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
             _reg_clsctx_ = reg_clsctx
 
         expected = [(HKCR, rf"CLSID\{reg_clsid}", "", "")]
-        self.assertEqual(expected, list(RegistryEntries(Cls)))
+        self.assertEqual(expected, list(RegistryEntries(Cls, frozen="dll")))
 
     @mock.patch.object(register, "sys")
     def test_inproc_windows_exe(self, _sys):
-        _sys.mock_add_spec(["frozen"])
-        _sys.frozen = "windows_exe"
+        _sys.mock_add_spec([])
         reg_clsid = GUID.create_new()
         reg_clsctx = comtypes.CLSCTX_INPROC_SERVER
 
@@ -470,12 +467,11 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
             _reg_clsctx_ = reg_clsctx
 
         expected = [(HKCR, rf"CLSID\{reg_clsid}", "", "")]
-        self.assertEqual(expected, list(RegistryEntries(Cls)))
+        self.assertEqual(expected, list(RegistryEntries(Cls, frozen="windows_exe")))
 
     @mock.patch.object(register, "sys")
     def test_inproc_dll_frozendllhandle_clsid_to_class(self, _sys):
-        _sys.mock_add_spec(["frozen", "frozendllhandle"])
-        _sys.frozen = "dll"
+        _sys.mock_add_spec(["frozendllhandle"])
         _sys.frozendllhandle = 1234
         reg_clsid = GUID.create_new()
         reg_clsctx = comtypes.CLSCTX_INPROC_SERVER
@@ -494,12 +490,14 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
 
         with mock.patch.dict(comtypes.server.inprocserver._clsid_to_class):
             comtypes.server.inprocserver._clsid_to_class.update({5678: Cls})
-            self.assertEqual(expected, list(RegistryEntries(Cls, serverdll=serverdll)))
+            self.assertEqual(
+                expected,
+                list(RegistryEntries(Cls, serverdll=serverdll, frozen="dll")),
+            )
 
     @mock.patch.object(register, "sys")
     def test_inproc_dll(self, _sys):
-        _sys.mock_add_spec(["frozen", "modules"])
-        _sys.frozen = "dll"
+        _sys.mock_add_spec(["modules"])
         _sys.modules = sys.modules
         reg_clsid = GUID.create_new()
         reg_clsctx = comtypes.CLSCTX_INPROC_SERVER
@@ -518,12 +516,13 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
             (HKCR, inproc_srv_sub, "PythonClass", full_classname),
             (HKCR, inproc_srv_sub, "PythonPath", os.path.dirname(__file__)),
         ]
-        self.assertEqual(expected, list(RegistryEntries(Cls, serverdll=serverdll)))
+        self.assertEqual(
+            expected, list(RegistryEntries(Cls, serverdll=serverdll, frozen="dll"))
+        )
 
     @mock.patch.object(register, "sys")
     def test_inproc_dll_reg_threading(self, _sys):
-        _sys.mock_add_spec(["frozen", "modules"])
-        _sys.frozen = "dll"
+        _sys.mock_add_spec(["modules"])
         _sys.modules = sys.modules
         reg_clsid = GUID.create_new()
         reg_threading = "Both"
@@ -545,4 +544,6 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
             (HKCR, inproc_srv_sub, "PythonPath", os.path.dirname(__file__)),
             (HKCR, inproc_srv_sub, "ThreadingModel", reg_threading),
         ]
-        self.assertEqual(expected, list(RegistryEntries(Cls, serverdll=serverdll)))
+        self.assertEqual(
+            expected, list(RegistryEntries(Cls, serverdll=serverdll, frozen="dll"))
+        )

--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -444,8 +444,7 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
 
     @mock.patch.object(register, "sys")
     def test_local_frozendllhandle(self, _sys):
-        _sys.mock_add_spec(["frozendllhandle"])
-        _sys.frozendllhandle = 1234
+        _sys.mock_add_spec([])
         reg_clsid = GUID.create_new()
         reg_clsctx = comtypes.CLSCTX_LOCAL_SERVER
 
@@ -454,7 +453,8 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
             _reg_clsctx_ = reg_clsctx
 
         expected = [(HKCR, rf"CLSID\{reg_clsid}", "", "")]
-        self.assertEqual(expected, list(RegistryEntries(Cls, frozen="dll")))
+        entries = RegistryEntries(Cls, frozen="dll", frozendllhandle=1234)
+        self.assertEqual(expected, list(entries))
 
     @mock.patch.object(register, "sys")
     def test_inproc_windows_exe(self, _sys):
@@ -471,8 +471,7 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
 
     @mock.patch.object(register, "sys")
     def test_inproc_dll_frozendllhandle_clsid_to_class(self, _sys):
-        _sys.mock_add_spec(["frozendllhandle"])
-        _sys.frozendllhandle = 1234
+        _sys.mock_add_spec([])
         reg_clsid = GUID.create_new()
         reg_clsctx = comtypes.CLSCTX_INPROC_SERVER
 
@@ -490,10 +489,10 @@ class Test_Frozen_RegistryEntries(ut.TestCase):
 
         with mock.patch.dict(comtypes.server.inprocserver._clsid_to_class):
             comtypes.server.inprocserver._clsid_to_class.update({5678: Cls})
-            self.assertEqual(
-                expected,
-                list(RegistryEntries(Cls, serverdll=serverdll, frozen="dll")),
+            entries = RegistryEntries(
+                Cls, serverdll=serverdll, frozen="dll", frozendllhandle=1234
             )
+            self.assertEqual(expected, list(entries))
 
     @mock.patch.object(register, "sys")
     def test_inproc_dll(self, _sys):


### PR DESCRIPTION
`sys.frozen` and `sys.frozendllhandle` are constants in `sys` that exist only when running under embedding tools. These constants are not present in a standard Python environment.

Using `hasattr` or `getattr` repeatedly to retrieve these constants is redundant.
To address this, they are now accessed only once within the `Registrar` constructor, and their values are injected into `RegistryEntries`.