### PR TITLE
Refactor `server.register`.

### DIFF
--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -221,10 +221,8 @@ class Registrar(object):
         # If force==False, we only remove those entries that we
         # actually would have written.  It seems ATL does the same.
         table = [t[:2] for t in self._generate_reg_entries(cls)]
-        # only unique entries
-        table = list(set(table))
-        table.sort()
-        table.reverse()
+        # reversed and only unique entries
+        table = reversed(sorted(list(set(table))))
         _debug("Unregister %s", cls)
         for hkey, subkey in table:
             _delete_key(hkey, subkey, force=force)

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -243,7 +243,6 @@ class Registrar(object):
 
 def _get_serverdll(handle: int) -> str:
     """Return the pathname of the dll hosting the COM object."""
-    assert isinstance(handle, int)
     return GetModuleFileName(handle, 260)
 
 

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -348,30 +348,30 @@ def _iter_reg_entries(cls: Type, reg_clsid: str) -> Iterator[_Entry]:
         reg_desc = getattr(cls, "_reg_novers_progid_", getattr(cls, "_reg_progid_", ""))
         if reg_desc:
             reg_desc = reg_desc.replace(".", " ")
-    yield (HKCR, f"CLSID\\{reg_clsid}", "", reg_desc)
+    yield (HKCR, rf"CLSID\{reg_clsid}", "", reg_desc)
 
     reg_progid = getattr(cls, "_reg_progid_", None)
     if reg_progid:
         # for ProgIDFromCLSID:
-        yield (HKCR, f"CLSID\\{reg_clsid}\\ProgID", "", reg_progid)  # 1
+        yield (HKCR, rf"CLSID\{reg_clsid}\ProgID", "", reg_progid)  # 1
 
         # for CLSIDFromProgID
         if reg_desc:
             yield (HKCR, reg_progid, "", reg_desc)  # 2
-        yield (HKCR, f"{reg_progid}\\CLSID", "", reg_clsid)  # 3
+        yield (HKCR, rf"{reg_progid}\CLSID", "", reg_clsid)  # 3
 
         reg_novers_progid = getattr(cls, "_reg_novers_progid_", None)
         if reg_novers_progid:
             yield (
                 HKCR,
-                f"CLSID\\{reg_clsid}\\VersionIndependentProgID",  # 1a
+                rf"CLSID\{reg_clsid}\VersionIndependentProgID",  # 1a
                 "",
                 reg_novers_progid,
             )
             if reg_desc:
                 yield (HKCR, reg_novers_progid, "", reg_desc)  # 2a
-            yield (HKCR, f"{reg_novers_progid}\\CurVer", "", reg_progid)  #
-            yield (HKCR, f"{reg_novers_progid}\\CLSID", "", reg_clsid)  # 3a
+            yield (HKCR, rf"{reg_novers_progid}\CurVer", "", reg_progid)  #
+            yield (HKCR, rf"{reg_novers_progid}\CLSID", "", reg_clsid)  # 3a
 
 
 def _iter_interp_local_ctx_entries(cls: Type, reg_clsid: str) -> Iterator[_Entry]:

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -45,6 +45,9 @@ import winreg
 from ctypes import WinDLL, WinError
 from ctypes.wintypes import HKEY, LONG, LPCWSTR
 from typing import Iterable, Iterator, List, Optional, Tuple, Type, Union
+from winreg import HKEY_CLASSES_ROOT as HKCR
+from winreg import HKEY_CURRENT_USER as HKCU
+from winreg import HKEY_LOCAL_MACHINE as HKLM
 
 import comtypes.server.inprocserver  # noqa
 from comtypes import CLSCTX_INPROC_SERVER, CLSCTX_LOCAL_SERVER
@@ -84,9 +87,9 @@ SHDeleteKey.restype = LSTATUS
 
 
 _KEYS = {
-    winreg.HKEY_CLASSES_ROOT: "HKCR",
-    winreg.HKEY_LOCAL_MACHINE: "HKLM",
-    winreg.HKEY_CURRENT_USER: "HKCU",
+    HKCR: "HKCR",
+    HKLM: "HKLM",
+    HKCU: "HKCU",
 }
 
 
@@ -123,11 +126,8 @@ class Registrar(object):
         """Delete logging entries from the registry."""
         clsid = cls._reg_clsid_
         try:
-            _debug(
-                'DeleteKey( %s\\CLSID\\%s\\Logging"'
-                % (_explain(winreg.HKEY_CLASSES_ROOT), clsid)
-            )
-            hkey = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, rf"CLSID\{clsid}")
+            _debug('DeleteKey( %s\\CLSID\\%s\\Logging"' % (_explain(HKCR), clsid))
+            hkey = winreg.OpenKey(HKCR, rf"CLSID\{clsid}")
             winreg.DeleteKey(hkey, "Logging")
         except WindowsError as detail:
             if get_winerror(detail) != 2:
@@ -138,11 +138,8 @@ class Registrar(object):
         # handlers
         # format
         clsid = cls._reg_clsid_
-        _debug(
-            'CreateKey( %s\\CLSID\\%s\\Logging"'
-            % (_explain(winreg.HKEY_CLASSES_ROOT), clsid)
-        )
-        hkey = winreg.CreateKey(winreg.HKEY_CLASSES_ROOT, rf"CLSID\{clsid}\Logging")
+        _debug('CreateKey( %s\\CLSID\\%s\\Logging"' % (_explain(HKCR), clsid))
+        hkey = winreg.CreateKey(HKCR, rf"CLSID\{clsid}\Logging")
         for item in levels:
             name, value = item.split("=")
             v = getattr(logging, value)
@@ -334,9 +331,6 @@ def _get_pythonpath(cls: Type) -> str:
     modname = cls.__module__
     dirname = os.path.dirname(sys.modules[modname].__file__)  # type: ignore
     return os.path.abspath(dirname)
-
-
-HKCR = winreg.HKEY_CLASSES_ROOT
 
 
 def _iter_reg_entries(cls: Type, reg_clsid: str) -> Iterator[_Entry]:

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -107,7 +107,7 @@ class Registrar(object):
     work.
     """
 
-    _frozen: Optional[str]
+    _frozen: Union[None, int, str]
     _frozendllhandle: Optional[int]
 
     def __init__(self) -> None:
@@ -277,7 +277,7 @@ class FrozenRegistryEntries(RegistryEntries):
     def __init__(
         self,
         cls: Type,
-        frozen: str,
+        frozen: Union[str, int],
         frozendllhandle: Optional[int] = None,
     ) -> None:
         self._cls = cls

--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -118,8 +118,8 @@ class Test_Registrar_nodebug(ut.TestCase):
         _winreg.DeleteKey.assert_called_once_with(hkey, "Logging")
 
 
+@mock.patch.object(register, "winreg")
 class Test_Registrar_debug(ut.TestCase):
-    @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_sets_format(self, _winreg):
         _winreg.REG_MULTI_SZ = MULTI_SZ
         _winreg.REG_SZ = SZ
@@ -143,7 +143,6 @@ class Test_Registrar_debug(ut.TestCase):
             ],
         )
 
-    @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_deletes_format(self, _winreg):
         _winreg.REG_MULTI_SZ = MULTI_SZ
         hkey = mock.Mock(spec=winreg.HKEYType)
@@ -162,7 +161,6 @@ class Test_Registrar_debug(ut.TestCase):
         )
         _winreg.DeleteValue.assert_called_once_with(hkey, "format")
 
-    @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_ignores_errors_on_deleting(self, _winreg):
         _winreg.REG_MULTI_SZ = MULTI_SZ
         hkey = mock.Mock(spec=winreg.HKEYType)
@@ -183,7 +181,6 @@ class Test_Registrar_debug(ut.TestCase):
         )
         _winreg.DeleteValue.assert_called_once_with(hkey, "format")
 
-    @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_not_ignores_errors_on_deleting(self, _winreg):
         _winreg.REG_MULTI_SZ = MULTI_SZ
         hkey = mock.Mock(spec=winreg.HKEYType)

--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -24,7 +24,6 @@ SZ = winreg.REG_SZ
 class Test_Registrar_nodebug(ut.TestCase):
     @mock.patch.object(register, "winreg")
     def test_calls_openkey_and_deletekey(self, _winreg):
-        _winreg.HKEY_CLASSES_ROOT = HKCR
         hkey = mock.Mock(spec=winreg.HKEYType)
         _winreg.OpenKey.return_value = hkey
         reg_clsid = GUID.create_new()
@@ -39,7 +38,6 @@ class Test_Registrar_nodebug(ut.TestCase):
 
     @mock.patch.object(register, "winreg")
     def test_ignores_winerror(self, _winreg):
-        _winreg.HKEY_CLASSES_ROOT = HKCR
         ERROR_FILE_NOT_FOUND = 2
         err = OSError(ERROR_FILE_NOT_FOUND, "msg", "filename", ERROR_FILE_NOT_FOUND)
         _winreg.OpenKey.side_effect = err
@@ -55,7 +53,6 @@ class Test_Registrar_nodebug(ut.TestCase):
 
     @mock.patch.object(register, "winreg")
     def test_not_ignores_winerror(self, _winreg):
-        _winreg.HKEY_CLASSES_ROOT = HKCR
         hkey = mock.Mock(spec=winreg.HKEYType)
         _winreg.OpenKey.return_value = hkey
         ERROR_ACCESS_DENIED = 5
@@ -78,7 +75,6 @@ class Test_Registrar_nodebug(ut.TestCase):
 class Test_Registrar_debug(ut.TestCase):
     @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_sets_format(self, _winreg):
-        _winreg.HKEY_CLASSES_ROOT = HKCR
         _winreg.REG_MULTI_SZ = MULTI_SZ
         _winreg.REG_SZ = SZ
         hkey = mock.Mock(spec=winreg.HKEYType)
@@ -103,7 +99,6 @@ class Test_Registrar_debug(ut.TestCase):
 
     @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_deletes_format(self, _winreg):
-        _winreg.HKEY_CLASSES_ROOT = HKCR
         _winreg.REG_MULTI_SZ = MULTI_SZ
         hkey = mock.Mock(spec=winreg.HKEYType)
         _winreg.CreateKey.return_value = hkey
@@ -123,7 +118,6 @@ class Test_Registrar_debug(ut.TestCase):
 
     @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_ignores_errors_on_deleting(self, _winreg):
-        _winreg.HKEY_CLASSES_ROOT = HKCR
         _winreg.REG_MULTI_SZ = MULTI_SZ
         hkey = mock.Mock(spec=winreg.HKEYType)
         _winreg.CreateKey.return_value = hkey
@@ -146,7 +140,6 @@ class Test_Registrar_debug(ut.TestCase):
 
     @mock.patch.object(register, "winreg")
     def test_calls_createkey_and_not_ignores_errors_on_deleting(self, _winreg):
-        _winreg.HKEY_CLASSES_ROOT = HKCR
         _winreg.REG_MULTI_SZ = MULTI_SZ
         hkey = mock.Mock(spec=winreg.HKEYType)
         _winreg.CreateKey.return_value = hkey

--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -71,8 +71,8 @@ class Test_delete_key(ut.TestCase):
         _sh_deletekey.assert_not_called()
 
 
+@mock.patch.object(register, "winreg")
 class Test_Registrar_nodebug(ut.TestCase):
-    @mock.patch.object(register, "winreg")
     def test_calls_openkey_and_deletekey(self, _winreg):
         hkey = mock.Mock(spec=winreg.HKEYType)
         _winreg.OpenKey.return_value = hkey
@@ -86,7 +86,6 @@ class Test_Registrar_nodebug(ut.TestCase):
         _winreg.OpenKey.assert_called_once_with(HKCR, rf"CLSID\{reg_clsid}")
         _winreg.DeleteKey.assert_called_once_with(hkey, "Logging")
 
-    @mock.patch.object(register, "winreg")
     def test_ignores_winerror(self, _winreg):
         err = OSError(ERROR_FILE_NOT_FOUND, "msg", "filename", ERROR_FILE_NOT_FOUND)
         _winreg.OpenKey.side_effect = err
@@ -100,7 +99,6 @@ class Test_Registrar_nodebug(ut.TestCase):
         _winreg.OpenKey.assert_called_once_with(HKCR, rf"CLSID\{reg_clsid}")
         _winreg.DeleteKey.assert_not_called()
 
-    @mock.patch.object(register, "winreg")
     def test_not_ignores_winerror(self, _winreg):
         hkey = mock.Mock(spec=winreg.HKEYType)
         _winreg.OpenKey.return_value = hkey


### PR DESCRIPTION
Through #737 and #738, the parts of the `server.register` codebase that can be organized have become clear.