### PR TITLE
Replace deprecated install command

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -56,7 +56,7 @@ jobs:
       - name: install comtypes
         run: |
           pip install --upgrade setuptools
-          python setup.py install
+          python -m pip install .
           pip uninstall comtypes -y
           python test_pip_install.py
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ environment:
 
 test_script:
    - C:\%py%\Scripts\pip.exe install --upgrade setuptools
-   - C:\%py%\python.exe setup.py install
+   - C:\%py%\python.exe -m pip install .
    - C:\%py%\Scripts\pip.exe uninstall comtypes -y
    - C:\%py%\python.exe test_pip_install.py
    - C:\%py%\python.exe -m unittest discover -v -s ./comtypes/test -t comtypes\test


### PR DESCRIPTION
See: https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#what-commands-should-be-used-instead