### PR TITLE
Refactor typings and import blocks in `client/__init__.py`, `_post_coinit/misc.py` and `test/test_getactiveobj.py`.

### DIFF
--- a/comtypes/_post_coinit/misc.py
+++ b/comtypes/_post_coinit/misc.py
@@ -13,24 +13,14 @@ from ctypes import (
     pointer,
 )
 from ctypes.wintypes import DWORD, LPCWSTR, LPVOID
-
-# fmt: off
-from typing import (  # noqa
-    Any, overload, TYPE_CHECKING, TypeVar,
-    # instead of `builtins`. see PEP585
-    Type,
-    # instead of `collections.abc`. see PEP585
-    Callable,
-    # instead of `A | B` and `None | A`. see PEP604
-    Optional,
-)
-# fmt: on
-if TYPE_CHECKING:
-    from comtypes import hints as hints  # noqa  # type: ignore
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, overload
 
 from comtypes import CLSCTX_LOCAL_SERVER, CLSCTX_REMOTE_SERVER, CLSCTX_SERVER, GUID
 from comtypes._memberspec import COMMETHOD
 from comtypes._post_coinit.unknwn import IUnknown
+
+if TYPE_CHECKING:
+    from comtypes import hints as hints  # noqa  # type: ignore
 
 
 def _is_object(obj):

--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -144,13 +144,13 @@ ctypes.POINTER(automation.IDispatch).__ctypes_from_outparam__ = wrap_outparam  #
 # Object creation
 #
 @overload
-def GetActiveObject(progid: _UnionT[str, CoClass, GUID]) -> Any: ...
+def GetActiveObject(progid: _UnionT[str, Type[CoClass], GUID]) -> Any: ...
 @overload
 def GetActiveObject(
-    progid: _UnionT[str, CoClass, GUID], interface: Type[_T_IUnknown]
+    progid: _UnionT[str, Type[CoClass], GUID], interface: Type[_T_IUnknown]
 ) -> _T_IUnknown: ...
 def GetActiveObject(
-    progid: _UnionT[str, CoClass, GUID],
+    progid: _UnionT[str, Type[CoClass], GUID],
     interface: Optional[Type[IUnknown]] = None,
     dynamic: bool = False,
 ) -> Any:
@@ -189,14 +189,14 @@ if TYPE_CHECKING:
 
     @overload
     def GetClassObject(
-        progid: _UnionT[str, CoClass, GUID],
+        progid: _UnionT[str, Type[CoClass], GUID],
         clsctx: Optional[int] = None,
         pServerInfo: Optional[comtypes.COSERVERINFO] = None,
         interface: None = None,
     ) -> hints.IClassFactory: ...
     @overload
     def GetClassObject(
-        progid: _UnionT[str, CoClass, GUID],
+        progid: _UnionT[str, Type[CoClass], GUID],
         clsctx: Optional[int] = None,
         pServerInfo: Optional[comtypes.COSERVERINFO] = None,
         interface: Type[_T_IUnknown] = hints.IClassFactory,
@@ -204,7 +204,7 @@ if TYPE_CHECKING:
 
 
 def GetClassObject(progid, clsctx=None, pServerInfo=None, interface=None):
-    # type: (_UnionT[str, CoClass, GUID], Optional[int], Optional[comtypes.COSERVERINFO], Optional[Type[IUnknown]]) -> IUnknown
+    # type: (_UnionT[str, Type[CoClass], GUID], Optional[int], Optional[comtypes.COSERVERINFO], Optional[Type[IUnknown]]) -> IUnknown
     """Create and return the class factory for a COM object.
 
     'clsctx' specifies how to create the object, use the CLSCTX_... constants.

--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -12,17 +12,17 @@ import ctypes
 import logging
 import os
 import sys
-from typing import Any, overload, TypeVar, TYPE_CHECKING
-from typing import Optional, Type, Union as _UnionT
+from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar, overload
+from typing import Union as _UnionT
 
 import comtypes
-from comtypes.hresult import *
-from comtypes import automation, CoClass, GUID, IUnknown, typeinfo
 import comtypes.client.dynamic
-from comtypes.client._constants import Constants
-from comtypes.client._events import GetEvents, ShowEvents, PumpEvents
-from comtypes.client._generate import GetModule
+from comtypes import GUID, CoClass, IUnknown, automation, typeinfo
 from comtypes.client._code_cache import _find_gen_dir
+from comtypes.client._constants import Constants
+from comtypes.client._events import GetEvents, PumpEvents, ShowEvents
+from comtypes.client._generate import GetModule
+from comtypes.hresult import *
 
 if TYPE_CHECKING:
     from comtypes import hints  # type: ignore

--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -8,9 +8,9 @@ import comtypes.test
 try:
     # pass Word libUUID
     comtypes.client.GetModule(("{00020905-0000-0000-C000-000000000046}",))
-    IMPORT_FAILED = False
+    IMPORT_WORD_FAILED = False
 except (ImportError, OSError):
-    IMPORT_FAILED = True
+    IMPORT_WORD_FAILED = True
 
 
 ################################################################
@@ -24,8 +24,8 @@ except (ImportError, OSError):
 ################################################################
 
 
-@unittest.skipIf(IMPORT_FAILED, "This depends on Word.")
-class Test(unittest.TestCase):
+@unittest.skipIf(IMPORT_WORD_FAILED, "This depends on Word.")
+class Test_Word(unittest.TestCase):
     def setUp(self):
         try:
             comtypes.client.GetActiveObject("Word.Application")


### PR DESCRIPTION
During the investigation of #679, I noticed inappropriate type annotations, unorganized import blocks, and test names or constant names that should be more descriptive. I have made corrections accordingly.