### PR TITLE
Add `ActiveObjTest` to `test_comserver`.

### DIFF
--- a/comtypes/test/TestComServer.py
+++ b/comtypes/test/TestComServer.py
@@ -151,7 +151,4 @@ if __name__ == "__main__":
         import traceback
 
         traceback.print_exc()
-        if sys.version_info >= (3, 0):
-            input()
-        else:
-            raw_input()
+        input()

--- a/comtypes/test/TestComServer.py
+++ b/comtypes/test/TestComServer.py
@@ -8,15 +8,14 @@ logging.basicConfig()
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), r"..\..")))
 
-import ctypes
-
 import comtypes
 import comtypes.client
+import comtypes.connectionpoints
 import comtypes.errorinfo
 import comtypes.server
 import comtypes.server.connectionpoints
 import comtypes.typeinfo
-from comtypes.hresult import *
+from comtypes.hresult import S_OK
 
 ################################################################
 

--- a/comtypes/test/TestComServer.py
+++ b/comtypes/test/TestComServer.py
@@ -1,5 +1,6 @@
-import sys, os
 import logging
+import os
+import sys
 
 logging.basicConfig()
 ##logging.basicConfig(level=logging.DEBUG)
@@ -8,13 +9,14 @@ logging.basicConfig()
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), r"..\..")))
 
 import ctypes
+
 import comtypes
-from comtypes.hresult import *
 import comtypes.client
 import comtypes.errorinfo
 import comtypes.server
 import comtypes.server.connectionpoints
 import comtypes.typeinfo
+from comtypes.hresult import *
 
 ################################################################
 

--- a/comtypes/test/TestComServer.py
+++ b/comtypes/test/TestComServer.py
@@ -30,6 +30,7 @@ if not hasattr(sys, "frozen"):
 
 # Import the wrapper
 from comtypes.gen import TestComServerLib
+from comtypes.gen.TestComServerLib import ITestComServer  # noqa
 
 ################################################################
 

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -179,11 +179,11 @@ class ActiveObjTest(unittest.TestCase):
             interface=comtypes.test.TestComServer.ITestComServer,
         )
 
-    def test_activeobj_registration(self):
+    def _doit(self, weak: bool):
         comobj = comtypes.test.TestComServer.TestComServer()
         with self.assertRaises(OSError):
             self.get_active_object()
-        handle = comtypes.server.RegisterActiveObject(comobj)
+        handle = comtypes.server.RegisterActiveObject(comobj, weak=weak)
         activeobj = self.get_active_object()
         self.assertEqual(activeobj.MixedInOut(2, 4), (3, 5))
         self.assertEqual(activeobj.AddRef(), 3)
@@ -193,6 +193,12 @@ class ActiveObjTest(unittest.TestCase):
         comtypes.server.RevokeActiveObject(handle)
         with self.assertRaises(OSError):
             self.get_active_object()
+
+    def test_activeobj_weak_registration(self):
+        self._doit(weak=True)
+
+    def test_activeobj_strong_registration(self):
+        self._doit(weak=False)
 
 
 class VariantTest(unittest.TestCase):


### PR DESCRIPTION
I’ve written tests for the functions added without tests in commit https://github.com/enthought/comtypes/commit/ea3c333c01674b28557513cd3e47ebe3e3f1261c over a decade ago.  

These tests will be crucial in verifying whether changes like those in #769 are appropriate.