### PR TITLE
Delete preview.bat

### DIFF
--- a/preview.bat
+++ b/preview.bat
@@ -1,7 +1,0 @@
-@echo off
-REM
-REM Convert setup.py's long description to HTML and show it.
-REM
-py25 setup.py --long-description | py25 web\rst2html.py --link-stylesheet --stylesheet=http://www.python.org/styles/styles.css > ~pypi.html
-start ~pypi.html
-del ~pypi.html


### PR DESCRIPTION
comtypes requires Python 3.8 or later.
This file uses Python 2.5, and the last release that supported it was version 0.6.4, released on January 24, 2014. Therefore, it has been more than 10 years since this file was usable, so it should be safe to delete.