### PR TITLE
Remove workarounds for Windows CE in `find_memleak`.

### DIFF
--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -1,5 +1,4 @@
 import gc
-import unittest
 from ctypes import *
 from ctypes.wintypes import *
 

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -1,6 +1,6 @@
 import gc
 from ctypes import POINTER, Structure, WinDLL, WinError, byref, c_size_t, sizeof
-from ctypes.wintypes import *
+from ctypes.wintypes import BOOL, DWORD, HANDLE
 
 ################################################################
 

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -33,50 +33,40 @@ _GetProcessMemoryInfo = _psapi.GetProcessMemoryInfo
 _GetProcessMemoryInfo.argtypes = [HANDLE, POINTER(PROCESS_MEMORY_COUNTERS), DWORD]
 _GetProcessMemoryInfo.restype = BOOL
 
-try:
-    _GetProcessMemoryInfo.argtypes = (
-        HANDLE,
-        POINTER(PROCESS_MEMORY_COUNTERS),
-        DWORD,
-    )
-except WindowsError:
-    # cannot search for memory leaks on Windows CE
-    def find_memleak(func, loops=None):
-        return 0
 
-else:
+def wss():
+    # Return the working set size (memory used by process)
+    pmi = PROCESS_MEMORY_COUNTERS()
+    if not _GetProcessMemoryInfo(-1, byref(pmi), sizeof(pmi)):
+        raise WinError()
+    return pmi.WorkingSetSize
 
-    def wss():
-        # Return the working set size (memory used by process)
-        pmi = PROCESS_MEMORY_COUNTERS()
-        if not _GetProcessMemoryInfo(-1, byref(pmi), sizeof(pmi)):
-            raise WinError()
-        return pmi.WorkingSetSize
 
-    LOOPS = 10, 1000
+LOOPS = 10, 1000
 
-    def find_memleak(func, loops=LOOPS):
-        # call 'func' several times, so that memory consumption
-        # stabilizes:
-        for j in range(loops[0]):
-            for k in range(loops[1]):
-                func()
-        gc.collect()
-        gc.collect()
-        gc.collect()
-        bytes = wss()
-        # call 'func' several times, recording the difference in
-        # memory consumption before and after the call.  Repeat this a
-        # few times, and return a list containing the memory
-        # consumption differences.
-        for j in range(loops[0]):
-            for k in range(loops[1]):
-                func()
-        gc.collect()
-        gc.collect()
-        gc.collect()
-        # return the increased in process size
-        result = wss() - bytes
-        # Sometimes the process size did decrease, we do not report leaks
-        # in this case:
-        return max(result, 0)
+
+def find_memleak(func, loops=LOOPS):
+    # call 'func' several times, so that memory consumption
+    # stabilizes:
+    for j in range(loops[0]):
+        for k in range(loops[1]):
+            func()
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    bytes = wss()
+    # call 'func' several times, recording the difference in
+    # memory consumption before and after the call.  Repeat this a
+    # few times, and return a list containing the memory
+    # consumption differences.
+    for j in range(loops[0]):
+        for k in range(loops[1]):
+            func()
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    # return the increased in process size
+    result = wss() - bytes
+    # Sometimes the process size did decrease, we do not report leaks
+    # in this case:
+    return max(result, 0)

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -1,4 +1,5 @@
-import unittest, gc
+import gc
+import unittest
 from ctypes import *
 from ctypes.wintypes import *
 

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -1,5 +1,5 @@
 import gc
-from ctypes import *
+from ctypes import POINTER, Structure, WinDLL, WinError, byref, c_size_t, sizeof
 from ctypes.wintypes import *
 
 ################################################################


### PR DESCRIPTION
As discussed in #211 and #554, this project no longer supports Windows CE.

I removed workarounds for CE in `find_memleak` and modernized the import block.