### PR TITLE
Small fixes for importing `ctypes` symbols.

### DIFF
--- a/comtypes/_post_coinit/misc.py
+++ b/comtypes/_post_coinit/misc.py
@@ -3,7 +3,6 @@ from ctypes import (
     POINTER,
     OleDLL,
     Structure,
-    _Pointer,
     byref,
     c_ulong,
     c_ushort,
@@ -20,6 +19,8 @@ from comtypes._memberspec import COMMETHOD
 from comtypes._post_coinit.unknwn import IUnknown
 
 if TYPE_CHECKING:
+    from ctypes import _Pointer
+
     from comtypes import hints as hints  # noqa  # type: ignore
 
 

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -2,10 +2,13 @@ import ctypes
 import logging
 import sys
 import winreg
-from typing import Any, Literal, Optional, Type
+from typing import TYPE_CHECKING, Any, Literal, Optional, Type
 
 from comtypes import GUID, COMObject, IUnknown, hresult
 from comtypes.server import IClassFactory
+
+if TYPE_CHECKING:
+    from ctypes import _Pointer
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug
@@ -24,8 +27,8 @@ class ClassFactory(COMObject):
     def IClassFactory_CreateInstance(
         self,
         this: Any,
-        punkOuter: Optional[Type["ctypes._Pointer[IUnknown]"]],
-        riid: "ctypes._Pointer[GUID]",
+        punkOuter: Optional[Type["_Pointer[IUnknown]"]],
+        riid: "_Pointer[GUID]",
         ppv: ctypes.c_void_p,
     ) -> int:
         _debug("ClassFactory.CreateInstance(%s)", riid[0])

--- a/comtypes/stream.py
+++ b/comtypes/stream.py
@@ -1,7 +1,10 @@
-from ctypes import HRESULT, POINTER, Array, c_ubyte, c_ulong, pointer
+from ctypes import HRESULT, POINTER, c_ubyte, c_ulong, pointer
 from typing import TYPE_CHECKING, Tuple
 
 from comtypes import COMMETHOD, GUID, IUnknown
+
+if TYPE_CHECKING:
+    from ctypes import Array as _CArrayType
 
 
 class ISequentialStream(IUnknown):
@@ -38,7 +41,7 @@ class ISequentialStream(IUnknown):
         ),
     ]
 
-    def RemoteRead(self, cb: int) -> Tuple["Array[c_ubyte]", int]:
+    def RemoteRead(self, cb: int) -> Tuple["_CArrayType[c_ubyte]", int]:
         """Reads a specified number of bytes from the stream object into memory
         starting at the current seek pointer.
         """
@@ -51,7 +54,7 @@ class ISequentialStream(IUnknown):
 
     if TYPE_CHECKING:
 
-        def RemoteWrite(self, pv: "Array[c_ubyte]", cb: int) -> int:
+        def RemoteWrite(self, pv: "_CArrayType[c_ubyte]", cb: int) -> int:
             """Writes a specified number of bytes into the stream object starting at
             the current seek pointer.
             """

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -11,7 +11,6 @@ from ctypes import (
     POINTER,
     OleDLL,
     WinDLL,
-    _Pointer,
     byref,
     c_int,
     c_void_p,
@@ -57,6 +56,8 @@ from comtypes.automation import (
 )
 
 if TYPE_CHECKING:
+    from ctypes import _Pointer
+
     from comtypes import hints  # type: ignore
 
 

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -15,6 +15,7 @@ from ctypes import (
     c_int,
     c_void_p,
     c_wchar_p,
+    create_unicode_buffer,
 )
 from ctypes.wintypes import (
     DWORD,
@@ -279,8 +280,6 @@ class ITypeLib(IUnknown):
         Returns the name with capitalization found in the type
         library, or None.
         """
-        from ctypes import create_unicode_buffer
-
         namebuf = create_unicode_buffer(name)
         found = BOOL()
         self.__com_IsName(namebuf, lHashVal, byref(found))  # type: ignore

--- a/comtypes/typeinfo.py
+++ b/comtypes/typeinfo.py
@@ -768,7 +768,7 @@ def GetModuleFileName(handle: Optional[int], maxsize: int) -> str:
 
     https://learn.microsoft.com/ja-jp/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw
     """
-    buf = ctypes.create_unicode_buffer(maxsize)
+    buf = create_unicode_buffer(maxsize)
     length = _GetModuleFileNameW(handle, buf, maxsize)
     return buf.value[:length]
 


### PR DESCRIPTION
I’ll fix minor inconsistencies in import styles in the production codebase.