### PR TITLE
Add `extend-select = ["I"]` to `[tool.ruff.lint]`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,11 @@ If that happens, you should run `python -m comtypes.clear_cache` to clear those 
 The command will delete the entire `.../comtypes/gen` directory.  
 Importing `comtypes.client` will restore the directory and `__init__.py` file.
 
+This project uses [Ruff](https://github.com/astral-sh/ruff/) as its linter and formatter.  
+The CI pipeline will detect any files in pull requests that do not conform to the rules specified in `pyproject.toml`.  
+To ensure a smooth contribution process, we recommend [installing Ruff](https://pypi.org/project/ruff/) and running `ruff check --fix comtypes/.` and `ruff format comtypes/.` before opening a PR or pushing your changes.  
+If any style issues are found, maintainers may ask you to make modifications.
+
 ### Pull requests
 When you have resolved your issue, open a pull request in the `comtypes` repository.  
 Please include the issue number on the PR comment.  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Create a new git branch in your local repository, and start coding!
 Tests can be run with `python -m unittest discover -v -s ./comtypes/test -t comtypes\test` command.
 
 When `comtypes.client.GetModule` is called, it parses the COM library, generates `.py` files under `.../comtypes/gen/...`, imports and returns `Python` modules.  
-Those `.py` files act like ”caches”.
+Those `.py` files act like "caches".
 
 If there are some problems with the developing code base, partial or non-executable modules might be created in `.../comtypes/gen/...`.  
 Importing them will cause some error.  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff.lint]
+extend-select = ["I"]
 ignore = ["E402"]
 
 [tool.ruff.lint.per-file-ignores]
@@ -26,6 +27,10 @@ ignore = ["E402"]
 "comtypes/tools/tlbparser.py" = ["F401"]
 "comtypes/tools/typedesc.py" = ["F403", "F405"]
 "comtypes/tools/typedesc_base.py" = ["F401"]
+# gen directory
+"comtypes/gen/*" = ["E", "F", "I"]
+# stub
+"comtypes/hints.pyi" = ["I"]
 # tests
 "comtypes/test/TestDispServer.py" = ["E401"]
 "comtypes/test/find_memleak.py" = ["E401", "F401", "F403", "F405"]


### PR DESCRIPTION
At this point, my formatting of the import blocks is complete.