### PR TITLE
Add type annotations to the signatures and return values of functions and methods in `client/_events.py`.

### DIFF
--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -21,7 +21,7 @@ import comtypes.typeinfo
 from comtypes import COMObject, IUnknown
 from comtypes._comobject import _MethodFinder
 from comtypes.client._generate import GetModule
-from comtypes.connectionpoints import IConnectionPointContainer
+from comtypes.connectionpoints import IConnectionPoint, IConnectionPointContainer
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,10 @@ _CloseHandle.restype = BOOL
 
 
 class _AdviseConnection(object):
+    cp: Optional[IConnectionPoint]
+    cookie: Optional[int]
+    receiver: Optional[COMObject]
+
     def __init__(
         self, source: IUnknown, interface: Type[IUnknown], receiver: COMObject
     ) -> None:

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -69,6 +69,7 @@ class _AdviseConnection(object):
     def __init__(
         self, source: IUnknown, interface: Type[IUnknown], receiver: COMObject
     ) -> None:
+        # Pre-initializing attributes to avoid AttributeError after failed connection.
         self.cp = None
         self.cookie = None
         self.receiver = None

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -17,11 +17,11 @@ from typing import Any, Callable, Optional, Type
 
 import comtypes
 import comtypes.automation
-import comtypes.connectionpoints
 import comtypes.typeinfo
 from comtypes import COMObject, IUnknown
 from comtypes._comobject import _MethodFinder
 from comtypes.client._generate import GetModule
+from comtypes.connectionpoints import IConnectionPointContainer
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class _AdviseConnection(object):
     def _connect(
         self, source: IUnknown, interface: Type[IUnknown], receiver: COMObject
     ) -> None:
-        cpc = source.QueryInterface(comtypes.connectionpoints.IConnectionPointContainer)
+        cpc = source.QueryInterface(IConnectionPointContainer)
         self.cp = cpc.FindConnectionPoint(ctypes.byref(interface._iid_))
         logger.debug("Start advise %s", interface)
         self.cookie = self.cp.Advise(receiver)
@@ -140,7 +140,7 @@ def find_single_connection_interface(source):
     # Enumerate the connection interfaces.  If we find a single one,
     # return it, if there are more, we give up since we cannot
     # determine which one to use.
-    cpc = source.QueryInterface(comtypes.connectionpoints.IConnectionPointContainer)
+    cpc = source.QueryInterface(IConnectionPointContainer)
     enum = cpc.EnumConnectionPoints()
     iid = enum.next().GetConnectionInterface()
     try:

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -18,6 +18,7 @@ import comtypes
 import comtypes.automation
 import comtypes.connectionpoints
 import comtypes.typeinfo
+from comtypes import COMObject
 from comtypes._comobject import _MethodFinder
 from comtypes.client._generate import GetModule
 
@@ -215,7 +216,7 @@ class _SinkMethodFinder(_MethodFinder):
 
 
 def CreateEventReceiver(interface, handler):
-    class Sink(comtypes.COMObject):
+    class Sink(COMObject):
         _com_interfaces_ = [interface]
 
         def _get_method_finder_(self, itf):


### PR DESCRIPTION
`find_single_connection_interface` has not been typed yet. That function might be dead code.