### PR TITLE
Introduce the `_CDataType` alias.

### DIFF
--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -1,5 +1,6 @@
 import ctypes
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -16,12 +17,9 @@ from typing import Union as _UnionT
 import comtypes
 from comtypes import _CData
 
-_PosParamFlagType = Tuple[int, Optional[str]]
-_OptParamFlagType = Tuple[int, Optional[str], Any]
-_ParamFlagType = _UnionT[_PosParamFlagType, _OptParamFlagType]
-_PosArgSpecElmType = Tuple[List[str], Type[_CData], str]
-_OptArgSpecElmType = Tuple[List[str], Type[_CData], str, Any]
-_ArgSpecElmType = _UnionT[_PosArgSpecElmType, _OptArgSpecElmType]
+if TYPE_CHECKING:
+    from comtypes import hints  # type: ignore
+
 
 DISPATCH_METHOD = 1
 DISPATCH_PROPERTYGET = 2
@@ -64,8 +62,8 @@ def _unpack_argspec(
 
 
 def _resolve_argspec(
-    items: Tuple[_ArgSpecElmType, ...],
-) -> Tuple[Tuple[_ParamFlagType, ...], Tuple[Type[_CData], ...]]:
+    items: Tuple["hints.ArgSpecElmType", ...],
+) -> Tuple[Tuple["hints.ParamFlagType", ...], Tuple[Type[_CData], ...]]:
     """Unpacks and converts from argspec to paramflags and argtypes.
 
     - paramflags is a sequence of `(pflags: int, argname: str, | None[, defval: Any])`.
@@ -102,7 +100,7 @@ class _ComMemberSpec(NamedTuple):
     restype: Optional[Type[_CData]]
     name: str
     argtypes: Tuple[Type[_CData], ...]
-    paramflags: Optional[Tuple[_ParamFlagType, ...]]
+    paramflags: Optional[Tuple["hints.ParamFlagType", ...]]
     idlflags: Tuple[_UnionT[str, int], ...]
     doc: Optional[str]
 
@@ -117,7 +115,7 @@ class _DispMemberSpec(NamedTuple):
     name: str
     idlflags: Tuple[_UnionT[str, int], ...]
     restype: Optional[Type[_CData]]
-    argspec: Tuple[_ArgSpecElmType, ...]
+    argspec: Tuple["hints.ArgSpecElmType", ...]
 
     @property
     def memid(self) -> int:
@@ -218,7 +216,7 @@ _DocType = Optional[str]
 def _fix_inout_args(
     func: Callable[..., Any],
     argtypes: Tuple[Type[_CData], ...],
-    paramflags: Tuple[_ParamFlagType, ...],
+    paramflags: Tuple["hints.ParamFlagType", ...],
 ) -> Callable[..., Any]:
     """This function provides a workaround for a bug in `ctypes`.
 

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -15,9 +15,10 @@ from typing import (
 from typing import Union as _UnionT
 
 import comtypes
-from comtypes import _CData
 
 if TYPE_CHECKING:
+    from ctypes import _CArgObject, _CDataType
+
     from comtypes import hints  # type: ignore
 
 
@@ -54,20 +55,20 @@ _NOTHING = object()
 
 def _unpack_argspec(
     idl: List[str],
-    typ: Type[_CData],
+    typ: Type["_CDataType"],
     name: Optional[str] = None,
     defval: Any = _NOTHING,
-) -> Tuple[List[str], Type[_CData], Optional[str], Any]:
+) -> Tuple[List[str], Type["_CDataType"], Optional[str], Any]:
     return idl, typ, name, defval
 
 
 def _resolve_argspec(
     items: Tuple["hints.ArgSpecElmType", ...],
-) -> Tuple[Tuple["hints.ParamFlagType", ...], Tuple[Type[_CData], ...]]:
+) -> Tuple[Tuple["hints.ParamFlagType", ...], Tuple[Type["_CDataType"], ...]]:
     """Unpacks and converts from argspec to paramflags and argtypes.
 
     - paramflags is a sequence of `(pflags: int, argname: str, | None[, defval: Any])`.
-    - argtypes is a sequence of `type[_CData]`.
+    - argtypes is a sequence of `type[_CDataType]`.
     """
     from comtypes.automation import VARIANT
 
@@ -97,9 +98,9 @@ def _resolve_argspec(
 class _ComMemberSpec(NamedTuple):
     """Specifier for a slot of COM method or property."""
 
-    restype: Optional[Type[_CData]]
+    restype: Optional[Type["_CDataType"]]
     name: str
-    argtypes: Tuple[Type[_CData], ...]
+    argtypes: Tuple[Type["_CDataType"], ...]
     paramflags: Optional[Tuple["hints.ParamFlagType", ...]]
     idlflags: Tuple[_UnionT[str, int], ...]
     doc: Optional[str]
@@ -114,7 +115,7 @@ class _DispMemberSpec(NamedTuple):
     what: Literal["DISPMETHOD", "DISPPROPERTY"]
     name: str
     idlflags: Tuple[_UnionT[str, int], ...]
-    restype: Optional[Type[_CData]]
+    restype: Optional[Type["_CDataType"]]
     argspec: Tuple["hints.ArgSpecElmType", ...]
 
     @property
@@ -215,7 +216,7 @@ _DocType = Optional[str]
 
 def _fix_inout_args(
     func: Callable[..., Any],
-    argtypes: Tuple[Type[_CData], ...],
+    argtypes: Tuple[Type["_CDataType"], ...],
     paramflags: Tuple["hints.ParamFlagType", ...],
 ) -> Callable[..., Any]:
     """This function provides a workaround for a bug in `ctypes`.
@@ -234,7 +235,7 @@ def _fix_inout_args(
     def call_with_inout(self, *args, **kw):
         args = list(args)
         # Indexed by order in the output
-        outargs: Dict[int, _UnionT[_CData, "ctypes._CArgObject"]] = {}
+        outargs: Dict[int, _UnionT["_CDataType", "_CArgObject"]] = {}
         outnum = 0
         param_index = 0
         # Go through all expected arguments and match them to the provided arguments.
@@ -260,7 +261,7 @@ def _fix_inout_args(
                 name = info[1]
                 # [in, out] parameters are passed as pointers,
                 # this is the pointed-to type:
-                atyp: Type[_CData] = getattr(argtypes[i], "_type_")
+                atyp: Type["_CDataType"] = getattr(argtypes[i], "_type_")
 
                 # Get the actual parameter, either as positional or
                 # keyword arg.

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -16,12 +16,12 @@ from typing import Union as _UnionT
 import comtypes
 from comtypes import _CData
 
-_PositionalParamFlagType = Tuple[int, Optional[str]]
-_OptionalParamFlagType = Tuple[int, Optional[str], Any]
-_ParamFlagType = _UnionT[_PositionalParamFlagType, _OptionalParamFlagType]
-_PositionalArgSpecElmType = Tuple[List[str], Type[_CData], str]
-_OptionalArgSpecElmType = Tuple[List[str], Type[_CData], str, Any]
-_ArgSpecElmType = _UnionT[_PositionalArgSpecElmType, _OptionalArgSpecElmType]
+_PosParamFlagType = Tuple[int, Optional[str]]
+_OptParamFlagType = Tuple[int, Optional[str], Any]
+_ParamFlagType = _UnionT[_PosParamFlagType, _OptParamFlagType]
+_PosArgSpecElmType = Tuple[List[str], Type[_CData], str]
+_OptArgSpecElmType = Tuple[List[str], Type[_CData], str, Any]
+_ArgSpecElmType = _UnionT[_PosArgSpecElmType, _OptArgSpecElmType]
 
 DISPATCH_METHOD = 1
 DISPATCH_PROPERTYGET = 2

--- a/comtypes/_vtbl.py
+++ b/comtypes/_vtbl.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from ctypes import _FuncPointer
 
     from comtypes import hints  # type: ignore
-    from comtypes._memberspec import _ArgSpecElmType, _DispMemberSpec, _ParamFlagType
+    from comtypes._memberspec import _DispMemberSpec
 
 logger = logging.getLogger(__name__)
 _debug = logger.debug
@@ -81,7 +81,7 @@ def _do_implement(interface_name: str, method_name: str) -> Callable[..., int]:
 def catch_errors(
     obj: "hints.COMObject",
     mth: Callable[..., Any],
-    paramflags: Optional[Tuple["_ParamFlagType", ...]],
+    paramflags: Optional[Tuple["hints.ParamFlagType", ...]],
     interface: Type[IUnknown],
     mthname: str,
 ) -> Callable[..., Any]:
@@ -130,7 +130,7 @@ def catch_errors(
 def hack(
     inst: "hints.COMObject",
     mth: Callable[..., Any],
-    paramflags: Optional[Tuple["_ParamFlagType", ...]],
+    paramflags: Optional[Tuple["hints.ParamFlagType", ...]],
     interface: Type[IUnknown],
     mthname: str,
 ) -> Callable[..., Any]:
@@ -238,7 +238,7 @@ class _MethodFinder(object):
         self,
         interface: Type[IUnknown],
         mthname: str,
-        paramflags: Optional[Tuple["_ParamFlagType", ...]],
+        paramflags: Optional[Tuple["hints.ParamFlagType", ...]],
         idlflags: Tuple[_UnionT[str, int], ...],
     ) -> Callable[..., Any]:
         mth = self.find_impl(interface, mthname, paramflags, idlflags)
@@ -260,7 +260,7 @@ class _MethodFinder(object):
         self,
         interface: Type[IUnknown],
         mthname: str,
-        paramflags: Optional[Tuple["_ParamFlagType", ...]],
+        paramflags: Optional[Tuple["hints.ParamFlagType", ...]],
         idlflags: Tuple[_UnionT[str, int], ...],
     ) -> Optional[Callable[..., Any]]:
         fq_name = f"{interface.__name__}_{mthname}"
@@ -429,7 +429,7 @@ def _make_dispentry(
     interface: Type[IUnknown],
     mthname: str,
     idlflags: Tuple[_UnionT[str, int], ...],
-    argspec: Tuple["_ArgSpecElmType", ...],
+    argspec: Tuple["hints.ArgSpecElmType", ...],
     invkind: int,
 ) -> Iterator[Tuple[Tuple[int, int], Callable[..., Any]]]:
     # We build a _dispmap_ entry now that maps invkind and dispid to

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Type
 
 import comtypes
 import comtypes.patcher
-from comtypes import BSTR, COMMETHOD, GUID, IID, STDMETHOD, IUnknown, _CData, _safearray
+from comtypes import BSTR, COMMETHOD, GUID, IID, STDMETHOD, IUnknown, _safearray
 from comtypes import hresult as hresult
 from comtypes._memberspec import DISPATCH_METHOD as DISPATCH_METHOD
 from comtypes._memberspec import DISPATCH_PROPERTYGET as DISPATCH_PROPERTYGET
@@ -20,7 +20,7 @@ from comtypes._memberspec import DISPATCH_PROPERTYPUTREF as DISPATCH_PROPERTYPUT
 from comtypes.safearray import _midlSAFEARRAY
 
 if TYPE_CHECKING:
-    from ctypes import _CArgObject
+    from ctypes import _CArgObject, _CDataType
 
     from comtypes import hints  # type: ignore
     from comtypes._memberspec import _DispMemberSpec
@@ -948,7 +948,7 @@ _arraycode_to_vartype = {
     "B": VT_UI1,
 }
 
-_ctype_to_vartype: Dict[Type[_CData], int] = {
+_ctype_to_vartype: Dict[Type["_CDataType"], int] = {
     c_byte: VT_I1,
     c_ubyte: VT_UI1,
     c_short: VT_I2,
@@ -985,7 +985,7 @@ _ctype_to_vartype: Dict[Type[_CData], int] = {
     # POINTER(IDispatch): VT_DISPATCH,
 }
 
-_vartype_to_ctype: Dict[int, Type[_CData]] = {}
+_vartype_to_ctype: Dict[int, Type["_CDataType"]] = {}
 for c, v in _ctype_to_vartype.items():
     _vartype_to_ctype[v] = c
 _vartype_to_ctype[VT_INT] = _vartype_to_ctype[VT_I4]

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -3,7 +3,7 @@
 # - utilities for type hints.
 import ctypes
 import sys
-from _ctypes import _CData
+from ctypes import _CData, _CDataType
 from typing import Any as Any, ClassVar, Generic, NoReturn, Protocol, TypeVar, overload
 from typing import Optional, Union as _UnionT
 from typing import List, Tuple as Tuple, Type
@@ -45,7 +45,7 @@ arguments and with `HRESULT` as its return type in its COM method definition.
 LP_LP_Vtbl: TypeAlias = ctypes._Pointer[ctypes._Pointer[ctypes.Structure]]
 """A pointer to a pointer to a virtual function table."""
 
-_CT = TypeVar("_CT", bound=ctypes._CData)
+_CT = TypeVar("_CT", bound=_CData)
 _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
 _T_Struct = TypeVar("_T_Struct", bound=ctypes.Structure)
 
@@ -293,6 +293,6 @@ def to_dunder_setitem(item: Any) -> Callable[..., NoReturn]: ...
 _PosParamFlagType: TypeAlias = Tuple[int, Optional[str]]
 _OptParamFlagType: TypeAlias = Tuple[int, Optional[str], Any]
 ParamFlagType: TypeAlias = _UnionT[_PosParamFlagType, _OptParamFlagType]
-_PosArgSpecElmType: TypeAlias = Tuple[List[str], Type[_CData], str]
-_OptArgSpecElmType: TypeAlias = Tuple[List[str], Type[_CData], str, Any]
+_PosArgSpecElmType: TypeAlias = Tuple[List[str], Type[_CDataType], str]
+_OptArgSpecElmType: TypeAlias = Tuple[List[str], Type[_CDataType], str, Any]
 ArgSpecElmType: TypeAlias = _UnionT[_PosArgSpecElmType, _OptArgSpecElmType]

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -3,9 +3,10 @@
 # - utilities for type hints.
 import ctypes
 import sys
+from _ctypes import _CData
 from typing import Any as Any, ClassVar, Generic, NoReturn, Protocol, TypeVar, overload
 from typing import Optional, Union as _UnionT
-from typing import Tuple as Tuple, Type
+from typing import List, Tuple as Tuple, Type
 from typing import Callable, Iterator, Sequence
 
 if sys.version_info >= (3, 9):
@@ -288,3 +289,10 @@ def to_dunder_setitem(
 ) -> Callable[Concatenate[_T_Inst, _P_Set], Any]: ...
 @overload
 def to_dunder_setitem(item: Any) -> Callable[..., NoReturn]: ...
+
+_PosParamFlagType: TypeAlias = Tuple[int, Optional[str]]
+_OptParamFlagType: TypeAlias = Tuple[int, Optional[str], Any]
+ParamFlagType: TypeAlias = _UnionT[_PosParamFlagType, _OptParamFlagType]
+_PosArgSpecElmType: TypeAlias = Tuple[List[str], Type[_CData], str]
+_OptArgSpecElmType: TypeAlias = Tuple[List[str], Type[_CData], str, Any]
+ArgSpecElmType: TypeAlias = _UnionT[_PosArgSpecElmType, _OptArgSpecElmType]

--- a/comtypes/test/test_inout_args.py
+++ b/comtypes/test/test_inout_args.py
@@ -8,7 +8,14 @@ from comtypes import IUnknown
 from comtypes._memberspec import _fix_inout_args
 
 if TYPE_CHECKING:
-    from comtypes._memberspec import _ArgSpecElmType
+    from comtypes import hints  # type: ignore
+
+    _ArgSpecType = Tuple[
+        hints.ArgSpecElmType,
+        hints.ArgSpecElmType,
+        hints.ArgSpecElmType,
+        hints.ArgSpecElmType,
+    ]
 
 WSTRING = c_wchar_p
 
@@ -259,7 +266,7 @@ class Test_ArgsKwargsCombinations(ut.TestCase):
 
 
 class PermutedArgspecTestingParams(NamedTuple):
-    argspec: "Tuple[_ArgSpecElmType, _ArgSpecElmType, _ArgSpecElmType, _ArgSpecElmType]"
+    argspec: "_ArgSpecType"
     args: Tuple[Any, Any, Any]
     orig_ret_val: Tuple[Any, Any, Any]
     fixed_ret_val: List[Any]


### PR DESCRIPTION
The changes in python/typeshed#12982 have been incorporated into major type checkers, allowing for type annotations in codebases for metaprogramming with `ctypes` to more closely reflect actual implementations.

First, I will update parts of the code where using `_CDataType`, a union of concrete classes, is more appropriate than `_CData`, the base class. 

Additionally, I have moved aliases that are only used for type annotations in `_memberspec` to `hints`.