### PR TITLE
Replace `260` literals/constant definitions with imports from `ctypes.wintypes.MAX_PATH`.

### DIFF
--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import types
 from ctypes import wintypes
+from ctypes.wintypes import MAX_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +97,6 @@ GetModuleFileName.restype = ctypes.c_ulong
 GetModuleFileName.argtypes = [wintypes.HMODULE, ctypes.c_wchar_p, ctypes.c_ulong]
 
 CSIDL_APPDATA = 26
-MAX_PATH = 260
 
 
 def _create_comtypes_gen_package():

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -43,7 +43,7 @@ import os
 import sys
 import winreg
 from ctypes import WinDLL, WinError
-from ctypes.wintypes import HKEY, LONG, LPCWSTR
+from ctypes.wintypes import HKEY, LONG, LPCWSTR, MAX_PATH
 from typing import Iterable, Iterator, List, Optional, Tuple, Type, Union
 from winreg import HKEY_CLASSES_ROOT as HKCR
 from winreg import HKEY_CURRENT_USER as HKCU
@@ -242,7 +242,7 @@ class Registrar(object):
 
 def _get_serverdll(handle: int) -> str:
     """Return the pathname of the dll hosting the COM object."""
-    return GetModuleFileName(handle, 260)
+    return GetModuleFileName(handle, MAX_PATH)
 
 
 class RegistryEntries(abc.ABC):

--- a/comtypes/test/test_server_register.py
+++ b/comtypes/test/test_server_register.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest as ut
 import winreg
+from ctypes.wintypes import MAX_PATH
 from unittest import mock
 
 import comtypes
@@ -236,7 +237,7 @@ class Test_get_serverdll(ut.TestCase):
         self.assertEqual(dll_path, _get_serverdll(handle))
         (((hmodule, maxsize), _),) = GetModuleFileName.call_args_list
         self.assertEqual(handle, hmodule)
-        self.assertEqual(260, maxsize)
+        self.assertEqual(MAX_PATH, maxsize)
 
 
 class Test_InterpRegistryEntries(ut.TestCase):

--- a/comtypes/test/test_typeinfo.py
+++ b/comtypes/test/test_typeinfo.py
@@ -1,6 +1,7 @@
 import ctypes
 import sys
 import unittest
+from ctypes.wintypes import MAX_PATH
 
 from comtypes import GUID, COMError
 from comtypes.typeinfo import (
@@ -96,14 +97,14 @@ class Test(unittest.TestCase):
 
 class Test_GetModuleFileName(unittest.TestCase):
     def test_null_handler(self):
-        self.assertEqual(GetModuleFileName(None, 260), sys.executable)
+        self.assertEqual(GetModuleFileName(None, MAX_PATH), sys.executable)
 
     def test_loaded_module_handle(self):
         import _ctypes
 
         dll_path = _ctypes.__file__
         hmodule = ctypes.WinDLL(dll_path)._handle
-        self.assertEqual(GetModuleFileName(hmodule, 260), dll_path)
+        self.assertEqual(GetModuleFileName(hmodule, MAX_PATH), dll_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is remaining tasks of #662.