### PR TITLE
Small fixes for import blocks in `server/localserver.py`, `client/_code_cache.py`, and `errorinfo.py`.

### DIFF
--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -11,8 +11,7 @@ import os
 import sys
 import tempfile
 import types
-from ctypes import wintypes
-from ctypes.wintypes import MAX_PATH
+from ctypes.wintypes import HMODULE, MAX_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +93,7 @@ SHGetSpecialFolderPath.argtypes = [
     ctypes.c_int,
 ]
 GetModuleFileName.restype = ctypes.c_ulong
-GetModuleFileName.argtypes = [wintypes.HMODULE, ctypes.c_wchar_p, ctypes.c_ulong]
+GetModuleFileName.argtypes = [HMODULE, ctypes.c_wchar_p, ctypes.c_ulong]
 
 CSIDL_APPDATA = 26
 

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -1,5 +1,5 @@
 import sys
-from ctypes import *
+from ctypes import POINTER, OleDLL, byref, c_wchar_p
 from ctypes.wintypes import DWORD, ULONG
 
 from comtypes import BSTR, COMMETHOD, GUID, HRESULT, IUnknown

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -1,13 +1,6 @@
 import logging
 import queue
-from ctypes import (
-    HRESULT,
-    POINTER,
-    OleDLL,
-    byref,
-    c_ulong,
-    c_void_p,
-)
+from ctypes import HRESULT, POINTER, OleDLL, byref, c_ulong, c_void_p
 from ctypes.wintypes import DWORD, LPDWORD
 from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Type
 


### PR DESCRIPTION
Small fixes for import blocks in `server/localserver.py`, `client/_code_cache.py`, and `errorinfo.py`.