### PR TITLE
Improve typing and refactor `_memberspec.py`.

### DIFF
--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -218,14 +218,14 @@ _PropFunc = Optional[Callable[..., Any]]
 _DocType = Optional[str]
 
 
-def _prepare_parameter(value: Any, atyp: Type["_CDataType"]):
+def _prepare_parameter(value: Any, atyp: Type["_CDataType"]) -> "_CDataType":
     # parameter was passed, call `from_param()` to
     # convert it to a `ctypes` type.
     if getattr(value, "_type_", None) is atyp:
         # Array of or pointer to type `atyp` was passed,
         # pointer to `atyp` expected.
         v = value
-    elif type(atyp) is _PyCSimpleType:
+    elif type(atyp) is _PyCSimpleType:  # type: ignore
         # The `from_param` method of simple types
         # (`c_int`, `c_double`, ...) returns a `byref` object which
         # we cannot use since later it will be wrapped in a pointer.
@@ -233,7 +233,7 @@ def _prepare_parameter(value: Any, atyp: Type["_CDataType"]):
         v = atyp(value)
     else:
         v = atyp.from_param(value)
-        assert not isinstance(v, _CArgObject)
+        assert not isinstance(v, _CArgObject)  # type: ignore
     return v
 
 

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -17,10 +17,12 @@ from typing import Union as _UnionT
 import comtypes
 
 if TYPE_CHECKING:
+    from _ctypes import _PyCSimpleType
     from ctypes import _CArgObject, _CDataType
 
     from comtypes import hints  # type: ignore
 else:
+    _PyCSimpleType = type(ctypes.c_int)
     _CArgObject = type(ctypes.byref(ctypes.c_int()))
 
 
@@ -231,7 +233,6 @@ def _fix_inout_args(
     #
     # TODO: The workaround should be disabled when a ctypes
     # version is used where the bug is fixed.
-    SIMPLETYPE = type(ctypes.c_int)
 
     def call_with_inout(self, *args, **kw):
         args = list(args)
@@ -274,7 +275,7 @@ def _fix_inout_args(
                         # Array of or pointer to type `atyp` was passed,
                         # pointer to `atyp` expected.
                         pass
-                    elif type(atyp) is SIMPLETYPE:
+                    elif type(atyp) is _PyCSimpleType:
                         # The `from_param` method of simple types
                         # (`c_int`, `c_double`, ...) returns a `byref` object which
                         # we cannot use since later it will be wrapped in a pointer.

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -218,21 +218,21 @@ _PropFunc = Optional[Callable[..., Any]]
 _DocType = Optional[str]
 
 
-def _prepare_parameter(v, atyp):
+def _prepare_parameter(value: Any, atyp: Type["_CDataType"]):
     # parameter was passed, call `from_param()` to
     # convert it to a `ctypes` type.
-    if getattr(v, "_type_", None) is atyp:
+    if getattr(value, "_type_", None) is atyp:
         # Array of or pointer to type `atyp` was passed,
         # pointer to `atyp` expected.
-        pass
+        v = value
     elif type(atyp) is _PyCSimpleType:
         # The `from_param` method of simple types
         # (`c_int`, `c_double`, ...) returns a `byref` object which
         # we cannot use since later it will be wrapped in a pointer.
         # Simply call the constructor with the argument in that case.
-        v = atyp(v)
+        v = atyp(value)
     else:
-        v = atyp.from_param(v)
+        v = atyp.from_param(value)
         assert not isinstance(v, _CArgObject)
     return v
 
@@ -256,7 +256,7 @@ def _fix_inout_args(
     def call_with_inout(self, *args, **kw):
         args = list(args)
         # Indexed by order in the output
-        outargs: Dict[int, _UnionT["_CDataType", "_CArgObject"]] = {}
+        outargs: Dict[int, "_CDataType"] = {}
         outnum = 0
         param_index = 0
         # Go through all expected arguments and match them to the provided arguments.

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -214,9 +214,6 @@ def COMMETHOD(idlflags, restype, methodname, *argspec) -> _ComMemberSpec:
 
 ################################################################
 
-_PropFunc = Optional[Callable[..., Any]]
-_DocType = Optional[str]
-
 
 def _prepare_parameter(value: Any, atyp: Type["_CDataType"]) -> "_CDataType":
     # parameter was passed, call `from_param()` to
@@ -334,6 +331,10 @@ def _fix_inout_args(
         return rescode
 
     return call_with_inout
+
+
+_PropFunc = Optional[Callable[..., Any]]
+_DocType = Optional[str]
 
 
 class PropertyMapping(object):

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from ctypes import _CArgObject, _CDataType
 
     from comtypes import hints  # type: ignore
+else:
+    _CArgObject = type(ctypes.byref(ctypes.c_int()))
 
 
 DISPATCH_METHOD = 1
@@ -230,7 +232,6 @@ def _fix_inout_args(
     # TODO: The workaround should be disabled when a ctypes
     # version is used where the bug is fixed.
     SIMPLETYPE = type(ctypes.c_int)
-    BYREFTYPE = type(ctypes.byref(ctypes.c_int()))
 
     def call_with_inout(self, *args, **kw):
         args = list(args)
@@ -281,7 +282,7 @@ def _fix_inout_args(
                         v = atyp(v)
                     else:
                         v = atyp.from_param(v)
-                        assert not isinstance(v, BYREFTYPE)
+                        assert not isinstance(v, _CArgObject)
                     return v
 
                 if is_positional:

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -213,6 +213,7 @@ def COMMETHOD(idlflags, restype, methodname, *argspec) -> _ComMemberSpec:
 
 
 ################################################################
+# workarounds for ctypes functions and parameters
 
 
 def _prepare_parameter(value: Any, atyp: Type["_CDataType"]) -> "_CDataType":
@@ -331,6 +332,9 @@ def _fix_inout_args(
         return rescode
 
     return call_with_inout
+
+
+################################################################
 
 
 _PropFunc = Optional[Callable[..., Any]]


### PR DESCRIPTION
- Move type aliases and closure functions defined within the function to module-level aliases and private functions.
- Rename the type aliases to follow the `typeshed` conventions.