### PR TITLE
Fix type annotations for `idlflags` and `_dispimpl_`.

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing import Union as _UnionT
 
+import comtypes
 from comtypes import GUID, IPersist, IUnknown, _CoUninitialize, hresult
 from comtypes._memberspec import DISPATCH_METHOD as DISPATCH_METHOD
 from comtypes._memberspec import DISPATCH_PROPERTYGET as DISPATCH_PROPERTYGET
@@ -214,7 +215,7 @@ class COMObject(object):
     _reg_typelib_: ClassVar[Tuple[str, int, int]]
     __typelib: "hints.ITypeLib"
     _com_pointers_: Dict[GUID, "hints.LP_LP_Vtbl"]
-    _dispimpl_: Dict[Tuple[int, int], Callable[..., Any]]
+    _dispimpl_: Dict[Tuple[comtypes.dispid, int], Callable[..., Any]]
 
     def __new__(cls, *args: Any, **kw: Any) -> "hints.Self":
         self = super(COMObject, cls).__new__(cls)

--- a/comtypes/_memberspec.py
+++ b/comtypes/_memberspec.py
@@ -99,6 +99,15 @@ def _resolve_argspec(
     return tuple(paramflags), tuple(argtypes)
 
 
+if TYPE_CHECKING:
+    _VarFlags = Tuple[str, ...]
+    _VarFlagsWithDispIdHelpstr = Tuple["dispid", "helpstring", hints.Unpack[_VarFlags]]
+    _VarFlagsWithDispId = Tuple["dispid", hints.Unpack[_VarFlags]]
+    _VarFlagsWithHelpstr = Tuple["helpstring", hints.Unpack[_VarFlags]]
+    _DispIdlFlags = _UnionT[_VarFlagsWithDispIdHelpstr, _VarFlagsWithDispId]
+    _ComIdlFlags = _UnionT[_VarFlags, _VarFlagsWithHelpstr]
+
+
 class _ComMemberSpec(NamedTuple):
     """Specifier for a slot of COM method or property."""
 
@@ -106,7 +115,7 @@ class _ComMemberSpec(NamedTuple):
     name: str
     argtypes: Tuple[Type["_CDataType"], ...]
     paramflags: Optional[Tuple["hints.ParamFlagType", ...]]
-    idlflags: Tuple[_UnionT[str, int], ...]
+    idlflags: _UnionT["_ComIdlFlags", "_DispIdlFlags"]
     doc: Optional[str]
 
     def is_prop(self) -> bool:
@@ -118,7 +127,7 @@ class _DispMemberSpec(NamedTuple):
 
     what: Literal["DISPMETHOD", "DISPPROPERTY"]
     name: str
-    idlflags: Tuple[_UnionT[str, int], ...]
+    idlflags: "_DispIdlFlags"
     restype: Optional[Type["_CDataType"]]
     argspec: Tuple["hints.ArgSpecElmType", ...]
 

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -258,6 +258,7 @@ def CreateEventReceiver(interface: Type[IUnknown], handler: Any) -> COMObject:
             # Can dispid be at a different index? Should check code generator...
             # ...but hand-written code should also work...
             dispid = idlflags[0]
+            assert isinstance(dispid, comtypes.dispid)
             impl = finder.get_impl(interface, mthname, paramflags, idlflags)
             # XXX Wouldn't work for 'propget', 'propput', 'propputref'
             # methods - are they allowed on event interfaces?

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -16,9 +16,11 @@ else:
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec, TypeAlias
     from typing import TypeGuard as TypeGuard
+    from typing import Unpack as Unpack
 else:
     from typing_extensions import Concatenate, ParamSpec, TypeAlias
     from typing_extensions import TypeGuard as TypeGuard
+    from typing_extensions import Unpack as Unpack
 if sys.version_info >= (3, 11):
     from typing import Self as Self
 else:


### PR DESCRIPTION
The originator of this project left the following comment:
https://github.com/enthought/comtypes/blob/44aafcb4e25396c2a42ea99c75f32c44cdf151e5/comtypes/client/_events.py#L258

As seen in the refactored current codebase, `dispid` is only assigned at index 0 of `idlflags`.

- `ComMethodGenerator`
https://github.com/enthought/comtypes/blob/01b6fc03ffe0279612a93ae031e60f9095793136/comtypes/tools/codegenerator/helpers.py#L117-L127

- `DispMethodGenerator`
https://github.com/enthought/comtypes/blob/01b6fc03ffe0279612a93ae031e60f9095793136/comtypes/tools/codegenerator/helpers.py#L224-L231

If there is a case where this is not true (i.e., where the newly added `assert isinstance(dispid, comtypes.dispid)` fails), it would be an undiscovered bug.