### PR TITLE
Add `SupportErrorInfoTest` to `test_comserver`.

### DIFF
--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -1,9 +1,13 @@
 import sys
 from ctypes import POINTER, OleDLL, byref, c_wchar_p
 from ctypes.wintypes import DWORD, ULONG
+from typing import TYPE_CHECKING
 
 from comtypes import BSTR, COMMETHOD, GUID, HRESULT, IUnknown
 from comtypes.hresult import *
+
+if TYPE_CHECKING:
+    from comtypes import hints  # type: ignore
 
 LPCOLESTR = c_wchar_p
 
@@ -43,6 +47,9 @@ class ISupportErrorInfo(IUnknown):
             [], HRESULT, "InterfaceSupportsErrorInfo", (["in"], POINTER(GUID), "riid")
         )
     ]
+    if TYPE_CHECKING:
+
+        def InterfaceSupportsErrorInfo(self, riid: GUID) -> hints.Hresult: ...
 
 
 ################################################################

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import comtypes.server
 import comtypes.test.TestComServer
-from comtypes import BSTR
+from comtypes import BSTR, errorinfo, hresult, shelllink
 from comtypes.automation import VARIANT, _midlSAFEARRAY
 from comtypes.client import CreateObject, GetActiveObject
 from comtypes.server.register import register, unregister
@@ -199,6 +199,26 @@ class ActiveObjTest(unittest.TestCase):
 
     def test_activeobj_strong_registration(self):
         self._doit(weak=False)
+
+
+class SupportErrorInfoTest(unittest.TestCase):
+    def create_object(self):
+        return CreateObject(
+            comtypes.test.TestComServer.TestComServer,
+            interface=comtypes.test.TestComServer.ITestComServer,
+        )
+
+    def test_returns_S_OK(self):
+        psei = self.create_object().QueryInterface(errorinfo.ISupportErrorInfo)
+        iid = comtypes.test.TestComServer.ITestComServer._iid_
+        hr = psei.InterfaceSupportsErrorInfo(iid)
+        self.assertEqual(hr, hresult.S_OK)
+
+    def test_returns_S_FALSE(self):
+        psei = self.create_object().QueryInterface(errorinfo.ISupportErrorInfo)
+        iid = shelllink.IShellLinkW._iid_
+        hr = psei.InterfaceSupportsErrorInfo(iid)
+        self.assertEqual(hr, hresult.S_FALSE)
 
 
 class VariantTest(unittest.TestCase):


### PR DESCRIPTION
We need to unravel the exception handling to understand the implementation and behavior of the COM server.

I plan to start them by adding tests (and also type hints) to see how interfaces that support `ISupportErrorInfo` behave.