### PR TITLE
Improve the type safety of `errorinfo.ReportException`.

### DIFF
--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -84,6 +84,7 @@ _SetErrorInfo.restype = HRESULT
 
 
 def CreateErrorInfo() -> ICreateErrorInfo:
+    """Creates an instance of a generic error object."""
     cei = POINTER(ICreateErrorInfo)()
     _CreateErrorInfo(byref(cei))
     return cei  # type: ignore

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -146,7 +146,11 @@ def ReportException(
     typ, value, tb = sys.exc_info()
     if stacklevel is not None:
         for _ in range(stacklevel):
+            if tb is None:
+                raise ValueError("'stacklevel' exceeds the available depth.")
             tb = tb.tb_next
+        if tb is None:
+            raise ValueError("'stacklevel' is specified, but no error information.")
         line = tb.tb_frame.f_lineno
         name = tb.tb_frame.f_globals["__name__"]
         text = f"{typ}: {value} ({name}, line {line:d})"

--- a/comtypes/test/test_errorinfo.py
+++ b/comtypes/test/test_errorinfo.py
@@ -98,3 +98,18 @@ class Test_ReportException(ut.TestCase):
                 assert pei is not None  # for static type guard
                 self.assertEqual(text, pei.GetDescription())
                 self.assertIsNone(errorinfo.GetErrorInfo())
+
+    def test_with_over_stacklevel(self):
+        self.assertIsNone(errorinfo.GetErrorInfo())
+        iid = shelllink.IShellLinkW._iid_
+        try:
+            raise_runtime_error()
+        except RuntimeError:
+            with self.assertRaises(ValueError):
+                errorinfo.ReportException(hres.E_UNEXPECTED, iid, stacklevel=4)
+
+    def test_with_no_error_and_zero_stacklevel(self):
+        self.assertIsNone(errorinfo.GetErrorInfo())
+        iid = shelllink.IShellLinkW._iid_
+        with self.assertRaises(ValueError):
+            errorinfo.ReportException(hres.E_UNEXPECTED, iid, stacklevel=0)


### PR DESCRIPTION
Due to the possibility that `sys.exc_info()[2]` and `TracebackType.tb_next` may return `None`, there are points in `errorinfo.ReportException` where the type checker will produce errors.

If this function is called with a specified `stacklevel` without catching an error, or if `stacklevel` is specified deeper than the cause of the error even when an error is caught, an `AttributeError` will be raised.

By explicitly detecting such cases and throwing a `ValueError`, the implementation of `errorinfo.ReportException` can be made type-safe.