### PR TITLE
Add type annotations and introduce `hresult` constants to `server/connectionpoints.py`.

### DIFF
--- a/comtypes/hresult.py
+++ b/comtypes/hresult.py
@@ -82,3 +82,10 @@ def HRESULT_FROM_WIN32(x):
         return x
     # 0x80000000 | FACILITY_WIN32 << 16 | x & 0xFFFF
     return c_long(0x80070000 | (x & 0xFFFF)).value
+
+
+# Win32 error codes are defined as unsigned 32-bit integers. However, to
+# ensure compatibility with COM and other HRESULT-based APIs, Windows converts
+# them into HRESULT values by setting the high bit, ensuring a consistent way
+# to indicate failure across these APIs.
+RPC_S_SERVER_UNAVAILABLE = -2147023174  # 0x800706BA (WIN32: 1722 0x6BA)

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -1,5 +1,5 @@
 import logging
-from ctypes import *
+from ctypes import pointer
 
 from comtypes import COMError, COMObject, IUnknown
 from comtypes.automation import IDispatch

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -65,7 +65,7 @@ class ConnectionPointImpl(COMObject):
                 try:
                     result = p.Invoke(dispid, *args, **kw)
                 except COMError as details:
-                    if details.hresult == -2147023174:
+                    if details.hresult == RPC_S_SERVER_UNAVAILABLE:
                         logger.warning(
                             "_call_sinks(%s, %s, *%s, **%s) failed; removing connection",
                             self,
@@ -94,7 +94,7 @@ class ConnectionPointImpl(COMObject):
                 try:
                     result = getattr(p, name)(*args, **kw)
                 except COMError as details:
-                    if details.hresult == -2147023174:
+                    if details.hresult == RPC_S_SERVER_UNAVAILABLE:
                         logger.warning(
                             "_call_sinks(%s, %s, *%s, **%s) failed; removing connection",
                             self,

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -1,8 +1,9 @@
 import logging
+from _ctypes import COMError
 from ctypes import pointer
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Tuple, Type
 
-from comtypes import COMError, COMObject, IUnknown
+from comtypes import COMObject, IUnknown
 from comtypes.automation import IDispatch
 from comtypes.connectionpoints import IConnectionPoint
 from comtypes.hresult import *

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -1,6 +1,6 @@
 import logging
 from ctypes import pointer
-from typing import Type
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Tuple, Type
 
 from comtypes import COMError, COMObject, IUnknown
 from comtypes.automation import IDispatch
@@ -22,7 +22,7 @@ class ConnectionPointImpl(COMObject):
         self, sink_interface: Type[IUnknown], sink_typeinfo: ITypeInfo
     ) -> None:
         super(ConnectionPointImpl, self).__init__()
-        self._connections = {}
+        self._connections: Dict[int, IUnknown] = {}
         self._cookie = 0
         self._sink_interface = sink_interface
         self._typeinfo = sink_typeinfo
@@ -129,9 +129,13 @@ class ConnectableObjectMixin(object):
     integer index into the _outgoing_interfaces_ list.
     """
 
+    if TYPE_CHECKING:
+        _outgoing_interfaces_: ClassVar[List[Type[IDispatch]]]
+        _reg_typelib_: ClassVar[Tuple[str, int, int]]
+
     def __init__(self) -> None:
         super(ConnectableObjectMixin, self).__init__()
-        self.__connections = {}
+        self.__connections: Dict[Type[IDispatch], ConnectionPointImpl] = {}
 
         tlib = LoadRegTypeLib(*self._reg_typelib_)
         for itf in self._outgoing_interfaces_:

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -1,11 +1,12 @@
 import logging
 from ctypes import pointer
+from typing import Type
 
 from comtypes import COMError, COMObject, IUnknown
 from comtypes.automation import IDispatch
 from comtypes.connectionpoints import IConnectionPoint
 from comtypes.hresult import *
-from comtypes.typeinfo import LoadRegTypeLib
+from comtypes.typeinfo import ITypeInfo, LoadRegTypeLib
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,9 @@ class ConnectionPointImpl(COMObject):
 
     _com_interfaces_ = [IConnectionPoint]
 
-    def __init__(self, sink_interface, sink_typeinfo):
+    def __init__(
+        self, sink_interface: Type[IUnknown], sink_typeinfo: ITypeInfo
+    ) -> None:
         super(ConnectionPointImpl, self).__init__()
         self._connections = {}
         self._cookie = 0
@@ -126,7 +129,7 @@ class ConnectableObjectMixin(object):
     integer index into the _outgoing_interfaces_ list.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(ConnectableObjectMixin, self).__init__()
         self.__connections = {}
 


### PR DESCRIPTION
While working on this task, I discovered from the `server/connectionpoints.py` codebase that this project could potentially use `IUnknown` as an event sink, not only `IDispatch`.
However, the codebase handling non-`IDispatch` event sinks clearly contains unbound variables and lacks testing.
Since the real-world COM servers used as test doubles in this project only use `IDispatch` event sinks. Expanding the tests and performing a safe refactoring would require defining a dedicated test COM server.