### PR TITLE
Delint `__InterlockedIncrement`/`...Decrement`.

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -330,10 +330,10 @@ class COMObject(object):
     def IUnknown_AddRef(
         self,
         this: Any,
-        __InterlockedIncrement: Callable[[c_long], int] = _InterlockedIncrement,
+        _increment: Callable[[c_long], int] = _InterlockedIncrement,
         _debug=_debug,
     ) -> int:
-        result = __InterlockedIncrement(self._refcnt)
+        result = _increment(self._refcnt)
         if result == 1:
             self.__keep__(self)
         _debug("%r.AddRef() -> %s", self, result)
@@ -347,14 +347,14 @@ class COMObject(object):
     def IUnknown_Release(
         self,
         this: Any,
-        __InterlockedDecrement: Callable[[c_long], int] = _InterlockedDecrement,
+        _decrement: Callable[[c_long], int] = _InterlockedDecrement,
         _debug=_debug,
     ) -> int:
         # If this is called at COM shutdown, _InterlockedDecrement()
         # must still be available, although module level variables may
         # have been deleted already - so we supply it as default
         # argument.
-        result = __InterlockedDecrement(self._refcnt)
+        result = _decrement(self._refcnt)
         _debug("%r.Release() -> %s", self, result)
         if result == 0:
             self._final_release_()

--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -24,7 +24,7 @@ if sys.version_info >= (3, 11):
     from typing import Unpack as Unpack
 else:
     from typing_extensions import Self as Self
-    from typing import Unpack as Unpack
+    from typing_extensions import Unpack as Unpack
 
 import comtypes
 from comtypes import IUnknown as IUnknown, COMObject as COMObject, GUID as GUID


### PR DESCRIPTION
Before the introduction of runtime positional-only parameters using `/`, it was common practice to use argument names beginning with `__` to indicate positional-only parameters.
As a remnant of this practice, type checkers still recognize arguments starting with `__` as positional-only.

This change resolves false positives caused by that behavior.