### PR TITLE
Convert `assertRaises` usage to context manager for improved readability.

### DIFF
--- a/comtypes/test/test_GUID.py
+++ b/comtypes/test/test_GUID.py
@@ -30,25 +30,24 @@ class Test(unittest.TestCase):
         )
 
     def test_invalid_constructor_arg(self):
-        self.assertRaises(WindowsError, GUID, "abc")
+        with self.assertRaises(WindowsError):
+            GUID("abc")
 
     def test_from_progid(self):
         self.assertEqual(
             GUID.from_progid("Scripting.FileSystemObject"),
             GUID("{0D43FE01-F093-11CF-8940-00A0C9054228}"),
         )
-        self.assertRaises(WindowsError, GUID.from_progid, "abc")
+        with self.assertRaises(WindowsError):
+            GUID.from_progid("abc")
 
     def test_as_progid(self):
         self.assertEqual(
             GUID("{0D43FE01-F093-11CF-8940-00A0C9054228}").as_progid(),
             "Scripting.FileSystemObject",
         )
-        self.assertRaises(
-            WindowsError,
-            lambda guid: guid.as_progid(),
-            GUID("{00000000-0000-0000-C000-000000000046}"),
-        )
+        with self.assertRaises(WindowsError):
+            GUID("{00000000-0000-0000-C000-000000000046}").as_progid()
 
     def test_create_new(self):
         self.assertNotEqual(GUID.create_new(), GUID.create_new())

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -61,7 +61,8 @@ class BasicTest(ut.TestCase):
         self.assertEqual(method_count(IMyInterface), 3)
 
         # assigning _methods_ does not work until we have an _iid_!
-        self.assertRaises(AttributeError, setattr, IMyInterface, "_methods_", [])
+        with self.assertRaises(AttributeError):
+            setattr(IMyInterface, "_methods_", [])
         IMyInterface._iid_ = GUID.create_new()
         IMyInterface._methods_ = []
         self.assertEqual(method_count(IMyInterface), 3)
@@ -96,9 +97,11 @@ class BasicTest(ut.TestCase):
             _iid_ = GUID.create_new()
 
         # We cannot assign _methods_ to IDerived before IBase has it's _methods_:
-        self.assertRaises(TypeError, lambda: setattr(IDerived, "_methods_", []))
+        with self.assertRaises(TypeError):
+            setattr(IDerived, "_methods_", [])
         # Make sure that setting _methods_ failed completely.
-        self.assertRaises(KeyError, lambda: IDerived.__dict__["_methods_"])
+        with self.assertRaises(KeyError):
+            IDerived.__dict__["_methods_"]
         IBase._methods_ = []
         # Now it works:
         IDerived._methods_ = []

--- a/comtypes/test/test_collections.py
+++ b/comtypes/test/test_collections.py
@@ -60,7 +60,8 @@ class Test(unittest.TestCase):
 
         # slicing is not (yet?) supported
         cv.Reset()
-        self.assertRaises(ArgumentError, lambda: cv[:])
+        with self.assertRaises(ArgumentError):
+            cv[:]
 
     @unittest.skip("This test takes a long time.  Do we need it? Can it be rewritten?")
     def test_leaks_1(self):
@@ -151,10 +152,12 @@ class TestCollectionInterface(unittest.TestCase):
         self.assertAccessInterface(d)
 
     def test_named_property_no_length(self):
-        self.assertRaises(TypeError, len, self.d.Item)
+        with self.assertRaises(TypeError):
+            len(self.d.Item)
 
     def test_named_property_not_iterable(self):
-        self.assertRaises(TypeError, list, self.d.Item)
+        with self.assertRaises(TypeError):
+            list(self.d.Item)
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_dict.py
+++ b/comtypes/test/test_dict.py
@@ -14,7 +14,8 @@ class Test(unittest.TestCase):
 
         # Count is a normal propget, no propput
         self.assertEqual(d.Count, 0)
-        self.assertRaises(AttributeError, lambda: setattr(d, "Count", -1))
+        with self.assertRaises(AttributeError):
+            setattr(d, "Count", -1)
 
         # HashVal is a 'named' propget, no propput
         ##d.HashVal

--- a/comtypes/test/test_dyndispatch.py
+++ b/comtypes/test/test_dyndispatch.py
@@ -66,10 +66,12 @@ class Test(unittest.TestCase):
         self.assertEqual(d3.Item["baz"], 3.14)
 
     def test_named_property_no_length(self):
-        self.assertRaises(TypeError, len, self.d.Item)
+        with self.assertRaises(TypeError):
+            len(self.d.Item)
 
     def test_named_property_not_iterable(self):
-        self.assertRaises(TypeError, list, self.d.Item)
+        with self.assertRaises(TypeError):
+            list(self.d.Item)
 
     def assertAccessInterface(self, d):
         """Asserts access via indexing and named property"""

--- a/comtypes/test/test_safearray.py
+++ b/comtypes/test/test_safearray.py
@@ -129,7 +129,8 @@ class SafeArrayTestCase(unittest.TestCase):
         self.assertEqual(SafeArrayGetVartype(sa), VT_I4)
 
         # TypeError: len() of unsized object
-        self.assertRaises(TypeError, lambda: t.from_param(object()))
+        with self.assertRaises(TypeError):
+            t.from_param(object())
 
     def test_VT_VARIANT(self):
         t = _midlSAFEARRAY(VARIANT)

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -66,7 +66,8 @@ class VariantTestCase(unittest.TestCase):
 
         missing = VARIANT.missing
         self.assertEqual(missing.vt, VT_ERROR)
-        self.assertRaises(NotImplementedError, lambda: missing.value)
+        with self.assertRaises(NotImplementedError):
+            missing.value
 
     def test_com_refcounts(self):
         # typelib for oleaut32

--- a/comtypes/test/test_w_getopt.py
+++ b/comtypes/test/test_w_getopt.py
@@ -20,10 +20,10 @@ class TestCase(unittest.TestCase):
 
     def test_3(self):
         # Invalid option
-        self.assertRaises(
-            GetoptError, w_getopt, "/TLIB hello.tlb hello.idl".split(), ["tlb:"]
-        )
+        with self.assertRaises(GetoptError):
+            w_getopt("/TLIB hello.tlb hello.idl".split(), ["tlb:"])
 
     def test_4(self):
         # Missing argument
-        self.assertRaises(GetoptError, w_getopt, "/TLB".split(), ["tlb:"])
+        with self.assertRaises(GetoptError):
+            w_getopt("/TLB".split(), ["tlb:"])


### PR DESCRIPTION
Testing improvements.