### PR TITLE
[client\_generate.py] Remove PATH variable

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -15,8 +15,6 @@ from comtypes.tools import codegenerator, tlbparser
 
 logger = logging.getLogger(__name__)
 
-PATH = os.environ["PATH"].split(os.pathsep)
-
 
 def _my_import(fullname: str) -> types.ModuleType:
     """helper function to import dotted modules"""


### PR DESCRIPTION
Fix: https://github.com/enthought/comtypes/issues/118

The variable isn't used since 2008: https://github.com/enthought/comtypes/commit/a6bee92cf1ff0e3c8eec07259bf3cf22df9f5398#diff-43f06e41bd1e46dbb0ded91a220ae60e7961e2b72126ad3b1031065c0bad4fb6