### PR TITLE
CI/CD Improvements for runners and the codecov badge.

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, windows-2019]
+        os: [windows-2025, windows-2022]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         architecture: ['x86', 'x64']
     steps:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/comtypes.svg)](https://pypi.org/project/comtypes/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/comtypes)](https://pypi.org/project/comtypes/) [![PyPI - Python Requires](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fpypi.org%2Fpypi%2Fcomtypes%2Fjson&query=info.requires_python&label=Python&nbsp;Requires)](https://pypi.org/project/comtypes/)  
 [![PyPI - License](https://img.shields.io/pypi/l/comtypes)](https://pypi.org/project/comtypes/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/comtypes)](https://pypi.org/project/comtypes/)  
 [![GitHub Repo stars](https://img.shields.io/github/stars/enthought/comtypes?style=social)](https://github.com/enthought/comtypes/stargazers) [![GitHub forks](https://img.shields.io/github/forks/enthought/comtypes?style=social)](https://github.com/enthought/comtypes/network/members) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)  
-[![Tidelift Subscription](https://tidelift.com/badges/package/pypi/comtypes)](https://tidelift.com/subscription/pkg/pypi-comtypes?utm_source=pypi-comtypes&utm_medium=readme)
-[![Coverage](https://img.shields.io/codecov/c/github/enthought/comtypes)](https://app.codecov.io/github/enthought/comtypes)
+[![Tidelift Subscription](https://tidelift.com/badges/package/pypi/comtypes)](https://tidelift.com/subscription/pkg/pypi-comtypes?utm_source=pypi-comtypes&utm_medium=readme) [![Coverage](https://img.shields.io/codecov/c/github/enthought/comtypes)](https://app.codecov.io/github/enthought/comtypes)  
 
 
 `comtypes` is a lightweight pure Python [COM](https://learn.microsoft.com/en-us/windows/win32/com/component-object-model--com--portal) package based on the [`ctypes`](https://docs.python.org/library/ctypes.html) foreign function interface library.


### PR DESCRIPTION
Closes #840.

This PR includes two key improvements for our CI/CD pipeline:

- Upgrading the Windows runner in GitHub Actions to windows-2022 to avoid disruptions after June 30, 2025.

- ~Fixing the codecov coverage badge in the README for accurate display (see https://github.com/enthought/comtypes/pull/775#issuecomment-2940030210).~

- Make the line breaks and spacing around the `codecov` badges in `README.md` consistent with other badges.