### PR TITLE
Add client-side `RegisterActiveObject`.

### DIFF
--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -214,6 +214,8 @@ from comtypes._post_coinit.misc import IPersist, IServiceProvider  # noqa
 
 from comtypes._post_coinit.instancemethod import instancemethod  # noqa
 from comtypes._post_coinit.activeobj import (  # noqa
+    ACTIVEOBJECT_STRONG,
+    ACTIVEOBJECT_WEAK,
     GetActiveObject,
     RegisterActiveObject,
     RevokeActiveObject,

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -213,7 +213,7 @@ from comtypes._post_coinit.misc import IPersist, IServiceProvider  # noqa
 
 
 from comtypes._post_coinit.instancemethod import instancemethod  # noqa
-from comtypes._post_coinit.activeobj import GetActiveObject  # noqa
+from comtypes._post_coinit.activeobj import GetActiveObject, RevokeActiveObject  # noqa
 from comtypes._post_coinit.misc import (  # noqa
     _is_object,
     CoGetObject,

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -213,12 +213,12 @@ from comtypes._post_coinit.misc import IPersist, IServiceProvider  # noqa
 
 
 from comtypes._post_coinit.instancemethod import instancemethod  # noqa
+from comtypes._post_coinit.activeobj import GetActiveObject  # noqa
 from comtypes._post_coinit.misc import (  # noqa
     _is_object,
     CoGetObject,
     CoCreateInstance,
     CoGetClassObject,
-    GetActiveObject,
     MULTI_QI,
     _COAUTHIDENTITY,
     COAUTHIDENTITY,

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -213,7 +213,11 @@ from comtypes._post_coinit.misc import IPersist, IServiceProvider  # noqa
 
 
 from comtypes._post_coinit.instancemethod import instancemethod  # noqa
-from comtypes._post_coinit.activeobj import GetActiveObject, RevokeActiveObject  # noqa
+from comtypes._post_coinit.activeobj import (  # noqa
+    GetActiveObject,
+    RegisterActiveObject,
+    RevokeActiveObject,
+)
 from comtypes._post_coinit.misc import (  # noqa
     _is_object,
     CoGetObject,

--- a/comtypes/_post_coinit/activeobj.py
+++ b/comtypes/_post_coinit/activeobj.py
@@ -1,5 +1,5 @@
 from ctypes import HRESULT, POINTER, OleDLL, byref
-from ctypes.wintypes import LPVOID
+from ctypes.wintypes import DWORD, LPVOID
 from typing import Optional, Type, TypeVar, overload
 
 from comtypes import GUID
@@ -7,6 +7,11 @@ from comtypes._post_coinit.unknwn import IUnknown
 from comtypes.GUID import REFCLSID
 
 _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
+
+
+def RevokeActiveObject(handle: int) -> None:
+    """Ends a pointer's status as active."""
+    _RevokeActiveObject(handle, None)
 
 
 @overload
@@ -25,6 +30,10 @@ def GetActiveObject(
 
 
 _oleaut32 = OleDLL("oleaut32")
+
+_RevokeActiveObject = _oleaut32.RevokeActiveObject
+_RevokeActiveObject.argtypes = [DWORD, LPVOID]
+_RevokeActiveObject.restype = HRESULT
 
 _GetActiveObject = _oleaut32.GetActiveObject
 _GetActiveObject.argtypes = [REFCLSID, LPVOID, POINTER(POINTER(IUnknown))]

--- a/comtypes/_post_coinit/activeobj.py
+++ b/comtypes/_post_coinit/activeobj.py
@@ -1,4 +1,4 @@
-from ctypes import HRESULT, POINTER, OleDLL, byref
+from ctypes import HRESULT, POINTER, OleDLL, byref, c_ulong, c_void_p
 from ctypes.wintypes import DWORD, LPVOID
 from typing import Optional, Type, TypeVar, overload
 
@@ -7,6 +7,13 @@ from comtypes._post_coinit.unknwn import IUnknown
 from comtypes.GUID import REFCLSID
 
 _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
+
+
+def RegisterActiveObject(punk, clsid, flags) -> int:
+    """Registers a pointer as the active object for its class and returns the handle."""
+    handle = c_ulong()
+    _RegisterActiveObject(punk, byref(clsid), flags, byref(handle))
+    return handle.value
 
 
 def RevokeActiveObject(handle: int) -> None:
@@ -30,6 +37,10 @@ def GetActiveObject(
 
 
 _oleaut32 = OleDLL("oleaut32")
+
+_RegisterActiveObject = _oleaut32.RegisterActiveObject
+_RegisterActiveObject.argtypes = [c_void_p, REFCLSID, DWORD, POINTER(DWORD)]
+_RegisterActiveObject.restype = HRESULT
 
 _RevokeActiveObject = _oleaut32.RevokeActiveObject
 _RevokeActiveObject.argtypes = [DWORD, LPVOID]

--- a/comtypes/_post_coinit/activeobj.py
+++ b/comtypes/_post_coinit/activeobj.py
@@ -1,0 +1,31 @@
+from ctypes import HRESULT, POINTER, OleDLL, byref
+from ctypes.wintypes import LPVOID
+from typing import Optional, Type, TypeVar, overload
+
+from comtypes import GUID
+from comtypes._post_coinit.unknwn import IUnknown
+from comtypes.GUID import REFCLSID
+
+_T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
+
+
+@overload
+def GetActiveObject(clsid: GUID, interface: None = None) -> IUnknown: ...
+@overload
+def GetActiveObject(clsid: GUID, interface: Type[_T_IUnknown]) -> _T_IUnknown: ...
+def GetActiveObject(
+    clsid: GUID, interface: Optional[Type[IUnknown]] = None
+) -> IUnknown:
+    """Retrieves a pointer to a running object"""
+    p = POINTER(IUnknown)()
+    _GetActiveObject(byref(clsid), None, byref(p))
+    if interface is not None:
+        p = p.QueryInterface(interface)  # type: ignore
+    return p  # type: ignore
+
+
+_oleaut32 = OleDLL("oleaut32")
+
+_GetActiveObject = _oleaut32.GetActiveObject
+_GetActiveObject.argtypes = [REFCLSID, LPVOID, POINTER(POINTER(IUnknown))]
+_GetActiveObject.restype = HRESULT

--- a/comtypes/_post_coinit/activeobj.py
+++ b/comtypes/_post_coinit/activeobj.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
 
 _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
 
+ACTIVEOBJECT_STRONG = 0x0
+ACTIVEOBJECT_WEAK = 0x1
+
 
 def RegisterActiveObject(
     punk: "_UnionT[IUnknown, hints.LP_LP_Vtbl]", clsid: GUID, flags: int

--- a/comtypes/_post_coinit/activeobj.py
+++ b/comtypes/_post_coinit/activeobj.py
@@ -1,15 +1,22 @@
 from ctypes import HRESULT, POINTER, OleDLL, byref, c_ulong, c_void_p
 from ctypes.wintypes import DWORD, LPVOID
-from typing import Optional, Type, TypeVar, overload
+from typing import TYPE_CHECKING, Optional, Type, TypeVar, overload
+from typing import Union as _UnionT
 
 from comtypes import GUID
 from comtypes._post_coinit.unknwn import IUnknown
 from comtypes.GUID import REFCLSID
 
+if TYPE_CHECKING:
+    from comtypes import hints  # type: ignore
+
+
 _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
 
 
-def RegisterActiveObject(punk, clsid, flags) -> int:
+def RegisterActiveObject(
+    punk: "_UnionT[IUnknown, hints.LP_LP_Vtbl]", clsid: GUID, flags: int
+) -> int:
     """Registers a pointer as the active object for its class and returns the handle."""
     handle = c_ulong()
     _RegisterActiveObject(punk, byref(clsid), flags, byref(handle))

--- a/comtypes/_post_coinit/misc.py
+++ b/comtypes/_post_coinit/misc.py
@@ -172,21 +172,6 @@ def CoGetClassObject(clsid, clsctx=None, pServerInfo=None, interface=None):
     return p  # type: ignore
 
 
-@overload
-def GetActiveObject(clsid: GUID, interface: None = None) -> IUnknown: ...
-@overload
-def GetActiveObject(clsid: GUID, interface: Type[_T_IUnknown]) -> _T_IUnknown: ...
-def GetActiveObject(
-    clsid: GUID, interface: Optional[Type[IUnknown]] = None
-) -> IUnknown:
-    """Retrieves a pointer to a running object"""
-    p = POINTER(IUnknown)()
-    _GetActiveObject(byref(clsid), None, byref(p))
-    if interface is not None:
-        p = p.QueryInterface(interface)  # type: ignore
-    return p  # type: ignore
-
-
 class MULTI_QI(Structure):
     _fields_ = [("pIID", POINTER(GUID)), ("pItf", POINTER(c_void_p)), ("hr", HRESULT)]
     if TYPE_CHECKING:
@@ -237,13 +222,6 @@ class _COSERVERINFO(Structure):
         pwszName: Optional[str]
         pAuthInfo: _COAUTHINFO
         dwReserved2: int
-
-
-_oleaut32 = OleDLL("oleaut32")
-
-_GetActiveObject = _oleaut32.GetActiveObject
-_GetActiveObject.argtypes = [REFCLSID, LPVOID, POINTER(POINTER(IUnknown))]
-_GetActiveObject.restype = HRESULT
 
 
 _ole32 = OleDLL("ole32")

--- a/comtypes/_post_coinit/misc.py
+++ b/comtypes/_post_coinit/misc.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, overlo
 from comtypes import CLSCTX_LOCAL_SERVER, CLSCTX_REMOTE_SERVER, CLSCTX_SERVER, GUID
 from comtypes._memberspec import COMMETHOD
 from comtypes._post_coinit.unknwn import IUnknown
+from comtypes.GUID import REFCLSID
 
 if TYPE_CHECKING:
     from ctypes import _Pointer
@@ -240,7 +241,6 @@ class _COSERVERINFO(Structure):
 
 _oleaut32 = OleDLL("oleaut32")
 
-REFCLSID = POINTER(GUID)
 _GetActiveObject = _oleaut32.GetActiveObject
 _GetActiveObject.argtypes = [REFCLSID, LPVOID, POINTER(POINTER(IUnknown))]
 _GetActiveObject.restype = HRESULT

--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -3,7 +3,7 @@
 import ctypes
 import logging
 
-from comtypes import automation
+from comtypes import RevokeActiveObject, automation  # noqa
 from comtypes.client import dynamic, lazybind  # noqa
 from comtypes.client._activeobj import RegisterActiveObject  # noqa
 from comtypes.client._code_cache import _find_gen_dir

--- a/comtypes/client/__init__.py
+++ b/comtypes/client/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 from comtypes import automation
 from comtypes.client import dynamic, lazybind  # noqa
+from comtypes.client._activeobj import RegisterActiveObject  # noqa
 from comtypes.client._code_cache import _find_gen_dir
 from comtypes.client._constants import Constants  # noqa
 from comtypes.client._events import GetEvents, PumpEvents, ShowEvents

--- a/comtypes/client/_activeobj.py
+++ b/comtypes/client/_activeobj.py
@@ -44,3 +44,11 @@ def GetActiveObject(
     if dynamic:
         return comtypes.client.dynamic.Dispatch(obj)
     return _manage(obj, clsid, interface=interface)
+
+
+def RegisterActiveObject(
+    punk: IUnknown, progid: _UnionT[str, Type[CoClass], GUID], weak: bool = True
+) -> int:
+    clsid = GUID.from_progid(progid)
+    flags = comtypes.ACTIVEOBJECT_WEAK if weak else comtypes.ACTIVEOBJECT_STRONG
+    return comtypes.RegisterActiveObject(punk, clsid, flags)

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -63,17 +63,13 @@ class IClassFactory(IUnknown):
 #         STDMETHOD(HRESULT, "AddConnection", [c_ulong, c_ulong]),
 #         STDMETHOD(HRESULT, "ReleaseConnection", [c_ulong, c_ulong, c_ulong])]
 
-# The following code is untested:
-
-ACTIVEOBJECT_STRONG = 0x0
-ACTIVEOBJECT_WEAK = 0x1
-
 
 def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
+    """Registers a pointer as the active object for its class and returns the handle."""
     punk = comobj._com_pointers_[IUnknown._iid_]
     clsid = comobj._reg_clsid_
     if weak:
-        flags = ACTIVEOBJECT_WEAK
+        flags = comtypes.ACTIVEOBJECT_WEAK
     else:
-        flags = ACTIVEOBJECT_STRONG
+        flags = comtypes.ACTIVEOBJECT_STRONG
     return comtypes.RegisterActiveObject(punk, clsid, flags)

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -68,8 +68,5 @@ def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
     """Registers a pointer as the active object for its class and returns the handle."""
     punk = comobj._com_pointers_[IUnknown._iid_]
     clsid = comobj._reg_clsid_
-    if weak:
-        flags = comtypes.ACTIVEOBJECT_WEAK
-    else:
-        flags = comtypes.ACTIVEOBJECT_STRONG
+    flags = comtypes.ACTIVEOBJECT_WEAK if weak else comtypes.ACTIVEOBJECT_STRONG
     return comtypes.RegisterActiveObject(punk, clsid, flags)

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,12 +1,13 @@
 import ctypes
 from ctypes import HRESULT, POINTER, OleDLL, byref, c_void_p
-from ctypes.wintypes import DWORD, LPVOID
+from ctypes.wintypes import DWORD
 from typing import TYPE_CHECKING, Any, Optional, Type
 
 import comtypes
 import comtypes.client
 import comtypes.client.dynamic
 from comtypes import GUID, STDMETHOD, IUnknown
+from comtypes import RevokeActiveObject as RevokeActiveObject
 from comtypes.automation import IDispatch
 from comtypes.GUID import REFCLSID
 
@@ -80,13 +81,6 @@ _RegisterActiveObject.argtypes = [
 ]
 _RegisterActiveObject.restype = HRESULT
 
-_RevokeActiveObject = _oleaut32.RevokeActiveObject
-_RevokeActiveObject.argtypes = [
-    DWORD,
-    LPVOID,
-]
-_RevokeActiveObject.restype = HRESULT
-
 
 def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
     punk = comobj._com_pointers_[IUnknown._iid_]
@@ -98,7 +92,3 @@ def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
     handle = ctypes.c_ulong()
     _RegisterActiveObject(punk, byref(clsid), flags, byref(handle))
     return handle.value
-
-
-def RevokeActiveObject(handle: int) -> None:
-    _RevokeActiveObject(handle, None)

--- a/comtypes/server/__init__.py
+++ b/comtypes/server/__init__.py
@@ -1,6 +1,5 @@
 import ctypes
-from ctypes import HRESULT, POINTER, OleDLL, byref, c_void_p
-from ctypes.wintypes import DWORD
+from ctypes import HRESULT, POINTER, byref
 from typing import TYPE_CHECKING, Any, Optional, Type
 
 import comtypes
@@ -9,7 +8,6 @@ import comtypes.client.dynamic
 from comtypes import GUID, STDMETHOD, IUnknown
 from comtypes import RevokeActiveObject as RevokeActiveObject
 from comtypes.automation import IDispatch
-from comtypes.GUID import REFCLSID
 
 if TYPE_CHECKING:
     from ctypes import _Pointer
@@ -70,17 +68,6 @@ class IClassFactory(IUnknown):
 ACTIVEOBJECT_STRONG = 0x0
 ACTIVEOBJECT_WEAK = 0x1
 
-_oleaut32 = OleDLL("oleaut32")
-
-_RegisterActiveObject = _oleaut32.RegisterActiveObject
-_RegisterActiveObject.argtypes = [
-    c_void_p,
-    REFCLSID,
-    DWORD,
-    POINTER(DWORD),
-]
-_RegisterActiveObject.restype = HRESULT
-
 
 def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
     punk = comobj._com_pointers_[IUnknown._iid_]
@@ -89,6 +76,4 @@ def RegisterActiveObject(comobj: comtypes.COMObject, weak: bool = True) -> int:
         flags = ACTIVEOBJECT_WEAK
     else:
         flags = ACTIVEOBJECT_STRONG
-    handle = ctypes.c_ulong()
-    _RegisterActiveObject(punk, byref(clsid), flags, byref(handle))
-    return handle.value
+    return comtypes.RegisterActiveObject(punk, clsid, flags)

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -1,11 +1,12 @@
 import logging
 import queue
-from ctypes import HRESULT, POINTER, OleDLL, byref, c_ulong, c_void_p
+from ctypes import HRESULT, OleDLL, byref, c_ulong, c_void_p
 from ctypes.wintypes import DWORD, LPDWORD
 from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Type
 
 import comtypes
 from comtypes import GUID, COMObject, IUnknown, hresult
+from comtypes.GUID import REFCLSID
 from comtypes.server import IClassFactory
 
 if TYPE_CHECKING:
@@ -23,7 +24,6 @@ REGCLS_SURROGATE = 8  # must be used when a surrogate process
 
 _ole32 = OleDLL("ole32")
 
-REFCLSID = POINTER(GUID)
 _CoRegisterClassObject = _ole32.CoRegisterClassObject
 _CoRegisterClassObject.argtypes = [REFCLSID, c_void_p, DWORD, DWORD, LPDWORD]
 _CoRegisterClassObject.restype = HRESULT

--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -1,9 +1,13 @@
+import contextlib
 import time
 import unittest
 
 import comtypes
 import comtypes.client
-import comtypes.test
+
+with contextlib.redirect_stdout(None):  # supress warnings
+    comtypes.client.GetModule("msvidctl.dll")
+from comtypes.gen import MSVidCtlLib as msvidctl
 
 try:
     # pass Word libUUID
@@ -65,6 +69,19 @@ class Test_Word(unittest.TestCase):
         self.assertEqual(variables, err.args)
         with self.assertRaises(WindowsError):
             comtypes.client.GetActiveObject("Word.Application")
+
+
+class Test_MSVidCtlLib(unittest.TestCase):
+    def test_register_and_revoke(self):
+        vidctl = comtypes.client.CreateObject(msvidctl.MSVidCtl)
+        with self.assertRaises(WindowsError):
+            comtypes.client.GetActiveObject(msvidctl.MSVidCtl)
+        handle = comtypes.client.RegisterActiveObject(vidctl, msvidctl.MSVidCtl)
+        activeobj = comtypes.client.GetActiveObject(msvidctl.MSVidCtl)
+        self.assertEqual(vidctl, activeobj)
+        comtypes.client.RevokeActiveObject(handle)
+        with self.assertRaises(WindowsError):
+            comtypes.client.GetActiveObject(msvidctl.MSVidCtl)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #844.

This supports scenarios where a desktop app or utility registers a COM object instance into the Running Object Table (ROT).
This allows other processes to discover that specific instance using `GetActiveObject`.