### PR TITLE
Run ruff check UP008

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -218,7 +218,7 @@ class COMObject:
     _dispimpl_: Dict[Tuple[comtypes.dispid, int], Callable[..., Any]]
 
     def __new__(cls, *args: Any, **kw: Any) -> "hints.Self":
-        self = super(COMObject, cls).__new__(cls)
+        self = super().__new__(cls)
         if isinstance(self, c_void_p):
             # We build the VTables only for direct instances of
             # CoClass, not for POINTERs to CoClass.

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -287,14 +287,12 @@ class _compointer_base(c_void_p, metaclass=_compointer_meta):
         if not isinstance(other, _compointer_base):
             return False
         # get the value property of the c_void_p baseclass, this is the pointer value
-        return (
-            super(_compointer_base, self).value == super(_compointer_base, other).value
-        )
+        return super().value == super(_compointer_base, other).value
 
     def __hash__(self) -> int:
         """Return the hash value of the pointer."""
         # hash the pointer values
-        return hash(super(_compointer_base, self).value)
+        return hash(super().value)
 
     # redefine the .value property; return the object itself.
     def __get_value(self) -> "hints.Self":
@@ -303,7 +301,7 @@ class _compointer_base(c_void_p, metaclass=_compointer_meta):
     value = property(__get_value, doc="""Return self.""")
 
     def __repr__(self) -> str:
-        ptr = super(_compointer_base, self).value
+        ptr = super().value
         return f"<{self.__class__.__name__} ptr=0x{ptr or 0:x} at {id(self):x}>"
 
     # This fixes the problem when there are multiple python interface types

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -209,7 +209,7 @@ class _SinkMethodFinder(_MethodFinder):
     """
 
     def __init__(self, inst: COMObject, sink: Any) -> None:
-        super(_SinkMethodFinder, self).__init__(inst)
+        super().__init__(inst)
         self.sink = sink
 
     def find_method(self, fq_name: str, mthname: str) -> Callable[..., Any]:
@@ -229,7 +229,7 @@ class _SinkMethodFinder(_MethodFinder):
 
     def _find_method(self, fq_name: str, mthname: str) -> Callable[..., Any]:
         try:
-            return super(_SinkMethodFinder, self).find_method(fq_name, mthname)
+            return super().find_method(fq_name, mthname)
         except AttributeError:
             try:
                 return getattr(self.sink, fq_name)

--- a/comtypes/persist.py
+++ b/comtypes/persist.py
@@ -266,7 +266,7 @@ class DictPropertyBag(COMObject):
     _com_interfaces_ = [IPropertyBag]
 
     def __init__(self, **kw):
-        super(DictPropertyBag, self).__init__()
+        super().__init__()
         self.values = kw
 
     def Read(self, this, name, pVar, errorlog):

--- a/comtypes/server/automation.py
+++ b/comtypes/server/automation.py
@@ -22,7 +22,7 @@ class VARIANTEnumerator(COMObject):
             items  # keep, so that we can restore our iterator (in Reset, and Clone).
         )
         self.seq = iter(self.items)
-        super(VARIANTEnumerator, self).__init__()
+        super().__init__()
 
     def Next(self, this, celt, rgVar, pCeltFetched):
         if not rgVar:
@@ -75,7 +75,7 @@ class COMCollection(COMObject):
     def __init__(self, itemtype, collection):
         self.collection = collection
         self.itemtype = itemtype
-        super(COMCollection, self).__init__()
+        super().__init__()
 
     def _get_Item(self, this, pathname, pitem):
         if not pitem:

--- a/comtypes/server/connectionpoints.py
+++ b/comtypes/server/connectionpoints.py
@@ -31,7 +31,7 @@ class ConnectionPointImpl(COMObject):
     def __init__(
         self, sink_interface: Type[IUnknown], sink_typeinfo: ITypeInfo
     ) -> None:
-        super(ConnectionPointImpl, self).__init__()
+        super().__init__()
         self._connections: Dict[int, IUnknown] = {}
         self._cookie = 0
         self._sink_interface = sink_interface
@@ -122,7 +122,7 @@ class ConnectableObjectMixin:
         _reg_typelib_: ClassVar[Tuple[str, int, int]]
 
     def __init__(self) -> None:
-        super(ConnectableObjectMixin, self).__init__()
+        super().__init__()
         self.__connections: Dict[Type[IDispatch], ConnectionPointImpl] = {}
 
         tlib = LoadRegTypeLib(*self._reg_typelib_)

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -22,7 +22,7 @@ class ClassFactory(COMObject):
     _com_interfaces_ = [IClassFactory]
 
     def __init__(self, cls: Type[COMObject]) -> None:
-        super(ClassFactory, self).__init__()
+        super().__init__()
         self._cls = cls
 
     def IClassFactory_CreateInstance(

--- a/comtypes/server/localserver.py
+++ b/comtypes/server/localserver.py
@@ -45,7 +45,7 @@ class ClassFactory(COMObject):
     regcls: int = REGCLS_MULTIPLEUSE
 
     def __init__(self, cls: Type[COMObject], *args, **kw) -> None:
-        super(ClassFactory, self).__init__()
+        super().__init__()
         self._cls = cls
         self._register_class()
         self._args = args

--- a/comtypes/tools/typedesc_base.py
+++ b/comtypes/tools/typedesc_base.py
@@ -198,7 +198,7 @@ class Structure(_Struct_Union_Base):
             self.size = int(size)
         else:
             self.size = None
-        super(Structure, self).__init__()
+        super().__init__()
 
 
 class Union(_Struct_Union_Base):
@@ -220,7 +220,7 @@ class Union(_Struct_Union_Base):
             self.size = int(size)
         else:
             self.size = None
-        super(Union, self).__init__()
+        super().__init__()
 
 
 class Field:

--- a/comtypes/viewobject.py
+++ b/comtypes/viewobject.py
@@ -55,7 +55,7 @@ class tagExtentInfo(Structure):
 
     def __init__(self, *args, **kw):
         self.cb = sizeof(self)
-        super(tagExtentInfo, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
     def __repr__(self):
         size = (self.sizelProposed.cx, self.sizelProposed.cy)


### PR DESCRIPTION
I simply runned the command: ruff check --select UP008 --fix --unsafe-fixes
For more detail about UP008, see https://docs.astral.sh/ruff/rules/super-call-with-parameters/
ruff version used: 0.11.13

Note that this is marked as a "unsafe-fixes" only because it can remove comments (which hasn't been the case).