### PR TITLE
Run ruff check UP009

### DIFF
--- a/comtypes/test/test_dispifc_records.py
+++ b/comtypes/test/test_dispifc_records.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import unittest
 from ctypes import byref, pointer
 

--- a/comtypes/test/test_dispifc_safearrays.py
+++ b/comtypes/test/test_dispifc_safearrays.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import unittest
 from ctypes import byref, c_double, pointer
 

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -1,5 +1,3 @@
-# -*- coding: latin-1 -*-
-
 import datetime
 import sys
 import unittest

--- a/comtypes/test/test_midl_safearray_create.py
+++ b/comtypes/test/test_midl_safearray_create.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import unittest
 from ctypes import HRESULT, POINTER, c_int, pointer
 

--- a/comtypes/test/test_recordinfo.py
+++ b/comtypes/test/test_recordinfo.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import unittest
 from ctypes import byref, pointer, sizeof
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # comtypes documentation build configuration file, created by
 # sphinx-quickstart on Mon Apr 07 16:12:34 2014.


### PR DESCRIPTION
I runned the command: ruff check --select UP009 --fix
For more detail about UP009, see: https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/
ruff version used: 0.11.13

Note that I also removed the latin-1 coding comment that wasn't cover by UP009.
