### PR TITLE
Run ruff check UP012

### DIFF
--- a/comtypes/test/test_storage.py
+++ b/comtypes/test/test_storage.py
@@ -58,7 +58,7 @@ class Test_IStorage(unittest.TestCase):
         filepath = Path(storage.Stat(STATFLAG_DEFAULT).pwcsName)
         self.assertTrue(filepath.exists())
         stream = storage.CreateStream("example", self.CREATE_STM_FLAG, 0, 0)
-        test_data = "Some data".encode("utf-8")
+        test_data = b"Some data"
         pv = (c_ubyte * len(test_data)).from_buffer(bytearray(test_data))
         stream.RemoteWrite(pv, len(test_data))
         stream.Commit(STGC_DEFAULT)

--- a/comtypes/test/test_stream.py
+++ b/comtypes/test/test_stream.py
@@ -37,7 +37,7 @@ def _create_stream() -> IStream:
 class Test_RemoteWrite(ut.TestCase):
     def test_RemoteWrite(self):
         stream = _create_stream()
-        test_data = "Some data".encode("utf-8")
+        test_data = b"Some data"
         pv = (c_ubyte * len(test_data)).from_buffer(bytearray(test_data))
 
         written = stream.RemoteWrite(pv, len(test_data))
@@ -49,7 +49,7 @@ class Test_RemoteWrite(ut.TestCase):
 class Test_RemoteRead(ut.TestCase):
     def test_RemoteRead(self):
         stream = _create_stream()
-        test_data = "Some data".encode("utf-8")
+        test_data = b"Some data"
         pv = (c_ubyte * len(test_data)).from_buffer(bytearray(test_data))
         stream.RemoteWrite(pv, len(test_data))
 


### PR DESCRIPTION
I simply runned the command: ruff check --select UP012 --fix
For more detail about UP012, see: https://docs.astral.sh/ruff/rules/unnecessary-encode-utf8/
ruff version used: 0.11.13