### PR TITLE
Run ruff check UP024

### DIFF
--- a/comtypes/_comobject.py
+++ b/comtypes/_comobject.py
@@ -414,7 +414,7 @@ class COMObject:
         try:
             self.__typelib
         except AttributeError:
-            raise WindowsError(hresult.E_NOTIMPL)
+            raise OSError(hresult.E_NOTIMPL)
         return self.__typelib.GetTypeInfoOfGuid(self._reg_clsid_)
 
     ################################################################
@@ -422,7 +422,7 @@ class COMObject:
 
     def IProvideClassInfo2_GetGUID(self, dwGuidKind: int) -> GUID:
         if dwGuidKind != GUIDKIND_DEFAULT_SOURCE_DISP_IID:
-            raise WindowsError(hresult.E_INVALIDARG)
+            raise OSError(hresult.E_INVALIDARG)
         return self._outgoing_interfaces_[0]._iid_
 
     ################################################################

--- a/comtypes/_post_coinit/unknwn.py
+++ b/comtypes/_post_coinit/unknwn.py
@@ -33,7 +33,7 @@ def _shutdown(
     else:
         try:
             func()
-        except WindowsError:
+        except OSError:
             pass
     # Set the flag which means that calling obj.Release() is no longer
     # needed.

--- a/comtypes/_vtbl.py
+++ b/comtypes/_vtbl.py
@@ -93,7 +93,7 @@ def catch_errors(
         except comtypes.ReturnHRESULT as err:
             (hr, text) = err.args
             return ReportError(text, iid=interface._iid_, clsid=clsid, hresult=hr)
-        except (COMError, WindowsError) as details:
+        except (OSError, COMError) as details:
             _error(
                 "Exception in %s.%s implementation:",
                 interface.__name__,
@@ -201,7 +201,7 @@ def hack(
                 msg = f"{source}: {descr}"
             hr = HRESULT_FROM_WIN32(hr)
             return ReportError(msg, iid=interface._iid_, clsid=clsid, hresult=hr)
-        except WindowsError as details:
+        except OSError as details:
             _error(
                 "Exception in %s.%s implementation:",
                 interface.__name__,

--- a/comtypes/client/_code_cache.py
+++ b/comtypes/client/_code_cache.py
@@ -115,7 +115,7 @@ def _create_comtypes_gen_package():
                 ofi = open(comtypes_init, "w")
                 ofi.write("# comtypes.gen package, directory for generated files.\n")
                 ofi.close()
-        except (OSError, IOError) as details:
+        except OSError as details:
             logger.info("Creating comtypes.gen package failed: %s", details)
             module = sys.modules["comtypes.gen"] = types.ModuleType("comtypes.gen")
             comtypes.gen = module

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -104,7 +104,7 @@ class _AdviseConnection:
             if self.cookie is not None:
                 assert self.cp is not None
                 self.cp.Unadvise(self.cookie)
-        except (COMError, WindowsError):
+        except (OSError, COMError):
             # Are we sure we want to ignore errors here?
             pass
 
@@ -381,7 +381,7 @@ def PumpEvents(timeout: Any) -> None:
                 handles,
                 byref(ctypes.c_ulong()),
             )
-        except WindowsError as details:
+        except OSError as details:
             if details.winerror != hresult.RPC_S_CALLPENDING:  # timeout expired
                 raise
         else:

--- a/comtypes/client/dynamic.py
+++ b/comtypes/client/dynamic.py
@@ -27,7 +27,7 @@ def Dispatch(obj):
     if isinstance(obj, ctypes.POINTER(automation.IDispatch)):
         try:
             tinfo = obj.GetTypeInfo(0)
-        except (COMError, WindowsError):
+        except (OSError, COMError):
             return _Dispatch(obj)
         return lazybind.Dispatch(obj, tinfo)
     return obj

--- a/comtypes/errorinfo.py
+++ b/comtypes/errorinfo.py
@@ -126,7 +126,7 @@ def ReportError(
             clsid = GUID(clsid)
         try:
             progid = clsid.as_progid()
-        except WindowsError:
+        except OSError:
             pass
         else:
             # progid for the class or application that created the error

--- a/comtypes/server/inprocserver.py
+++ b/comtypes/server/inprocserver.py
@@ -92,7 +92,7 @@ def _setup_logging(clsid: GUID) -> None:
 
     try:
         hkey = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"CLSID\%s\Logging" % clsid)
-    except WindowsError:
+    except OSError:
         return
     from comtypes.logutil import NTDebugHandler
 

--- a/comtypes/server/register.py
+++ b/comtypes/server/register.py
@@ -105,7 +105,7 @@ def _delete_key(hkey: int, subkey: str, *, force: bool) -> None:
         else:
             _debug("DeleteKey %s\\%s", _explain(hkey), subkey)
             winreg.DeleteKey(hkey, subkey)
-    except WindowsError as detail:
+    except OSError as detail:
         if get_winerror(detail) != 2:
             raise
 
@@ -142,7 +142,7 @@ class Registrar:
             _debug('DeleteKey( %s\\CLSID\\%s\\Logging"' % (_explain(HKCR), clsid))
             hkey = winreg.OpenKey(HKCR, rf"CLSID\{clsid}")
             winreg.DeleteKey(hkey, "Logging")
-        except WindowsError as detail:
+        except OSError as detail:
             if get_winerror(detail) != 2:
                 raise
 
@@ -166,7 +166,7 @@ class Registrar:
             _debug("DeleteValue(format)")
             try:
                 winreg.DeleteValue(hkey, "format")
-            except WindowsError as detail:
+            except OSError as detail:
                 if get_winerror(detail) != 2:
                     raise
 
@@ -231,7 +231,7 @@ class Registrar:
             try:
                 _debug("UnRegisterTypeLib(%s, %s, %s)", *tlib)
                 UnRegisterTypeLib(*tlib)
-            except WindowsError as detail:
+            except OSError as detail:
                 if not get_winerror(detail) in (
                     TYPE_E_REGISTRYACCESS,
                     TYPE_E_CANTLOADLIBRARY,

--- a/comtypes/test/test_agilent.py
+++ b/comtypes/test/test_agilent.py
@@ -12,7 +12,7 @@ from comtypes.test import ResourceDenied
 
 try:
     GUID.from_progid("Agilent546XX.Agilent546XX")
-except WindowsError:
+except OSError:
     pass
 
 else:

--- a/comtypes/test/test_client_dynamic.py
+++ b/comtypes/test/test_client_dynamic.py
@@ -26,7 +26,7 @@ class Test_Dispatch_Function(ut.TestCase):
 
     def test_returns_dynamic_Dispatch_if_takes_ptrIDispatch_and_raised_winerr(self):
         obj = mock.MagicMock(spec=ctypes.POINTER(automation.IDispatch))
-        obj.GetTypeInfo.side_effect = WindowsError()
+        obj.GetTypeInfo.side_effect = OSError()
         self.assertIsInstance(dynamic.Dispatch(obj), dynamic._Dispatch)
 
     def test_returns_what_is_took_if_takes_other(self):

--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -22,7 +22,7 @@ except ImportError:
 def setUpModule():
     try:
         register(comtypes.test.TestComServer.TestComServer)
-    except WindowsError as e:
+    except OSError as e:
         if e.winerror != 5:  # [Error 5] Access is denied
             raise e
         raise unittest.SkipTest(

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -51,7 +51,7 @@ def add_test(fname):
     def test(self):
         try:
             comtypes.typeinfo.LoadTypeLibEx(fname)
-        except WindowsError:
+        except OSError:
             return
         comtypes.client.GetModule(fname)
 

--- a/comtypes/test/test_dispinterface.py
+++ b/comtypes/test/test_dispinterface.py
@@ -16,7 +16,7 @@ except ImportError:
 def setUpModule():
     try:
         register(comtypes.test.TestDispServer.TestDispServer)
-    except WindowsError as e:
+    except OSError as e:
         if e.winerror != 5:  # [Error 5] Access is denied
             raise e
         raise unittest.SkipTest(

--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -33,7 +33,7 @@ class Test_Word(unittest.TestCase):
     def setUp(self):
         try:
             comtypes.client.GetActiveObject("Word.Application")
-        except WindowsError:
+        except OSError:
             pass
         else:
             # seems word is running, we cannot test this.

--- a/comtypes/test/test_msscript.py
+++ b/comtypes/test/test_msscript.py
@@ -11,7 +11,7 @@ from comtypes.client import CreateObject
 try:
     GUID.from_progid("MSScriptControl.ScriptControl")
     CreateObject("MSScriptControl.ScriptControl")
-except WindowsError:
+except OSError:
     # doesn't exist on Windows CE or in 64-bit.
     pass
 else:

--- a/comtypes/test/test_npsupport.py
+++ b/comtypes/test/test_npsupport.py
@@ -70,9 +70,7 @@ def enabled_disabled(disabled_error):
             from comtypes import npsupport
 
             if npsupport.enabled:
-                raise EnvironmentError(
-                    "Expected numpy interop not to be enabled but it is."
-                )
+                raise OSError("Expected numpy interop not to be enabled but it is.")
             with self.assertRaises(disabled_error):
                 func(self)
 

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -310,7 +310,7 @@ def check_perf(rep=20000):
         import cPickle as pickle
     try:
         previous = pickle.load(open("result.pickle", "rb"))
-    except IOError:
+    except OSError:
         previous = {}
 
     results = {}


### PR DESCRIPTION
I simply runned the command: ruff check --select UP024 --fix
For more detail about UP024, see: https://docs.astral.sh/ruff/rules/os-error-alias/
ruff version used: 0.11.13