### PR TITLE
Create codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
With this, the CI won't fails when the patch coverage isn't "good". Ex where it fails: https://github.com/enthought/comtypes/pull/847
Doc: https://docs.codecov.com/docs/commit-status

PS: This PR is following https://github.com/enthought/comtypes/pull/775