### PR TITLE
Skip unstable `test_eval` in INPROC server tests.

### DIFF
--- a/comtypes/test/test_comserver.py
+++ b/comtypes/test/test_comserver.py
@@ -116,6 +116,11 @@ class TestInproc(BaseServerTest, unittest.TestCase):
             "TestComServerLib.TestComServer", clsctx=comtypes.CLSCTX_INPROC_SERVER
         )
 
+    @unittest.skip("Fails occasionally with a memory leak on INPROC.")
+    def test_eval(self):
+        # This test sometimes leaks memory when run as an in-process server.
+        pass
+
 
 class TestLocalServer(BaseServerTest, unittest.TestCase):
     def create_object(self):


### PR DESCRIPTION
To address the instability of `test_eval` when run against an in-process server, this PR introduces a skip for this specific test within the `TestInproc`.

The `test_eval` remains validated by the `TestLocalServer`, ensuring no large regression in coverage.