### PR TITLE
Adjust structure sizes and alignments for 64-bit Python in `viewobject.py`.

### DIFF
--- a/comtypes/test/test_viewobject.py
+++ b/comtypes/test/test_viewobject.py
@@ -1,0 +1,6 @@
+import unittest
+
+import comtypes.viewobject  # noqa
+
+
+class Test_IViewObject(unittest.TestCase): ...

--- a/comtypes/test/test_viewobject.py
+++ b/comtypes/test/test_viewobject.py
@@ -1,8 +1,9 @@
 import unittest
+from ctypes.wintypes import SIZEL
 
 import comtypes.client
 from comtypes import IUnknown
-from comtypes.viewobject import DVASPECT_CONTENT, IAdviseSink, IViewObject
+from comtypes.viewobject import DVASPECT_CONTENT, IAdviseSink, IViewObject, IViewObject2
 
 
 def create_shell_explorer() -> IUnknown:
@@ -26,3 +27,11 @@ class Test_IViewObject(unittest.TestCase):
         cookie = vo.Freeze(DVASPECT_CONTENT, -1, None)
         self.assertIsInstance(cookie, int)
         vo.Unfreeze(cookie)
+
+
+class Test_IViewObject2(unittest.TestCase):
+    def test_GetExtent(self):
+        vo2 = create_shell_explorer().QueryInterface(IViewObject2)
+        size = vo2.GetExtent(DVASPECT_CONTENT, -1, None)
+        self.assertTrue(size)
+        self.assertIsInstance(size, SIZEL)

--- a/comtypes/test/test_viewobject.py
+++ b/comtypes/test/test_viewobject.py
@@ -1,6 +1,28 @@
 import unittest
 
-import comtypes.viewobject  # noqa
+import comtypes.client
+from comtypes import IUnknown
+from comtypes.viewobject import DVASPECT_CONTENT, IAdviseSink, IViewObject
 
 
-class Test_IViewObject(unittest.TestCase): ...
+def create_shell_explorer() -> IUnknown:
+    return comtypes.client.CreateObject("Shell.Explorer")
+
+
+class Test_IViewObject(unittest.TestCase):
+    def test_Advise_GetAdvise(self):
+        vo = create_shell_explorer().QueryInterface(IViewObject)
+        # Test that we can clear any existing advise connection.
+        vo.SetAdvise(DVASPECT_CONTENT, 0, None)
+        # Verify that no advise connection is present.
+        aspect, advf, sink = vo.GetAdvise()
+        self.assertIsInstance(aspect, int)
+        self.assertIsInstance(advf, int)
+        self.assertIsInstance(sink, IAdviseSink)
+        self.assertFalse(sink)  # A NULL com pointer evaluates to False.
+
+    def test_Freeze_Unfreeze(self):
+        vo = create_shell_explorer().QueryInterface(IViewObject)
+        cookie = vo.Freeze(DVASPECT_CONTENT, -1, None)
+        self.assertIsInstance(cookie, int)
+        vo.Unfreeze(cookie)

--- a/comtypes/viewobject.py
+++ b/comtypes/viewobject.py
@@ -1,6 +1,16 @@
 # XXX need to find out what the share from comtypes.dataobject.
-from ctypes import *
-from ctypes import POINTER, c_int, sizeof
+from ctypes import (
+    HRESULT,
+    POINTER,
+    Structure,
+    alignment,
+    c_int,
+    c_ubyte,
+    c_ulong,
+    c_ushort,
+    c_void_p,
+    sizeof,
+)
 from ctypes.wintypes import _RECTL, HDC, SIZEL, tagPOINT, tagRECT
 
 from comtypes import COMMETHOD, GUID, IUnknown

--- a/comtypes/viewobject.py
+++ b/comtypes/viewobject.py
@@ -1,8 +1,11 @@
 # XXX need to find out what the share from comtypes.dataobject.
 from ctypes import *
+from ctypes import POINTER, c_int, sizeof
 from ctypes.wintypes import _RECTL, HDC, SIZEL, tagPOINT, tagRECT
 
 from comtypes import COMMETHOD, GUID, IUnknown
+
+X64_PYTHON = sizeof(POINTER(c_int)) * 8 == 64
 
 
 class tagPALETTEENTRY(Structure):
@@ -27,7 +30,10 @@ class tagLOGPALETTE(Structure):
     ]
 
 
-assert sizeof(tagLOGPALETTE) == 8, sizeof(tagLOGPALETTE)
+if X64_PYTHON:
+    assert sizeof(tagLOGPALETTE) == 12, sizeof(tagLOGPALETTE)
+else:
+    assert sizeof(tagLOGPALETTE) == 8, sizeof(tagLOGPALETTE)
 assert alignment(tagLOGPALETTE) == 2, alignment(tagLOGPALETTE)
 
 
@@ -42,8 +48,12 @@ class tagDVTARGETDEVICE(Structure):
     ]
 
 
-assert sizeof(tagDVTARGETDEVICE) == 16, sizeof(tagDVTARGETDEVICE)
-assert alignment(tagDVTARGETDEVICE) == 4, alignment(tagDVTARGETDEVICE)
+if X64_PYTHON:
+    assert sizeof(tagDVTARGETDEVICE) == 24, sizeof(tagDVTARGETDEVICE)
+    assert alignment(tagDVTARGETDEVICE) == 8, alignment(tagDVTARGETDEVICE)
+else:
+    assert sizeof(tagDVTARGETDEVICE) == 16, sizeof(tagDVTARGETDEVICE)
+    assert alignment(tagDVTARGETDEVICE) == 4, alignment(tagDVTARGETDEVICE)
 
 
 class tagExtentInfo(Structure):

--- a/comtypes/viewobject.py
+++ b/comtypes/viewobject.py
@@ -84,6 +84,10 @@ class tagExtentInfo(Structure):
 
 assert sizeof(tagExtentInfo) == 16, sizeof(tagExtentInfo)
 assert alignment(tagExtentInfo) == 4, alignment(tagExtentInfo)
+
+PALETTEENTRY = tagPALETTEENTRY
+LOGPALETTE = tagLOGPALETTE
+DVTARGETDEVICE = tagDVTARGETDEVICE
 DVEXTENTINFO = tagExtentInfo
 
 IAdviseSink = IUnknown  # fake the interface


### PR DESCRIPTION
Closes #446.