### PR TITLE
Modernize `npsupport` by removing the patch for the `np._typecodes`.

### DIFF
--- a/comtypes/_npsupport.py
+++ b/comtypes/_npsupport.py
@@ -96,23 +96,17 @@ class Interop:
         if not self.enabled:
             return {}
         import numpy as np
-        from numpy import ctypeslib
+        from numpy.ctypeslib import as_ctypes_type
 
-        try:
-            from numpy.ctypeslib import _typecodes
-        except ImportError:
-            from numpy.ctypeslib import as_ctypes_type
+        dtypes_to_ctypes = {}
 
-            dtypes_to_ctypes = {}
-
-            for tp in set(np.sctypeDict.values()):
-                try:
-                    ctype_for = as_ctypes_type(tp)
-                    dtypes_to_ctypes[np.dtype(tp).str] = ctype_for
-                except NotImplementedError:
-                    continue
-            ctypeslib._typecodes = dtypes_to_ctypes
-        return ctypeslib._typecodes
+        for tp in set(np.sctypeDict.values()):
+            try:
+                ctype_for = as_ctypes_type(tp)
+                dtypes_to_ctypes[np.dtype(tp).str] = ctype_for
+            except NotImplementedError:
+                continue
+        return dtypes_to_ctypes
 
     def isndarray(self, value):
         """Check if a value is an ndarray.

--- a/comtypes/_npsupport.py
+++ b/comtypes/_npsupport.py
@@ -92,7 +92,7 @@ class Interop:
 
         return self.numpy.dtype(tagVARIANT_format)
 
-    def _check_ctypeslib_typecodes(self):
+    def _build_typecodes(self):
         if not self.enabled:
             return {}
         import numpy as np
@@ -168,7 +168,7 @@ class Interop:
         # if that succeeded we can be enabled
         self.enabled = True
         self.VARIANT_dtype = self._make_variant_dtype()
-        self.typecodes = self._check_ctypeslib_typecodes()
+        self.typecodes = self._build_typecodes()
         self.datetime64 = self.numpy.datetime64
         self.com_null_date64 = self.numpy.datetime64("1899-12-30T00:00:00", "ns")
 


### PR DESCRIPTION
Fixes #858 