### PR TITLE
Add tests for `DictPropertyBag` and type hints for `IPropertyBag`.

### DIFF
--- a/comtypes/persist.py
+++ b/comtypes/persist.py
@@ -12,7 +12,7 @@ interface, useful in client code.
 
 from ctypes import POINTER, Structure, c_int, c_ulong, c_ushort, c_wchar_p
 from ctypes.wintypes import BOOL, DWORD, WORD
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from comtypes import COMMETHOD, GUID, HRESULT, IPersist, IUnknown
 from comtypes.automation import VARIANT, tagEXCEPINFO
@@ -64,6 +64,13 @@ class IPropertyBag(IUnknown):
             (["in"], POINTER(VARIANT), "pVar"),
         ),
     ]
+
+    if TYPE_CHECKING:
+
+        def Read(
+            self, pszPropName: str, pVar: VARIANT, pErrorLog: Optional[IErrorLog]
+        ) -> Any: ...
+        def Write(self, pszPropName: str, pVar: Any) -> hints.Hresult: ...
 
 
 class IPersistPropertyBag(IPersist):

--- a/comtypes/test/test_persist.py
+++ b/comtypes/test/test_persist.py
@@ -1,8 +1,10 @@
 import tempfile
 import unittest as ut
+from _ctypes import COMError
 from pathlib import Path
 
-from comtypes import GUID, CoCreateInstance, IPersist, persist
+from comtypes import GUID, CoCreateInstance, IPersist, hresult, persist
+from comtypes.automation import VARIANT
 
 CLSID_ShellLink = GUID("{00021401-0000-0000-C000-000000000046}")
 
@@ -36,3 +38,34 @@ class Test_IPersistFile(ut.TestCase):
         pf.Save(str(tgt_file), True)
         self.assertEqual(pf.GetCurFile(), str(tgt_file))
         self.assertTrue(tgt_file.exists())
+
+
+class Test_DictPropertyBag(ut.TestCase):
+    def create_itf_ptr(self) -> persist.IPropertyBag:
+        # Create a DictPropertyBag instance with some initial values
+        impl = persist.DictPropertyBag(Key1="value1", Key2=123, Key3=True)
+        # Get the IPropertyBag interface pointer
+        itf = impl.QueryInterface(persist.IPropertyBag)
+        return itf
+
+    def test_read_existing_properties(self):
+        itf = self.create_itf_ptr()
+        self.assertEqual(itf.Read("Key1", VARIANT(), None), "value1")
+        self.assertEqual(itf.Read("Key2", VARIANT(), None), 123)
+        self.assertEqual(itf.Read("Key3", VARIANT(), None), True)
+
+    def test_write_new_property(self):
+        itf = self.create_itf_ptr()
+        itf.Write("Key4", "new_value")
+        self.assertEqual(itf.Read("Key4", VARIANT(), None), "new_value")
+
+    def test_update_existing_property(self):
+        itf = self.create_itf_ptr()
+        itf.Write("Key1", "updated_value")
+        self.assertEqual(itf.Read("Key1", VARIANT(), None), "updated_value")
+
+    def test_read_non_existent_property(self):
+        itf = self.create_itf_ptr()
+        with self.assertRaises(COMError) as cm:
+            itf.Read("NonExistentProp", VARIANT(), None)
+        self.assertEqual(cm.exception.hresult, hresult.E_INVALIDARG)


### PR DESCRIPTION
This PR adds a new test class, `Test_DictPropertyBag`, to test the `IPropertyBag` interface's functionality via the `DictPropertyBag` implementation.
This includes tests for:
- Reading existing properties.
- Writing new properties.
- Updating existing properties.
- Handling attempts to read non-existent properties.

Additionally, this introduces type hints for the `IPropertyBag` interface methods (`Read` and `Write`) within a `TYPE_CHECKING` block.