### PR TITLE
Fix `numpy` interoperability and enable `datetime64` tests.

### DIFF
--- a/comtypes/_npsupport.py
+++ b/comtypes/_npsupport.py
@@ -169,6 +169,7 @@ class Interop:
         self.enabled = True
         self.VARIANT_dtype = self._make_variant_dtype()
         self.typecodes = self._check_ctypeslib_typecodes()
+        self.datetime64 = self.numpy.datetime64
         self.com_null_date64 = self.numpy.datetime64("1899-12-30T00:00:00", "ns")
 
 

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -398,13 +398,13 @@ def _make_safearray_type(itemtype):
 def _ndarray_to_variant_array(value):
     """Convert an ndarray to VARIANT_dtype array"""
     # Check that variant arrays are supported
-    if comtypes.npsupport.interop.VARIANT_dtype is None:
+    if comtypes.npsupport.VARIANT_dtype is None:
         msg = "VARIANT ndarrays require NumPy 1.7 or newer."
         raise RuntimeError(msg)
-    numpy = comtypes.npsupport.interop.numpy
+    numpy = comtypes.npsupport.numpy
 
     # special cases
-    if numpy.issubdtype(value.dtype, comtypes.npsupport.interop.datetime64):
+    if numpy.issubdtype(value.dtype, comtypes.npsupport.datetime64):
         return _datetime64_ndarray_to_variant_array(value)
 
     from comtypes.automation import VARIANT
@@ -423,12 +423,12 @@ def _datetime64_ndarray_to_variant_array(value):
     # fractional days.
     from comtypes.automation import VT_DATE
 
-    numpy = comtypes.npsupport.interop.numpy
+    numpy = comtypes.npsupport.numpy
     value = numpy.array(value, "datetime64[ns]")
-    value = value - comtypes.npsupport.interop.com_null_date64
+    value = value - comtypes.npsupport.com_null_date64
     # Convert to days
     value = value / numpy.timedelta64(1, "D")
-    varr = numpy.zeros(value.shape, comtypes.npsupport.interop.VARIANT_dtype, order="F")
+    varr = numpy.zeros(value.shape, comtypes.npsupport.VARIANT_dtype, order="F")
     varr["vt"] = VT_DATE
     varr["_"]["VT_R8"].flat = value.flat
     return varr

--- a/comtypes/safearray.py
+++ b/comtypes/safearray.py
@@ -410,7 +410,7 @@ def _ndarray_to_variant_array(value):
     from comtypes.automation import VARIANT
 
     # Empty array
-    varr = numpy.zeros(value.shape, comtypes.npsupport.interop.VARIANT_dtype, order="F")
+    varr = numpy.zeros(value.shape, comtypes.npsupport.VARIANT_dtype, order="F")
     # Convert each value to a variant and put it in the array.
     varr.flat = [VARIANT(v) for v in value.flat]
     return varr

--- a/comtypes/test/test_npsupport.py
+++ b/comtypes/test/test_npsupport.py
@@ -110,10 +110,6 @@ class NumpySupportTestCase(unittest.TestCase):
         self.assertTrue(isinstance(fourth, numpy.ndarray))
         self.assertTrue(isinstance(fifth, tuple))
 
-    @unittest.skip(
-        "Skipping because numpy cannot currently create an array of variants "
-        "because it doesn't recognise the VARIANT_BOOL typecode 'v'."
-    )
     def test_datetime64_ndarray(self):
         comtypes.npsupport.enable()
         dates = numpy.array(


### PR DESCRIPTION
This PR addresses issues related to `numpy` interoperability, specifically focusing on `safearray` and `_npsupport`.

- `comtypes/safearray.py`: Correct the access path for `VARIANT_dtype`, `numpy`, `datetime64`, and `com_null_date64`.
- `comtypes/_npsupport.py`: Add `self.datetime64 = self.numpy.datetime64` to the `Interop` class to ensure proper handling of `datetime64` types.
- `comtypes/test/test_npsupport.py`: Re-enable the `test_datetime64_ndarray` test case by removing the `@unittest.skip` decorator.