### PR TITLE
Revive and correct integer handling logic for `VARIANT`s.

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -273,9 +273,7 @@ class tagVARIANT(Structure):
                     # did work.
                     self.vt = VT_UI8
                     return
-            # VT_R8 is last resort.
-            self.vt = VT_R8
-            u.VT_R8 = float(value)
+            raise TypeError(f"Cannot put {value!r} in VARIANT")
         elif isinstance(value, (float, c_double)):
             self.vt = VT_R8
             self._.VT_R8 = value

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -245,9 +245,6 @@ class tagVARIANT(Structure):
         elif isinstance(value, bool):
             self.vt = VT_BOOL
             self._.VT_BOOL = value
-        elif isinstance(value, (int, c_int)):
-            self.vt = VT_I4
-            self._.VT_I4 = value
         elif isinstance(value, int):
             u = self._
             # try VT_I4 first.
@@ -364,6 +361,9 @@ class tagVARIANT(Structure):
         elif isinstance(value, c_uint):
             self.vt = VT_UI4
             self._.VT_UI4 = value
+        elif isinstance(value, c_int):
+            self.vt = VT_I4
+            self._.VT_I4 = value
         elif isinstance(value, c_float):
             self.vt = VT_R4
             self._.VT_R4 = value

--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -261,12 +261,11 @@ class tagVARIANT(Structure):
                     self.vt = VT_UI4
                     return
             # try VT_I8 next.
-            if value >= 0:
-                u.VT_I8 = value
-                if u.VT_I8 == value:
-                    # did work.
-                    self.vt = VT_I8
-                    return
+            u.VT_I8 = value
+            if u.VT_I8 == value:
+                # did work.
+                self.vt = VT_I8
+                return
             # try VT_UI8 next.
             if value >= 0:
                 u.VT_UI8 = value

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -129,6 +129,32 @@ class VariantTestCase(unittest.TestCase):
         self.assertEqual(v.value, 1)
         self.assertIsInstance(v.value, int)
 
+    def test_vt_uix_range_boundaries(self):
+        MIN_VT_I4 = -(2**31)
+        MAX_VT_I4 = 2**31 - 1
+        MAX_VT_UI4 = 2**32 - 1
+        MIN_VT_I8 = -(2**63)
+        MAX_VT_I8 = 2**63 - 1
+        MAX_VT_UI8 = 2**64 - 1
+        for val, vt in [
+            (MIN_VT_I8, VT_I8),
+            (MIN_VT_I4 - 1, VT_I8),
+            (MIN_VT_I4, VT_I4),
+            (0, VT_I4),
+            (MAX_VT_I4, VT_I4),
+            (MAX_VT_I4 + 1, VT_UI4),
+            (MAX_VT_UI4, VT_UI4),
+            (MAX_VT_UI4 + 1, VT_I8),
+            (MAX_VT_I8, VT_I8),
+            (MAX_VT_I8 + 1, VT_UI8),
+            (MAX_VT_UI8, VT_UI8),
+        ]:
+            with self.subTest(val=val, vt=vt):
+                v = VARIANT()
+                v.value = val
+                self.assertEqual(v.value, val)
+                self.assertEqual(v.vt, vt)
+
     def test_datetime(self):
         now = datetime.datetime.now()
 

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -155,6 +155,16 @@ class VariantTestCase(unittest.TestCase):
                 self.assertEqual(v.value, val)
                 self.assertEqual(v.vt, vt)
 
+    def test_out_of_vt_uix_range(self):
+        MIN_VT_I8 = -(2**63)
+        MAX_VT_UI8 = 2**64 - 1
+        for val, vt in [
+            (MIN_VT_I8 - 1, VT_R8),
+            (MAX_VT_UI8 + 1, VT_R8),
+        ]:
+            with self.subTest(val=val, vt=vt), self.assertRaises(TypeError):
+                VARIANT().value = val
+
     def test_datetime(self):
         now = datetime.datetime.now()
 


### PR DESCRIPTION
Fixes #787

## The Problem

The existing code had several issues that prevented correct handling of integers outside the 32-bit signed range (`VT_I4`):

1. Initial `int` handling:
   All Python `int` types were initially grouped with `c_int` and directed towards `VT_I4`, preventing the large-integer logic from ever being reached.

2. Dead code for large integers:
   The logic intended to handle `VT_I8` (64-bit signed int) and `VT_UI8` (64-bit unsigned int) was effectively dead code.
   An incorrect `if value >= 0` check for `VT_I8` meant that any negative number outside the `VT_I4` range would fail assignment.

3. Dangerous fallback to `VT_R8`:
   Very large integers were silently converted to `VT_R8` (64-bit float), risking precision loss.
   For example, casting negative integers below the `VT_I8` minimum isn't guaranteed to be exact. These implicit conversions often lead to subtle, hard-to-diagnose bugs.

It appears the original author's intent was to create a sophisticated type-selection mechanism that would automatically choose the possible `VARTYPE` that could hold a given integer.
This PR aims to restore that intended behavior.

## Changes

This PR introduces the following fixes and improvements:

1. Separated `int` and `c_int` handling:
   The logic for Python's `int` is now distinct from `ctypes.c_int`, allowing Python integers to flow through the proper type selection branches.

2. Corrected `VT_I8` Logic:
   The erroneous `value >= 0` check has been removed, enabling correct handling of large negative integers.

3. Explicit error for out-of-range integers:
   The silent fallback to `VT_R8` has been replaced with a `TypeError`. This ensures that developers are immediately made aware of values that cannot be safely represented, preventing data corruption.

4. Comprehensive boundary tests:
   New unit tests have been added to verify the behavior at the boundaries of `VT_I4`, `VT_UI4`, `VT_I8`, and `VT_UI8`, and to ensure that a `TypeError` is raised for out-of-range values.

These changes make the `VARIANT` integer handling more robust, predictable, and aligned with what we believe was the original design intent.