### PR TITLE
Update `hints.pyi` and the type symbols under `TYPE_CHECKING` blocks in the generated codebase for PEP585 compliance.

### DIFF
--- a/comtypes/hints.pyi
+++ b/comtypes/hints.pyi
@@ -8,7 +8,6 @@ from ctypes import _CData, _CDataType
 from typing import Annotated as Annotated
 from typing import Any as Any
 from typing import ClassVar, Generic, NoReturn, Optional, Protocol, TypeVar, overload
-from typing import Tuple as Tuple
 from typing import Union as _UnionT
 
 if sys.version_info >= (3, 10):

--- a/comtypes/tools/codegenerator/typeannotator.py
+++ b/comtypes/tools/codegenerator/typeannotator.py
@@ -263,7 +263,7 @@ class ComMethodAnnotator(_MethodAnnotator[typedesc.ComMethod]):
         elif len(outargs) == 1:
             out = outargs[0]
         else:
-            out = "hints.Tuple[" + ", ".join(outargs) + "]"
+            out = "tuple[" + ", ".join(outargs) + "]"
         in_ = ("self, " + ", ".join(inargs)) if inargs else "self"
         content = f"def {name}({in_}) -> {out}: ..."
         if keyword.iskeyword(name):


### PR DESCRIPTION
See #876.

As they have the smallest impact on the runtime codebase, I chose type stubs and symbols under `TYPE_CHECKING` blocks as the first step of #876.