### PR TITLE
Use `collections.abc.Iterator` in `typeannotator` to align with PEP585.

### DIFF
--- a/comtypes/tools/codegenerator/typeannotator.py
+++ b/comtypes/tools/codegenerator/typeannotator.py
@@ -1,7 +1,7 @@
 import abc
 import keyword
-from collections.abc import Iterable, Sequence
-from typing import Any, Generic, Iterator, Optional, Protocol, TypeVar
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Any, Generic, Optional, Protocol, TypeVar
 
 from comtypes.tools import typedesc
 


### PR DESCRIPTION
This addresses the missing content in #879.