### PR TITLE
Remove Internet Explorer dependency from `test_QueryService.py`.

### DIFF
--- a/comtypes/test/test_QueryService.py
+++ b/comtypes/test/test_QueryService.py
@@ -31,6 +31,7 @@ class TestCase(unittest.TestCase):
         ss = es.GetSelectionServices(mc)
         # QueryInterface for `IHTMLDocument3` to access `getElementById`.
         element = doc.QueryInterface(mshtml.IHTMLDocument3).getElementById("test")
+        self.assertEqual(element.innerHTML, "Hello")
         # MarkupPointer related tests:
         ms = doc.QueryInterface(mshtml.IMarkupServices)
         p_start = ms.CreateMarkupPointer()


### PR DESCRIPTION
Related to #302

This focuses on removing the `InternetExplorer.Application` dependency from `comtypes/test/test_QueryService.py`.

The test now manipulates and verifies `MSHTML` COM objects (`HTMLDocument`, etc...) instead of relying on an `InternetExplorer.Application` instance.