### PR TITLE
Add tests for `stdole.IPicture` creation through `IStream`.

### DIFF
--- a/comtypes/test/test_stream.py
+++ b/comtypes/test/test_stream.py
@@ -237,6 +237,9 @@ _OleLoadPicture.argtypes = (
 )
 _OleLoadPicture.restype = HRESULT
 
+# Constants for the type of a picture object
+PICTYPE_BITMAP = 1
+
 # Constants for GetDeviceCaps
 LOGPIXELSX = 88  # Logical pixels/inch in X
 LOGPIXELSY = 90  # Logical pixels/inch in Y
@@ -361,6 +364,7 @@ class Test_Picture(ut.TestCase):
                 byref(pic),
             )
             self.assertEqual(hr, hresult.S_OK)
+            self.assertEqual(pic.Type, PICTYPE_BITMAP)
             pstm.RemoteSeek(0, STREAM_SEEK_SET)
             buf, read = pstm.RemoteRead(len(data))
         self.assertEqual(bytes(buf)[:read], data)


### PR DESCRIPTION
Added `test_ole_load_picture` to validate the creation of a *new* `stdole.IPicture` object by passing a pre-filled `IStream` (containing bitmap data) to `OleLoadPicture`.
This test specifically ensures that `CreateStreamOnHGlobal` is invoked with a non-NULL `hGlobal` and `fDeleteOnRelease` set to `False`.