### PR TITLE
Revive and enhance `test_outparam`.

### DIFF
--- a/comtypes/test/test_outparam.py
+++ b/comtypes/test/test_outparam.py
@@ -56,7 +56,7 @@ _CoGetMalloc(1, byref(malloc))
 assert bool(malloc)
 
 
-def from_outparm(self):
+def from_outparam(self):
     if not self:
         return None
     result = wstring_at(self)
@@ -80,7 +80,7 @@ def comstring(text, typ=c_wchar_p):
 
 
 class Test(unittest.TestCase):
-    @patch.object(c_wchar_p, "__ctypes_from_outparam__", from_outparm)
+    @patch.object(c_wchar_p, "__ctypes_from_outparam__", from_outparam)
     def test_c_char(self):
         ptr = c_wchar_p("abc")
         # The normal constructor does not allocate memory using `CoTaskMemAlloc`.
@@ -94,9 +94,9 @@ class Test(unittest.TestCase):
 
         # The `__ctypes_from_outparam__` method is called to convert an output
         # parameter into a Python object. In this test, the custom
-        # `from_outparm` function not only converts the `c_wchar_p` to a Python
-        # string but also frees the associated memory. Therefore, it can only
-        # be called once for each allocated memory block.
+        # `from_outparam` function not only converts the `c_wchar_p` to a
+        # Python string but also frees the associated memory. Therefore, it can
+        # only be called once for each allocated memory block.
         for wchar_ptr, expected in [
             (x, "Hello, World"),
             (y, "foo bar"),


### PR DESCRIPTION
This pull request re-enables and refactors the `test_c_char` in `test_outparam.py`, which was previously skipped "for misterious reasons"(3cadc717, #298, #271).
It is unclear why this test has started working again without any direct changes. Our best guess is that a combination of CPython bugfix releases and community-led fixes like #473 has resolved the underlying issue.

##  **Test Enhancement:**
The re-enabled `test_c_char` now provides verification for the correct handling pointers and their associated memory management within COM interoperability.
The explicit checks for `malloc.DidAlloc` directly address the nuances of COM memory ownership.

## **Refactoring Value:**
The test code has been improved for clarity, robustness, and maintainability.
*   The use of `self.subTest` provides granular feedback for each test case, making it easier to identify and debug specific failures.
*   Conversion of `ValueError` to direct `assert` statements aligns with idiomatic Python testing practices, simplifying test logic.
*   Conversion of `print` statements to `logger.debug` allows for better control over debugging output, improving the signal-to-noise ratio during test execution.
*   Removal of redundant `str` conversion and irrelevant comments streamlines the codebase.