### PR TITLE
Enhance and refactor COM moniker and binding context tests

### DIFF
--- a/comtypes/test/monikers_helper.py
+++ b/comtypes/test/monikers_helper.py
@@ -1,9 +1,13 @@
 from ctypes import HRESULT, POINTER, OleDLL, c_wchar_p
 from ctypes.wintypes import DWORD
 
-from comtypes import IUnknown
+from comtypes import GUID, IUnknown
 
+# https://learn.microsoft.com/en-us/windows/win32/api/objidl/ne-objidl-mksys
 MKSYS_ITEMMONIKER = 4
+
+CLSID_AntiMoniker = GUID("{00000305-0000-0000-c000-000000000046}")
+CLSID_ItemMoniker = GUID("{00000304-0000-0000-c000-000000000046}")
 
 ROTFLAGS_ALLOWANYCLIENT = 1
 
@@ -22,3 +26,6 @@ _CreateBindCtx.restype = HRESULT
 _GetRunningObjectTable = _ole32.GetRunningObjectTable
 _GetRunningObjectTable.argtypes = [DWORD, POINTER(POINTER(IUnknown))]
 _GetRunningObjectTable.restype = HRESULT
+
+# Common COM Errors from Moniker/Binding Context operations
+MK_E_UNAVAILABLE = -2147221021  # 0x800401E3

--- a/comtypes/test/test_moniker.py
+++ b/comtypes/test/test_moniker.py
@@ -1,6 +1,5 @@
 import contextlib
 import unittest
-from _ctypes import COMError
 from ctypes import POINTER, byref
 
 from comtypes import GUID, hresult
@@ -8,6 +7,8 @@ from comtypes.client import CreateObject, GetModule
 from comtypes.test.monikers_helper import (
     MKSYS_ITEMMONIKER,
     ROTFLAGS_ALLOWANYCLIENT,
+    CLSID_AntiMoniker,
+    CLSID_ItemMoniker,
     _CreateBindCtx,
     _CreateItemMoniker,
     _GetRunningObjectTable,
@@ -39,34 +40,29 @@ def _create_rot() -> IRunningObjectTable:
     return rot  # type: ignore
 
 
-class Test_IMoniker(unittest.TestCase):
-    def test_IsSystemMoniker(self):
+class Test_IsSystemMoniker_GetDisplayName_Inverse(unittest.TestCase):
+    def test_item(self):
         item_id = str(GUID.create_new())
         mon = _create_item_moniker("!", item_id)
         self.assertEqual(mon.IsSystemMoniker(), MKSYS_ITEMMONIKER)
-
-
-class Test_IBindCtx(unittest.TestCase):
-    def test_EnumObjectParam(self):
         bctx = _create_bctx()
-        with self.assertRaises(COMError) as err_ctx:
-            # calling `EnumObjectParam` results in a return value of E_NOTIMPL.
-            # https://learn.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-ibindctx-enumobjectparam#notes-to-callers
-            bctx.EnumObjectParam()
-        self.assertEqual(err_ctx.exception.hresult, hresult.E_NOTIMPL)
+        self.assertEqual(mon.GetDisplayName(bctx, None), f"!{item_id}")
+        self.assertEqual(mon.GetClassID(), CLSID_ItemMoniker)
+        self.assertEqual(mon.Inverse().GetClassID(), CLSID_AntiMoniker)
 
 
-class Test_IRunningObjectTable(unittest.TestCase):
-    def test_register_and_revoke_item_moniker(self):
+class Test_IsRunning(unittest.TestCase):
+    def test_item(self):
         vidctl = CreateObject(msvidctl.MSVidCtl, interface=msvidctl.IMSVidCtl)
         item_id = str(GUID.create_new())
         mon = _create_item_moniker("!", item_id)
         rot = _create_rot()
         bctx = _create_bctx()
+        # Before registering: should NOT be running
         self.assertEqual(mon.IsRunning(bctx, None, None), hresult.S_FALSE)
         dw_reg = rot.Register(ROTFLAGS_ALLOWANYCLIENT, vidctl, mon)
+        # After registering: should be running
         self.assertEqual(mon.IsRunning(bctx, None, None), hresult.S_OK)
-        self.assertEqual(f"!{item_id}", mon.GetDisplayName(bctx, None))
-        self.assertEqual(rot.GetObject(mon).QueryInterface(msvidctl.IMSVidCtl), vidctl)
         rot.Revoke(dw_reg)
+        # After revoking: should NOT be running again
         self.assertEqual(mon.IsRunning(bctx, None, None), hresult.S_FALSE)

--- a/comtypes/test/test_rot.py
+++ b/comtypes/test/test_rot.py
@@ -6,7 +6,7 @@ from ctypes import POINTER, byref
 from comtypes import GUID, hresult
 from comtypes.client import CreateObject, GetModule
 from comtypes.test.monikers_helper import (
-    MKSYS_ITEMMONIKER,
+    MK_E_UNAVAILABLE,
     ROTFLAGS_ALLOWANYCLIENT,
     _CreateBindCtx,
     _CreateItemMoniker,
@@ -39,35 +39,26 @@ def _create_rot() -> IRunningObjectTable:
     return rot  # type: ignore
 
 
-class Test_IMoniker(unittest.TestCase):
-    def test_IsSystemMoniker(self):
-        item_id = str(GUID.create_new())
-        mon = _create_item_moniker("!", item_id)
-        self.assertEqual(mon.IsSystemMoniker(), MKSYS_ITEMMONIKER)
-
-
-class Test_IBindCtx(unittest.TestCase):
-    def test_EnumObjectParam(self):
-        bctx = _create_bctx()
-        with self.assertRaises(COMError) as err_ctx:
-            # calling `EnumObjectParam` results in a return value of E_NOTIMPL.
-            # https://learn.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-ibindctx-enumobjectparam#notes-to-callers
-            bctx.EnumObjectParam()
-        self.assertEqual(err_ctx.exception.hresult, hresult.E_NOTIMPL)
-
-
-# TODO: Isolate this test case.
-class Test_IRunningObjectTable(unittest.TestCase):
-    def test_register_and_revoke_item_moniker(self):
+class Test_Register_Revoke_GetObject_IsRunning(unittest.TestCase):
+    def test_item(self):
         vidctl = CreateObject(msvidctl.MSVidCtl, interface=msvidctl.IMSVidCtl)
         item_id = str(GUID.create_new())
         mon = _create_item_moniker("!", item_id)
         rot = _create_rot()
         bctx = _create_bctx()
-        self.assertEqual(mon.IsRunning(bctx, None, None), hresult.S_FALSE)
+        # Before registering: should NOT be running
+        with self.assertRaises(COMError) as cm:
+            rot.GetObject(mon)
+        self.assertEqual(cm.exception.hresult, MK_E_UNAVAILABLE)
+        self.assertEqual(rot.IsRunning(mon), hresult.S_FALSE)
+        # After registering: should be running
         dw_reg = rot.Register(ROTFLAGS_ALLOWANYCLIENT, vidctl, mon)
+        self.assertEqual(rot.IsRunning(mon), hresult.S_OK)
         self.assertEqual(mon.IsRunning(bctx, None, None), hresult.S_OK)
-        self.assertEqual(f"!{item_id}", mon.GetDisplayName(bctx, None))
         self.assertEqual(rot.GetObject(mon).QueryInterface(msvidctl.IMSVidCtl), vidctl)
         rot.Revoke(dw_reg)
-        self.assertEqual(mon.IsRunning(bctx, None, None), hresult.S_FALSE)
+        # After revoking: should NOT be running again
+        self.assertEqual(rot.IsRunning(mon), hresult.S_FALSE)
+        with self.assertRaises(COMError) as cm:
+            rot.GetObject(mon)
+        self.assertEqual(cm.exception.hresult, MK_E_UNAVAILABLE)


### PR DESCRIPTION
## **Enabling Future Test Expansion**:
This PR lays the groundwork for expanding the test coverage for `IBindCtx`, `IMoniker`, and `IRunningObjectTable` methods. 
Anticipating that directly adding new tests would lead to overgrown and difficult-to-manage test modules, a proactive restructuring was undertaken.

## **Structured Test Module Organization**:
To prevent test module bloat, the testing landscape for COM interfaces has been segmented. Tests for `IBindCtx`, `IMoniker`, and `IRunningObjectTable` are now separated into dedicated modules (`test_bctx.py`, `test_moniker.py`, `test_rot.py`).
This partitioning ensures that as new method-specific tests are introduced, they can be added to their respective, focused modules, maintaining clarity and manageability.

## **Eliminating Redundancy with Centralized Helpers**:
The modularization of tests necessitated the extraction of common `ctypes` function definitions and COM-related constants.
These shared components were previously duplicated or would have become so across the newly split test files.
By centralizing them into `monikers_helper.py`, the project avoids "WET" code.