### PR TITLE
Add comprehensive testing for `IGlobalInterfaceTable` (GIT) marshaling.

### DIFF
--- a/comtypes/test/test_git.py
+++ b/comtypes/test/test_git.py
@@ -23,10 +23,12 @@ from comtypes.persist import STGM_READ, IPersistFile
 
 _user32 = WinDLL("user32")
 
+# https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-peekmessagea
 PeekMessage = _user32.PeekMessageA
 PeekMessage.argtypes = [POINTER(MSG), HWND, UINT, UINT, UINT]
 PeekMessage.restype = BOOL
 
+# https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-msgwaitformultipleobjects
 MsgWaitForMultipleObjects = _user32.MsgWaitForMultipleObjects
 MsgWaitForMultipleObjects.restype = DWORD
 MsgWaitForMultipleObjects.argtypes = [
@@ -58,6 +60,9 @@ IMG_DATA = base64.b64decode(DOT_B64_IMG)
 
 
 def CoGetApartmentType() -> tuple[int, int]:
+    # https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cogetapartmenttype
+    # https://learn.microsoft.com/en-us/windows/desktop/api/objidl/ne-objidl-apttype
+    # https://learn.microsoft.com/en-us/windows/desktop/api/objidl/ne-objidl-apttypequalifier
     typ, qf = DWORD(), DWORD()
     _CoGetApartmentType(typ, qf)
     return typ.value, qf.value


### PR DESCRIPTION
## Overview
This pull request introduces comprehensive unit tests for the `IGlobalInterfaceTable` (GIT) functionalities within the `git` module. 
These tests are verifying the handling of COM apartment boundaries which was an untested area previously.

### Demonstrated Solution for Thread Boundary Violations
The tests specifically target and reproduce "thread boundary violations" by attempting direct access to STA (Single-Threaded Apartment) COM objects from different threads without proper marshaling.
By contrasting this failed direct access with successful access through GIT, the tests clearly demonstrate that GIT provides a mechanism for sharing interfaces across apartments.

## Technical Background (for documentation integration)
The tests intentionally utilize out-of-process COM objects, such as `Paint.Picture`, because in-process objects can sometimes "accidentally work".