### PR TITLE
Fix a code path in `logutil.NTDebugHandler` and add a deprecation decorator to `logutil.setup_logging`.

### DIFF
--- a/comtypes/logutil.py
+++ b/comtypes/logutil.py
@@ -20,14 +20,10 @@ class NTDebugHandler(logging.Handler):
     def emit(
         self,
         record,
-        writeA=_OutputDebugStringA,
         writeW=_OutputDebugStringW,
     ):
         text = self.format(record)
-        if isinstance(text, str):
-            writeA(text + "\n")
-        else:
-            writeW(text + "\n")
+        writeW(text + "\n")
 
 
 logging.NTDebugHandler = NTDebugHandler


### PR DESCRIPTION
Part of #920 

## Summary
This pull request improves the `logutil` module by fixing `NTDebugHandler`'s Python 2/3 compatibility issues and deprecating `setup_logging` to streamline the codebase.

## Enhanced Reliability
### `logutil.NTDebugHandler` is now available
Previously, `logutil.NTDebugHandler` suffered from Python 2/3 `str` vs `bytes` incompatibility, leading to runtime errors when handling debug output.
This change eliminates the problematic type branching, ensuring that `_OutputDebugStringW` is consistently used.
This makes `NTDebugHandler` reliable for debugging in modern Python environments, where `logging.Formatter.format` always returns Unicode strings.

### Debug output capture is now testable
To ensure the correct functioning of `NTDebugHandler`, a new mechanism to capture `OutputDebugStringW` output has been introduced.
This enables robust testing of Windows debug output, allowing for verification of what was previously an untestable component.
This new capability not only validates the current fix but also provides a foundation for future debugging-related enhancements.

## Streamlined Codebase
### Reduce unnecessary responsibilities in `logutil`
The `setup_logging` function, which handled general logging configuration unrelated to COM or Windows-specific functionalities, has been deprecated.
This change clarifies the scope of `logutil` by removing excessive responsibilities that are better handled by application-level logging configurations, thus simplifying the library's overall purpose and reducing its maintenance burden.