### PR TITLE
Suppress unwanted log output in `logutil` tests and refactor `DBWIN` capture.

### DIFF
--- a/comtypes/test/test_logutil.py
+++ b/comtypes/test/test_logutil.py
@@ -196,19 +196,19 @@ def _listen_on_dbwin_channel(
 
 
 @contextlib.contextmanager
-def _run_dbwin_listener(ready: threading.Event, interval: int) -> Iterator[Queue]:
-    captured = Queue()
-    finished = threading.Event()
+def _run_dbwin_listener(ready: threading.Event, interval_ms: int) -> Iterator[Queue]:
+    messages = Queue()
+    stop = threading.Event()
     th = threading.Thread(
         target=_listen_on_dbwin_channel,
-        args=(interval, captured, ready, finished, _GetCurrentProcessId()),
+        args=(interval_ms, messages, ready, stop, _GetCurrentProcessId()),
         daemon=True,
     )
     th.start()
     try:
-        yield captured
+        yield messages
     finally:
-        finished.set()
+        stop.set()
         th.join()
 
 


### PR DESCRIPTION
CI logs were cluttered with unintended log messages leaking from `logutil` tests.

This PR suppresses log output during tests to keep CI logs clean, and refactors the DBWIN channel capture code to improve readability.