### PR TITLE
Unify Windows message handling APIs in `messageloop.py`.

### DIFF
--- a/comtypes/messageloop.py
+++ b/comtypes/messageloop.py
@@ -11,6 +11,11 @@ if TYPE_CHECKING:
 
     _FilterCallable = Callable[["_CArgObject"], Iterable[Any]]  # type: ignore
 
+# PeekMessage options
+PM_NOREMOVE = 0x0000
+PM_REMOVE = 0x0001
+PM_NOYIELD = 0x0002
+
 _user32 = WinDLL("user32")
 
 GetMessage = _user32.GetMessageA

--- a/comtypes/messageloop.py
+++ b/comtypes/messageloop.py
@@ -25,6 +25,11 @@ DispatchMessage = _user32.DispatchMessageA
 DispatchMessage.argtypes = [POINTER(MSG)]
 DispatchMessage.restype = LRESULT
 
+# https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-peekmessagea
+PeekMessage = _user32.PeekMessageA
+PeekMessage.argtypes = [POINTER(MSG), HWND, ctypes.c_uint, ctypes.c_uint, ctypes.c_uint]
+PeekMessage.restype = BOOL
+
 
 class _MessageLoop:
     def __init__(self) -> None:

--- a/comtypes/messageloop.py
+++ b/comtypes/messageloop.py
@@ -1,6 +1,7 @@
 import ctypes
 from ctypes import WinDLL, WinError, byref
-from ctypes.wintypes import MSG
+from ctypes.wintypes import BOOL, MSG
+from ctypes.wintypes import LPLONG as LRESULT
 from typing import TYPE_CHECKING, SupportsIndex
 
 if TYPE_CHECKING:
@@ -14,8 +15,15 @@ _user32 = WinDLL("user32")
 
 GetMessage = _user32.GetMessageA
 GetMessage.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.c_uint]
+GetMessage.restype = BOOL
+
 TranslateMessage = _user32.TranslateMessage
+TranslateMessage.argtypes = [ctypes.c_void_p]
+TranslateMessage.restype = BOOL
+
 DispatchMessage = _user32.DispatchMessageA
+DispatchMessage.argtypes = [ctypes.c_void_p]
+DispatchMessage.restype = LRESULT
 
 
 class _MessageLoop:

--- a/comtypes/messageloop.py
+++ b/comtypes/messageloop.py
@@ -1,5 +1,5 @@
 import ctypes
-from ctypes import WinDLL, WinError, byref
+from ctypes import POINTER, WinDLL, WinError, byref
 from ctypes.wintypes import BOOL, MSG
 from ctypes.wintypes import LPLONG as LRESULT
 from typing import TYPE_CHECKING, SupportsIndex
@@ -14,15 +14,15 @@ if TYPE_CHECKING:
 _user32 = WinDLL("user32")
 
 GetMessage = _user32.GetMessageA
-GetMessage.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.c_uint]
+GetMessage.argtypes = [POINTER(MSG), ctypes.c_void_p, ctypes.c_uint, ctypes.c_uint]
 GetMessage.restype = BOOL
 
 TranslateMessage = _user32.TranslateMessage
-TranslateMessage.argtypes = [ctypes.c_void_p]
+TranslateMessage.argtypes = [POINTER(MSG)]
 TranslateMessage.restype = BOOL
 
 DispatchMessage = _user32.DispatchMessageA
-DispatchMessage.argtypes = [ctypes.c_void_p]
+DispatchMessage.argtypes = [POINTER(MSG)]
 DispatchMessage.restype = LRESULT
 
 

--- a/comtypes/messageloop.py
+++ b/comtypes/messageloop.py
@@ -1,6 +1,6 @@
 import ctypes
 from ctypes import POINTER, WinDLL, WinError, byref
-from ctypes.wintypes import BOOL, MSG
+from ctypes.wintypes import BOOL, HWND, MSG
 from ctypes.wintypes import LPLONG as LRESULT
 from typing import TYPE_CHECKING, SupportsIndex
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 _user32 = WinDLL("user32")
 
 GetMessage = _user32.GetMessageA
-GetMessage.argtypes = [POINTER(MSG), ctypes.c_void_p, ctypes.c_uint, ctypes.c_uint]
+GetMessage.argtypes = [POINTER(MSG), HWND, ctypes.c_uint, ctypes.c_uint]
 GetMessage.restype = BOOL
 
 TranslateMessage = _user32.TranslateMessage

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -3,7 +3,12 @@ from ctypes import byref
 from ctypes.wintypes import MSG
 
 from comtypes.client import CreateObject, GetEvents
-from comtypes.messageloop import DispatchMessage, PeekMessage, TranslateMessage
+from comtypes.messageloop import (
+    PM_REMOVE,
+    DispatchMessage,
+    PeekMessage,
+    TranslateMessage,
+)
 
 # FIXME: External test dependencies like this seem bad.  Find a different
 # built-in win32 API to use.
@@ -45,7 +50,6 @@ class EventSink:
 
 def PumpWaitingMessages():
     msg = MSG()
-    PM_REMOVE = 0x0001
     while PeekMessage(byref(msg), 0, 0, 0, PM_REMOVE):
         TranslateMessage(byref(msg))
         DispatchMessage(byref(msg))

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -1,9 +1,9 @@
 import unittest as ut
-from ctypes import POINTER, WinDLL, byref
-from ctypes.wintypes import BOOL, HWND, MSG, UINT
-from ctypes.wintypes import LPLONG as LRESULT
+from ctypes import byref
+from ctypes.wintypes import MSG
 
 from comtypes.client import CreateObject, GetEvents
+from comtypes.messageloop import DispatchMessage, PeekMessage, TranslateMessage
 
 # FIXME: External test dependencies like this seem bad.  Find a different
 # built-in win32 API to use.
@@ -44,25 +44,11 @@ class EventSink:
 
 
 def PumpWaitingMessages():
-    _user32 = WinDLL("user32")
-
-    _PeekMessageA = _user32.PeekMessageA
-    _PeekMessageA.argtypes = [POINTER(MSG), HWND, UINT, UINT, UINT]
-    _PeekMessageA.restype = BOOL
-
-    _TranslateMessage = _user32.TranslateMessage
-    _TranslateMessage.argtypes = [POINTER(MSG)]
-    _TranslateMessage.restype = BOOL
-
-    _DispatchMessageA = _user32.DispatchMessageA
-    _DispatchMessageA.argtypes = [POINTER(MSG)]
-    _DispatchMessageA.restype = LRESULT
-
     msg = MSG()
     PM_REMOVE = 0x0001
-    while _PeekMessageA(byref(msg), 0, 0, 0, PM_REMOVE):
-        _TranslateMessage(byref(msg))
-        _DispatchMessageA(byref(msg))
+    while PeekMessage(byref(msg), 0, 0, 0, PM_REMOVE):
+        TranslateMessage(byref(msg))
+        DispatchMessage(byref(msg))
 
 
 class Test(ut.TestCase):

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -1,6 +1,7 @@
 import unittest as ut
 from ctypes import POINTER, Structure, WinDLL, byref, c_long, c_uint, c_ulong
-from ctypes.wintypes import BOOL, HWND, LPLONG, UINT
+from ctypes.wintypes import BOOL, HWND, UINT
+from ctypes.wintypes import LPLONG as LRESULT
 
 from comtypes.client import CreateObject, GetEvents
 
@@ -68,7 +69,6 @@ def PumpWaitingMessages():
     _TranslateMessage.argtypes = [POINTER(MSG)]
     _TranslateMessage.restype = BOOL
 
-    LRESULT = LPLONG
     _DispatchMessageA = _user32.DispatchMessageA
     _DispatchMessageA.argtypes = [POINTER(MSG)]
     _DispatchMessageA.restype = LRESULT

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -1,6 +1,6 @@
 import unittest as ut
-from ctypes import POINTER, Structure, WinDLL, byref, c_long, c_uint, c_ulong
-from ctypes.wintypes import BOOL, HWND, UINT
+from ctypes import POINTER, WinDLL, byref
+from ctypes.wintypes import BOOL, HWND, MSG, UINT
 from ctypes.wintypes import LPLONG as LRESULT
 
 from comtypes.client import CreateObject, GetEvents
@@ -41,21 +41,6 @@ class EventSink:
     def DocumentComplete(self, this, *args):
         # print "DocumentComplete", args
         self._events.append("DocumentComplete")
-
-
-class POINT(Structure):
-    _fields_ = [("x", c_long), ("y", c_long)]
-
-
-class MSG(Structure):
-    _fields_ = [
-        ("hWnd", c_ulong),
-        ("message", c_uint),
-        ("wParam", c_ulong),
-        ("lParam", c_ulong),
-        ("time", c_ulong),
-        ("pt", POINT),
-    ]
 
 
 def PumpWaitingMessages():

--- a/comtypes/test/test_git.py
+++ b/comtypes/test/test_git.py
@@ -7,7 +7,7 @@ import unittest as ut
 from _ctypes import COMError
 from collections.abc import Iterator
 from ctypes import HRESULT, POINTER, OleDLL, WinDLL, byref
-from ctypes.wintypes import BOOL, DWORD, HANDLE, HWND, MSG, UINT
+from ctypes.wintypes import BOOL, DWORD, HANDLE, MSG
 from pathlib import Path
 from queue import Queue
 
@@ -18,15 +18,10 @@ from comtypes.git import (
     RegisterInterfaceInGlobal,
     RevokeInterfaceFromGlobal,
 )
-from comtypes.messageloop import DispatchMessage, TranslateMessage
+from comtypes.messageloop import DispatchMessage, PeekMessage, TranslateMessage
 from comtypes.persist import STGM_READ, IPersistFile
 
 _user32 = WinDLL("user32")
-
-# https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-peekmessagea
-PeekMessage = _user32.PeekMessageA
-PeekMessage.argtypes = [POINTER(MSG), HWND, UINT, UINT, UINT]
-PeekMessage.restype = BOOL
 
 # https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-msgwaitformultipleobjects
 MsgWaitForMultipleObjects = _user32.MsgWaitForMultipleObjects

--- a/comtypes/test/test_git.py
+++ b/comtypes/test/test_git.py
@@ -18,7 +18,12 @@ from comtypes.git import (
     RegisterInterfaceInGlobal,
     RevokeInterfaceFromGlobal,
 )
-from comtypes.messageloop import DispatchMessage, PeekMessage, TranslateMessage
+from comtypes.messageloop import (
+    PM_REMOVE,
+    DispatchMessage,
+    PeekMessage,
+    TranslateMessage,
+)
 from comtypes.persist import STGM_READ, IPersistFile
 
 _user32 = WinDLL("user32")
@@ -43,8 +48,6 @@ _CoGetApartmentType.argtypes = [
 _CoGetApartmentType.restype = HRESULT
 
 QS_ALLINPUT = 0x04FF  # All message types including SendMessage
-
-PM_REMOVE = 0x0001  # Remove message from queue after Peek
 
 APTTYPE_MAINSTA = 3
 


### PR DESCRIPTION
## Overview
This PR centralizes the definitions of Windows message-related APIs and constants into `messageloop.py`.
It also strengthens the type safety of these definitions and eliminates redundant boilerplate code across the test suite.

## Improved Maintainability and Type Safety
### Explicit Function Signatures
The `argtypes` and `restype` for `GetMessage`, `TranslateMessage`, `DispatchMessage`, and `PeekMessage` are now explicitly defined.
This transition from "loose" calls to typed calls allows `ctypes` to perform basic argument validation, preventing common developer errors related to stack corruption or incorrect type passing.

### Standardized Resource usage
The code now leverages standard `ctypes.wintypes` (such as `MSG`, `HWND`, and `BOOL`) more consistently.