### PR TITLE
Replace Internet Explorer with MSXML in `test_eventinterface.py`.

### DIFF
--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -1,9 +1,11 @@
 import gc
 import time
 import unittest as ut
-from ctypes import byref
+from ctypes import HRESULT, byref
 from ctypes.wintypes import MSG
 
+from comtypes import COMMETHOD, GUID, IUnknown
+from comtypes.automation import DISPID
 from comtypes.client import CreateObject, GetEvents
 from comtypes.messageloop import (
     PM_REMOVE,
@@ -12,42 +14,35 @@ from comtypes.messageloop import (
     TranslateMessage,
 )
 
-# FIXME: External test dependencies like this seem bad.  Find a different
-# built-in win32 API to use.
 # The primary goal is to verify how `GetEvents` behaves when the
 # `interface` argument is explicitly specified versus when it is omitted,
 # using an object that has multiple outgoing event interfaces.
 
 
-class EventSink:
+class IPropertyNotifySink(IUnknown):
+    # https://learn.microsoft.com/en-us/windows/win32/api/ocidl/nn-ocidl-ipropertynotifysink
+    _iid_ = GUID("{9BFBBC02-EFF1-101A-84ED-00AA00341D07}")
+    _methods_ = [
+        COMMETHOD([], HRESULT, "OnChanged", (["in"], DISPID, "dispid")),
+        COMMETHOD([], HRESULT, "OnRequestEdit", (["in"], DISPID, "dispid")),
+    ]
+
+
+class MSXMLDocumentSink:
     def __init__(self):
         self._events = []
 
-    # some DWebBrowserEvents
-    def OnVisible(self, this, *args):
-        # print "OnVisible", args
-        self._events.append("OnVisible")
+    def onreadystatechange(self, this, *args):
+        self._events.append("onreadystatechange")
 
-    def BeforeNavigate(self, this, *args):
-        # print "BeforeNavigate", args
-        self._events.append("BeforeNavigate")
+    def ondataavailable(self, this, *args):
+        self._events.append("ondataavailable")
 
-    def NavigateComplete(self, this, *args):
-        # print "NavigateComplete", args
-        self._events.append("NavigateComplete")
+    def OnChanged(self, this, *args):
+        self._events.append("OnChanged")
 
-    # some DWebBrowserEvents2
-    def BeforeNavigate2(self, this, *args):
-        # print "BeforeNavigate2", args
-        self._events.append("BeforeNavigate2")
-
-    def NavigateComplete2(self, this, *args):
-        # print "NavigateComplete2", args
-        self._events.append("NavigateComplete2")
-
-    def DocumentComplete(self, this, *args):
-        # print "DocumentComplete", args
-        self._events.append("DocumentComplete")
+    def OnRequestEdit(self, this, *args):
+        self._events.append("OnRequestEdit")
 
 
 def PumpWaitingMessages():
@@ -57,64 +52,43 @@ def PumpWaitingMessages():
         DispatchMessage(byref(msg))
 
 
-class Test(ut.TestCase):
+class Test_MSXML(ut.TestCase):
+    def setUp(self):
+        self.doc = CreateObject("Msxml2.DOMDocument")
+        self.doc.async_ = True
+
     def tearDown(self):
+        del self.doc
         gc.collect()
         time.sleep(2)
 
-    @ut.skip(
-        "External test dependencies like this seem bad.  Find a different built-in "
-        "win32 API to use."
-    )
     def test_default_eventinterface(self):
-        sink = EventSink()
-        ie = CreateObject("InternetExplorer.Application")
-        conn = GetEvents(ie, sink=sink)
-        ie.Visible = True
-        ie.Navigate2(URL="http://docs.python.org/", Flags=0)
+        sink = MSXMLDocumentSink()
+        conn = GetEvents(self.doc, sink)
+        self.doc.loadXML("<root/>")
 
-        for i in range(50):
+        for _ in range(50):
             PumpWaitingMessages()
             time.sleep(0.1)
-        ie.Visible = False
-        ie.Quit()
+        self.assertIn("onreadystatechange", sink._events)
+        self.assertNotIn("OnChanged", sink._events)
 
-        self.assertEqual(
-            sink._events,
-            [
-                "OnVisible",
-                "BeforeNavigate2",
-                "NavigateComplete2",
-                "DocumentComplete",
-                "OnVisible",
-            ],
-        )
-
-        del ie
         del conn
 
-    @ut.skip(
-        "External test dependencies like this seem bad.  Find a different built-in "
-        "win32 API to use."
-    )
     def test_nondefault_eventinterface(self):
-        sink = EventSink()
-        ie = CreateObject("InternetExplorer.Application")
-        import comtypes.gen.SHDocVw as mod
+        sink = MSXMLDocumentSink()
 
-        conn = GetEvents(ie, sink, interface=mod.DWebBrowserEvents)
+        conn = GetEvents(self.doc, sink, interface=IPropertyNotifySink)
 
-        ie.Visible = True
-        ie.Navigate2(Flags=0, URL="http://docs.python.org/")
+        self.doc.loadXML("<root/>")
 
-        for i in range(50):
+        for _ in range(50):
             PumpWaitingMessages()
             time.sleep(0.1)
-        ie.Visible = False
-        ie.Quit()
+        self.assertNotIn("onreadystatechange", sink._events)
+        self.assertIn("OnChanged", sink._events)
 
-        self.assertEqual(sink._events, ["BeforeNavigate", "NavigateComplete"])
-        del ie
+        del conn
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -79,9 +79,12 @@ class Test_MSXML(ut.TestCase):
         conn = GetEvents(self.doc, sink)
         self.doc.loadXML("<root/>")
 
+        # Give the message loop time to process incoming events.
         for _ in range(50):
             PumpWaitingMessages()
             time.sleep(0.1)
+        # Should receive events from the default dispatch interface, but not
+        # events from `IPropertyNotifySink`.
         self.assertIn("onreadystatechange", sink._events)
         self.assertNotIn("OnChanged", sink._events)
 
@@ -96,9 +99,12 @@ class Test_MSXML(ut.TestCase):
 
         self.doc.loadXML("<root/>")
 
+        # Give the message loop time to process incoming events.
         for _ in range(50):
             PumpWaitingMessages()
             time.sleep(0.1)
+        # Should receive events from `IPropertyNotifySink`, but not events from
+        # the default dispatch interface.
         self.assertNotIn("onreadystatechange", sink._events)
         self.assertIn("OnChanged", sink._events)
 

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -34,12 +34,14 @@ class MSXMLDocumentSink:
     def __init__(self):
         self._events = []
 
+    # Events from the default dispatch interface
     def onreadystatechange(self, this, *args):
         self._events.append("onreadystatechange")
 
     def ondataavailable(self, this, *args):
         self._events.append("ondataavailable")
 
+    # Events from `IPropertyNotifySink`
     def OnChanged(self, this, *args):
         self._events.append("OnChanged")
 

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -1,3 +1,5 @@
+import gc
+import time
 import unittest as ut
 from ctypes import byref
 from ctypes.wintypes import MSG
@@ -57,11 +59,7 @@ def PumpWaitingMessages():
 
 class Test(ut.TestCase):
     def tearDown(self):
-        import gc
-
         gc.collect()
-        import time
-
         time.sleep(2)
 
     @ut.skip(
@@ -74,7 +72,6 @@ class Test(ut.TestCase):
         conn = GetEvents(ie, sink=sink)
         ie.Visible = True
         ie.Navigate2(URL="http://docs.python.org/", Flags=0)
-        import time
 
         for i in range(50):
             PumpWaitingMessages()
@@ -109,7 +106,6 @@ class Test(ut.TestCase):
 
         ie.Visible = True
         ie.Navigate2(Flags=0, URL="http://docs.python.org/")
-        import time
 
         for i in range(50):
             PumpWaitingMessages()

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -66,6 +66,8 @@ class Test_MSXML(ut.TestCase):
 
     def tearDown(self):
         del self.doc
+        # Force garbage collection and wait slightly to ensure COM resources
+        # are released properly between tests.
         gc.collect()
         time.sleep(2)
 

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -70,6 +70,9 @@ class Test_MSXML(ut.TestCase):
         time.sleep(2)
 
     def test_default_eventinterface(self):
+        # Verify that `GetEvents` automatically connects to the default source
+        # interface (dispatch events like `onreadystatechange`) when no
+        # interface is explicitly requested.
         sink = MSXMLDocumentSink()
         conn = GetEvents(self.doc, sink)
         self.doc.loadXML("<root/>")
@@ -83,6 +86,8 @@ class Test_MSXML(ut.TestCase):
         del conn
 
     def test_nondefault_eventinterface(self):
+        # Verify that `GetEvents` can connect to a non-default interface
+        # (like `IPropertyNotifySink`) when it is explicitly provided.
         sink = MSXMLDocumentSink()
 
         conn = GetEvents(self.doc, sink, interface=IPropertyNotifySink)

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -58,6 +58,9 @@ def PumpWaitingMessages():
 
 class Test_MSXML(ut.TestCase):
     def setUp(self):
+        # We use `Msxml2.DOMDocument` because it is a built-in Windows
+        # component that supports both a default source interface and the
+        # `IPropertyNotifySink` connection point.
         self.doc = CreateObject("Msxml2.DOMDocument")
         self.doc.async_ = True
 

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -23,7 +23,9 @@ class IPropertyNotifySink(IUnknown):
     # https://learn.microsoft.com/en-us/windows/win32/api/ocidl/nn-ocidl-ipropertynotifysink
     _iid_ = GUID("{9BFBBC02-EFF1-101A-84ED-00AA00341D07}")
     _methods_ = [
+        # Called when a property has changed.
         COMMETHOD([], HRESULT, "OnChanged", (["in"], DISPID, "dispid")),
+        # Called when an object wants to know if it's okay to change a property.
         COMMETHOD([], HRESULT, "OnRequestEdit", (["in"], DISPID, "dispid")),
     ]
 

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -30,7 +30,7 @@ class IPropertyNotifySink(IUnknown):
     ]
 
 
-class MSXMLDocumentSink:
+class EventSink:
     def __init__(self):
         self._events = []
 
@@ -75,7 +75,7 @@ class Test_MSXML(ut.TestCase):
         # Verify that `GetEvents` automatically connects to the default source
         # interface (dispatch events like `onreadystatechange`) when no
         # interface is explicitly requested.
-        sink = MSXMLDocumentSink()
+        sink = EventSink()
         conn = GetEvents(self.doc, sink)
         self.doc.loadXML("<root/>")
 
@@ -93,7 +93,7 @@ class Test_MSXML(ut.TestCase):
     def test_nondefault_eventinterface(self):
         # Verify that `GetEvents` can connect to a non-default interface
         # (like `IPropertyNotifySink`) when it is explicitly provided.
-        sink = MSXMLDocumentSink()
+        sink = EventSink()
 
         conn = GetEvents(self.doc, sink, interface=IPropertyNotifySink)
 


### PR DESCRIPTION
related to #302 

## Overview
This PR replaces the dependency on `InternetExplorer.Application` in `test_eventinterface.py` with `Msxml2.DOMDocument`.
This change ensures that the test suite can run reliably on modern Windows environments where Internet Explorer is no longer supported.
The PR also introduces the `IPropertyNotifySink` interface definition and enhances documentation across the test file.

## Improved maintainability and clarity
### Explicit documentation of test intent
The refactored tests now include detailed comments explaining *why* `MSXML` is used and *what* each test case verifies (e.g., default vs. non-default source interfaces).
This makes the test logic transparent for new contributors and simplifies future debugging of event-related issues.

### Consistent resource management
By centralizing imports like `gc` and `time` and adding explanatory comments about resource cleanup in `tearDown`.