### PR TITLE
Improve error handling for `GetEvents` with currently unsupported COM servers.

### DIFF
--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -120,6 +120,8 @@ def FindOutgoingInterface(source: IUnknown) -> type[IUnknown]:
     except COMError:
         pass
     else:
+        if guid == comtypes.GUID():
+            raise NotImplementedError("retrieved outgoing interface IID is GUID_NULL")
         # another try: block needed?
         try:
             interface = comtypes.com_interface_registry[str(guid)]

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -121,6 +121,8 @@ def FindOutgoingInterface(source: IUnknown) -> type[IUnknown]:
         pass
     else:
         if guid == comtypes.GUID():
+            # Some COM servers, even if they implement `IProvideClassInfo2`,
+            # may return GUID_NULL instead of the default source interface's GUID.
             raise NotImplementedError("retrieved outgoing interface IID is GUID_NULL")
         # another try: block needed?
         try:

--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -262,7 +262,15 @@ def CreateEventReceiver(interface: type[IUnknown], handler: Any) -> COMObject:
             # Can dispid be at a different index? Should check code generator...
             # ...but hand-written code should also work...
             dispid = m.idlflags[0]
-            assert isinstance(dispid, comtypes.dispid)
+            if not isinstance(dispid, comtypes.dispid):
+                # The interface is a subclass of `IDispatch` but its methods do not
+                # have DISPIDs, indicating it's not an interface suitable for event
+                # handling.
+                raise NotImplementedError(
+                    "Event receiver creation requires event methods to have DISPIDs "
+                    f"for dispatching, but '{interface.__name__}' ({interface._iid_}) "
+                    "lacks them, even though it inherits from 'IDispatch'."
+                )
             impl = finder.get_impl(interface, m.name, m.paramflags, m.idlflags)
             # XXX Wouldn't work for 'propget', 'propput', 'propputref'
             # methods - are they allowed on event interfaces?

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -146,10 +146,7 @@ class Test_IMAPI2FS(ut.TestCase):
         # `DFileSystemImageEvents`. Although it inherits from `IDispatch`,
         # it is a custom interface (`TKIND_INTERFACE`), not a dual or pure
         # dispatch interface (`TKIND_DISPATCH`).
-        # Its methods are v-table bound, and the interface definition
-        # that comtypes generates from the type info lacks the `dispid`
-        # attributes that `GetEvents` requires.
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(NotImplementedError):
             GetEvents(self.image, sink)
 
 

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -1,8 +1,10 @@
 import gc
+import tempfile
 import time
 import unittest as ut
 from ctypes import HRESULT, byref
 from ctypes.wintypes import MSG
+from pathlib import Path
 
 from comtypes import COMMETHOD, GUID, IUnknown
 from comtypes.automation import DISPID
@@ -120,6 +122,35 @@ class Test_MSHTML(ut.TestCase):
         # `IProvideClassInfo2`.
         with self.assertRaises(NotImplementedError):
             GetEvents(doc, sink)
+
+
+class Test_IMAPI2FS(ut.TestCase):
+    def setUp(self):
+        CLSID_MsftFileSystemImage = GUID("{2C941FC5-975B-59BE-A960-9A2A262853A5}")
+        self.image = CreateObject(CLSID_MsftFileSystemImage)
+        self.image.FileSystemsToCreate = 1  # FsiFileSystemISO9660
+        td = tempfile.TemporaryDirectory()
+        self.tmp_dir = Path(td.name)
+        self.addCleanup(td.cleanup)
+
+    def tearDown(self):
+        del self.image
+        # Force garbage collection and wait slightly to ensure COM resources
+        # are released properly between tests.
+        gc.collect()
+        time.sleep(2)
+
+    def test(self):
+        sink = object()
+        # The default event interface for IMAPI2's FileSystemImage is
+        # `DFileSystemImageEvents`. Although it inherits from `IDispatch`,
+        # it is a custom interface (`TKIND_INTERFACE`), not a dual or pure
+        # dispatch interface (`TKIND_DISPATCH`).
+        # Its methods are v-table bound, and the interface definition
+        # that comtypes generates from the type info lacks the `dispid`
+        # attributes that `GetEvents` requires.
+        with self.assertRaises(AssertionError):
+            GetEvents(self.image, sink)
 
 
 if __name__ == "__main__":

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -111,5 +111,19 @@ class Test_MSXML(ut.TestCase):
         del conn
 
 
+class Test_MSHTML(ut.TestCase):
+    def test(self):
+        doc = CreateObject("htmlfile")
+        sink = object()
+        # MSHTML's HTMLDocument (which is what `CreateObject('htmlfile')`
+        # returns) does not expose a valid default source interface through
+        # `IProvideClassInfo2`.
+        # Specifically, it returns `GUID_NULL` as its default source interface,
+        # which results in a `KeyError` when `GetEvents` tries to look it up in
+        # the interface registry.
+        with self.assertRaises(KeyError, msg="{00000000-0000-0000-0000-000000000000}"):
+            GetEvents(doc, sink)
+
+
 if __name__ == "__main__":
     ut.main()

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -140,12 +140,13 @@ class Test_IMAPI2FS(ut.TestCase):
         gc.collect()
         time.sleep(2)
 
-    def test(self):
+    def test_event_methods_lack_dispids(self):
         sink = object()
         # The default event interface for IMAPI2's FileSystemImage is
         # `DFileSystemImageEvents`. Although it inherits from `IDispatch`,
         # it is a custom interface (`TKIND_INTERFACE`), not a dual or pure
-        # dispatch interface (`TKIND_DISPATCH`).
+        # dispatch interface (`TKIND_DISPATCH`); therefore, its methods
+        # do not have DISPIDs.
         with self.assertRaises(NotImplementedError):
             GetEvents(self.image, sink)
 

--- a/comtypes/test/test_eventinterface.py
+++ b/comtypes/test/test_eventinterface.py
@@ -112,16 +112,13 @@ class Test_MSXML(ut.TestCase):
 
 
 class Test_MSHTML(ut.TestCase):
-    def test(self):
+    def test_retrieved_outgoing_iid_is_guid_null(self):
         doc = CreateObject("htmlfile")
         sink = object()
         # MSHTML's HTMLDocument (which is what `CreateObject('htmlfile')`
         # returns) does not expose a valid default source interface through
         # `IProvideClassInfo2`.
-        # Specifically, it returns `GUID_NULL` as its default source interface,
-        # which results in a `KeyError` when `GetEvents` tries to look it up in
-        # the interface registry.
-        with self.assertRaises(KeyError, msg="{00000000-0000-0000-0000-000000000000}"):
+        with self.assertRaises(NotImplementedError):
             GetEvents(doc, sink)
 
 


### PR DESCRIPTION
## Overview
This PR improves the robustness and clarity of the event handling system in `client`.
It specifically addresses edge cases where COM servers return invalid interface `GUID`s or define event interfaces that lack `DISPID` for connection point-based events, which are currently unsupported by `GetEvents`.

## Enhanced Error Handling
### Explicit `NotImplementedError` for invalid interface GUIDs
Previously, when a COM server's `IProvideClassInfo2` returned `GUID_NULL` for its default source interface (a known issue with some servers like `htmlfile`), the system would fail with an uninformative `KeyError`.
This is now explicitly caught and raised as a `NotImplementedError`, providing a clearer signal that the server is not providing the necessary information to establish an event connection.

### Replaced assertions with descriptive exceptions for missing DISPIDs
In `CreateEventReceiver`, an `assert` was used to verify the presence of DISPIDs.
This has been replaced with a formal check that raises a `NotImplementedError` with a detailed message.
This improvement is crucial for debugging issues with custom event interfaces (like those in `IMAPI2FS`) that inherit from `IDispatch` but lack the DISPIDs required for dispatch-based event sinks.

### Expanded test coverage for COM servers
New test cases using `MSHTML` (`htmlfile`) and `IMAPI2FS` (`MsftFileSystemImage`) have been introduced.
These tests verify the new error handling paths.