### PR TITLE
Refactor `test_basic.py` to use public APIs.

### DIFF
--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -14,8 +14,6 @@ def method_count(interface):
 
 class BasicTest(ut.TestCase):
     def test_IUnknown(self):
-        from comtypes import IUnknown
-
         self.assertEqual(method_count(IUnknown), 3)
 
     def test_release(self):

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -3,7 +3,7 @@ import unittest as ut
 from ctypes import HRESULT, POINTER, byref
 
 from comtypes import GUID, STDMETHOD, IUnknown
-from comtypes.typeinfo import ICreateTypeLib2, _CreateTypeLib2
+from comtypes.typeinfo import CreateTypeLib, ICreateTypeLib2, _CreateTypeLib2
 
 # XXX leaks references!
 
@@ -114,8 +114,6 @@ class BasicTest(ut.TestCase):
         b = POINTER(IUnknown)()
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))
-
-        from comtypes.typeinfo import CreateTypeLib
 
         # we do not save the lib, so no file will be created.
         # these should NOT be identical

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -23,6 +23,7 @@ class BasicTest(ut.TestCase):
         # — whether ICreateTypeLib2 or otherwise — could be used for this test.
         p = CreateTypeLib("blabla", syskind=SYS_WIN32)
         self.assertIsInstance(p, ICreateTypeLib2)
+        self.assertIsInstance(p, IUnknown)
         # initial refcount is 2
         for i in range(2, 10):
             self.assertEqual(p.AddRef(), i)
@@ -34,6 +35,7 @@ class BasicTest(ut.TestCase):
         # — whether ICreateTypeLib2 or otherwise — could be used for this test.
         p = CreateTypeLib("blabla", syskind=SYS_WIN32)
         self.assertIsInstance(p, ICreateTypeLib2)
+        self.assertIsInstance(p, IUnknown)
         self.assertEqual(p.AddRef(), 2)
         self.assertEqual(p.Release(), 1)
 

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -3,7 +3,7 @@ import unittest as ut
 from ctypes import HRESULT, POINTER, byref
 
 from comtypes import GUID, STDMETHOD, IUnknown
-from comtypes.typeinfo import CreateTypeLib, ICreateTypeLib2, _CreateTypeLib2
+from comtypes.typeinfo import SYS_WIN32, CreateTypeLib, ICreateTypeLib2, _CreateTypeLib2
 
 # XXX leaks references!
 
@@ -25,7 +25,7 @@ class BasicTest(ut.TestCase):
         # Since all COM interfaces derive from IUnknown and have the same reference counting behavior, any interface
         # — whether ICreateTypeLib2 or otherwise — could be used for this test.
         p = POINTER(ICreateTypeLib2)()
-        _CreateTypeLib2(1, "blabla", byref(p))
+        _CreateTypeLib2(SYS_WIN32, "blabla", byref(p))
         # initial refcount is 2
         for i in range(2, 10):
             self.assertEqual(p.AddRef(), i)
@@ -36,7 +36,7 @@ class BasicTest(ut.TestCase):
         # Since all COM interfaces derive from IUnknown and have the same QueryInterface behavior, any interface
         # — whether ICreateTypeLib2 or otherwise — could be used for this test.
         p = POINTER(ICreateTypeLib2)()
-        _CreateTypeLib2(1, "blabla", byref(p))
+        _CreateTypeLib2(SYS_WIN32, "blabla", byref(p))
         self.assertEqual(p.AddRef(), 2)
         self.assertEqual(p.Release(), 1)
 

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -1,9 +1,9 @@
 ##import ut
 import unittest as ut
-from ctypes import HRESULT, POINTER, byref
+from ctypes import HRESULT, POINTER
 
 from comtypes import GUID, STDMETHOD, IUnknown
-from comtypes.typeinfo import SYS_WIN32, CreateTypeLib, ICreateTypeLib2, _CreateTypeLib2
+from comtypes.typeinfo import SYS_WIN32, CreateTypeLib, ICreateTypeLib2
 
 # XXX leaks references!
 
@@ -24,8 +24,8 @@ class BasicTest(ut.TestCase):
     def test_refcounts(self):
         # Since all COM interfaces derive from IUnknown and have the same reference counting behavior, any interface
         # — whether ICreateTypeLib2 or otherwise — could be used for this test.
-        p = POINTER(ICreateTypeLib2)()
-        _CreateTypeLib2(SYS_WIN32, "blabla", byref(p))
+        p = CreateTypeLib("blabla", syskind=SYS_WIN32)
+        self.assertIsInstance(p, ICreateTypeLib2)
         # initial refcount is 2
         for i in range(2, 10):
             self.assertEqual(p.AddRef(), i)
@@ -35,8 +35,8 @@ class BasicTest(ut.TestCase):
     def test_qi(self):
         # Since all COM interfaces derive from IUnknown and have the same QueryInterface behavior, any interface
         # — whether ICreateTypeLib2 or otherwise — could be used for this test.
-        p = POINTER(ICreateTypeLib2)()
-        _CreateTypeLib2(SYS_WIN32, "blabla", byref(p))
+        p = CreateTypeLib("blabla", syskind=SYS_WIN32)
+        self.assertIsInstance(p, ICreateTypeLib2)
         self.assertEqual(p.AddRef(), 2)
         self.assertEqual(p.Release(), 1)
 

--- a/comtypes/test/test_basic.py
+++ b/comtypes/test/test_basic.py
@@ -1,4 +1,3 @@
-##import ut
 import unittest as ut
 from ctypes import HRESULT, POINTER
 


### PR DESCRIPTION
## Overview
This PR refactors `test/test_basic.py` to improve maintainability.
It primarily replaces internal, low-level function calls with public APIs for fundamental COM behavior verification and cleans up redundant code.

### Decoupling from Internal Implementations
The tests for COM pointer reference counting and `QueryInterface` now utilize the public `CreateTypeLib` function instead of the private `_CreateTypeLib2`.
Referencing the comments from #764 helps future maintainers easily understand the underlying intent of these tests.

### Improved Code Clarity and Maintainability
Redundant inline imports, magic numbers, and commented-out code have been removed or replaced with named constants like `SYS_WIN32`.