### PR TITLE
Refine type hints for COM object creation and retrieval.

### DIFF
--- a/comtypes/_post_coinit/misc.py
+++ b/comtypes/_post_coinit/misc.py
@@ -14,6 +14,7 @@ from ctypes import (
 )
 from ctypes.wintypes import DWORD, LPCWSTR, LPVOID
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, overload
+from typing import Union as _UnionT
 
 from comtypes import CLSCTX_LOCAL_SERVER, CLSCTX_REMOTE_SERVER, CLSCTX_SERVER, GUID
 from comtypes._memberspec import COMMETHOD
@@ -21,7 +22,7 @@ from comtypes._post_coinit.unknwn import IUnknown
 from comtypes.GUID import REFCLSID
 
 if TYPE_CHECKING:
-    from ctypes import _Pointer
+    from ctypes import _CArgObject, _Pointer
 
     from comtypes import hints as hints  # noqa  # type: ignore
 
@@ -146,20 +147,20 @@ def CoCreateInstance(
 def CoGetClassObject(
     clsid: GUID,
     clsctx: Optional[int] = None,
-    pServerInfo: "Optional[COSERVERINFO]" = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
     interface: None = None,
 ) -> "hints.IClassFactory": ...
 @overload
 def CoGetClassObject(
     clsid: GUID,
     clsctx: Optional[int] = None,
-    pServerInfo: "Optional[COSERVERINFO]" = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
     interface: type[_T_IUnknown] = IUnknown,
 ) -> _T_IUnknown: ...
 def CoGetClassObject(
     clsid: GUID,
     clsctx: Optional[int] = None,
-    pServerInfo: "Optional[COSERVERINFO]" = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
     interface: Optional[type[IUnknown]] = None,
 ) -> IUnknown:
     if clsctx is None:
@@ -337,7 +338,7 @@ def CoCreateInstanceEx(
     interface: None = None,
     clsctx: Optional[int] = None,
     machine: Optional[str] = None,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
 ) -> IUnknown: ...
 @overload
 def CoCreateInstanceEx(
@@ -345,14 +346,14 @@ def CoCreateInstanceEx(
     interface: type[_T_IUnknown],
     clsctx: Optional[int] = None,
     machine: Optional[str] = None,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
 ) -> _T_IUnknown: ...
 def CoCreateInstanceEx(
     clsid: GUID,
     interface: Optional[type[IUnknown]] = None,
     clsctx: Optional[int] = None,
     machine: Optional[str] = None,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
 ) -> IUnknown:
     """The basic windows api to create a COM class object and return a
     pointer to an interface, possibly on another machine.

--- a/comtypes/client/_activeobj.py
+++ b/comtypes/client/_activeobj.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TypeVar, overload
+from typing import Any, Literal, Optional, TypeVar, overload
 from typing import Union as _UnionT
 
 import comtypes
@@ -14,10 +14,24 @@ _T_IUnknown = TypeVar("_T_IUnknown", bound=IUnknown)
 # Object creation
 #
 @overload
-def GetActiveObject(progid: _UnionT[str, type[CoClass], GUID]) -> Any: ...
+def GetActiveObject(
+    progid: _UnionT[str, type[CoClass], GUID],
+    interface: None = None,
+    dynamic: Literal[False] = False,
+) -> Any: ...
 @overload
 def GetActiveObject(
-    progid: _UnionT[str, type[CoClass], GUID], interface: type[_T_IUnknown]
+    progid: _UnionT[str, type[CoClass], GUID],
+    interface: None = None,
+    dynamic: Literal[True] = True,
+) -> _UnionT[
+    "comtypes.client.lazybind.Dispatch", "comtypes.client.dynamic._Dispatch"
+]: ...
+@overload
+def GetActiveObject(
+    progid: _UnionT[str, type[CoClass], GUID],
+    interface: type[_T_IUnknown] = IUnknown,
+    dynamic: Literal[False] = False,
 ) -> _T_IUnknown: ...
 def GetActiveObject(
     progid: _UnionT[str, type[CoClass], GUID],

--- a/comtypes/client/_create.py
+++ b/comtypes/client/_create.py
@@ -56,8 +56,28 @@ def CreateObject(
     progid: _UnionT[str, type[CoClass], GUID],
     clsctx: Optional[int] = None,
     machine: Optional[str] = None,
-    interface: Optional[type[_T_IUnknown]] = None,
-    dynamic: bool = ...,
+    interface: None = None,
+    dynamic: Literal[False] = False,
+    pServerInfo: Optional[COSERVERINFO] = None,
+) -> Any: ...
+@overload
+def CreateObject(
+    progid: _UnionT[str, type[CoClass], GUID],
+    clsctx: Optional[int] = None,
+    machine: Optional[str] = None,
+    interface: None = None,
+    dynamic: Literal[True] = True,
+    pServerInfo: Optional[COSERVERINFO] = None,
+) -> _UnionT[
+    "comtypes.client.lazybind.Dispatch", "comtypes.client.dynamic._Dispatch"
+]: ...
+@overload
+def CreateObject(
+    progid: _UnionT[str, type[CoClass], GUID],
+    clsctx: Optional[int] = None,
+    machine: Optional[str] = None,
+    interface: type[_T_IUnknown] = IUnknown,
+    dynamic: Literal[False] = False,
     pServerInfo: Optional[COSERVERINFO] = None,
 ) -> _T_IUnknown: ...
 def CreateObject(

--- a/comtypes/client/_create.py
+++ b/comtypes/client/_create.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, overload
 from typing import Union as _UnionT
 
 import comtypes
@@ -123,11 +123,25 @@ def CreateObject(
 
 
 @overload
-def CoGetObject(displayname: str, interface: type[_T_IUnknown]) -> _T_IUnknown: ...
+def CoGetObject(
+    displayname: str,
+    interface: None = None,
+    dynamic: Literal[False] = False,
+) -> Any: ...
 @overload
 def CoGetObject(
-    displayname: str, interface: None = None, dynamic: bool = False
-) -> Any: ...
+    displayname: str,
+    interface: None = None,
+    dynamic: Literal[True] = True,
+) -> _UnionT[
+    "comtypes.client.lazybind.Dispatch", "comtypes.client.dynamic._Dispatch"
+]: ...
+@overload
+def CoGetObject(
+    displayname: str,
+    interface: type[_T_IUnknown],
+    dynamic: Literal[False] = False,
+) -> _T_IUnknown: ...
 def CoGetObject(
     displayname: str,
     interface: Optional[type[IUnknown]] = None,

--- a/comtypes/client/_create.py
+++ b/comtypes/client/_create.py
@@ -8,6 +8,8 @@ from comtypes import COSERVERINFO, GUID, CoClass, IUnknown, automation
 from comtypes.client._managing import _manage
 
 if TYPE_CHECKING:
+    from ctypes import _CArgObject
+
     from comtypes import hints  # type: ignore
 
 
@@ -23,20 +25,20 @@ logger = logging.getLogger(__name__)
 def GetClassObject(
     progid: _UnionT[str, type[CoClass], GUID],
     clsctx: Optional[int] = None,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
     interface: None = None,
 ) -> "hints.IClassFactory": ...
 @overload
 def GetClassObject(
     progid: _UnionT[str, type[CoClass], GUID],
     clsctx: Optional[int] = None,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
     interface: type[_T_IUnknown] = IUnknown,
 ) -> _T_IUnknown: ...
 def GetClassObject(
     progid: _UnionT[str, type[CoClass], GUID],
     clsctx: Optional[int] = None,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
     interface: Optional[type[IUnknown]] = None,
 ) -> IUnknown:
     """Create and return the class factory for a COM object.
@@ -58,7 +60,7 @@ def CreateObject(
     machine: Optional[str] = None,
     interface: None = None,
     dynamic: Literal[False] = False,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
 ) -> Any: ...
 @overload
 def CreateObject(
@@ -67,7 +69,7 @@ def CreateObject(
     machine: Optional[str] = None,
     interface: None = None,
     dynamic: Literal[True] = True,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
 ) -> _UnionT[
     "comtypes.client.lazybind.Dispatch", "comtypes.client.dynamic._Dispatch"
 ]: ...
@@ -78,7 +80,7 @@ def CreateObject(
     machine: Optional[str] = None,
     interface: type[_T_IUnknown] = IUnknown,
     dynamic: Literal[False] = False,
-    pServerInfo: Optional[COSERVERINFO] = None,
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,
 ) -> _T_IUnknown: ...
 def CreateObject(
     progid: _UnionT[str, type[CoClass], GUID],  # which object to create
@@ -86,7 +88,7 @@ def CreateObject(
     machine: Optional[str] = None,  # where to create the object
     interface: Optional[type[IUnknown]] = None,  # the interface we want
     dynamic: bool = False,  # use dynamic dispatch
-    pServerInfo: Optional[COSERVERINFO] = None,  # server info struct for remoting
+    pServerInfo: "_UnionT[None, _CArgObject, COSERVERINFO]" = None,  # server info struct for remoting
 ) -> Any:
     """Create a COM object from 'progid', and try to QueryInterface()
     it to the most useful interface, generating typelib support on


### PR DESCRIPTION
## Summary
This PR focuses **type-hint improvements** for core COM object creation and retrieval functions.
The goal is solely to enhance static type safety and developer experience within IDEs by providing precise `@overload` signatures and `Literal` hints.

## Changes

### 1. Static Type Resolution for Object Creation
- **Functions affected**: `CreateObject`, `GetActiveObject`, `CoGetObject`
- **Focus**: Added `Literal` type hints to the `dynamic` parameter.

### 2. Overload Mapping for Interface Specification
- **Functions affected**: `CreateObject`, `GetActiveObject`, `GetClassObject`, `CoGetClassObject`, `CoCreateInstanceEx`
- **Focus**: Refined `@overload` signatures to link the `interface` argument directly to the function's return type in the eyes of static analyzers.

### 3. Type-Safe Pointers for Low-Level Compatibility
- **Functions affected**: `CreateObject`, `GetClassObject`, `CoGetClassObject`, `CoCreateInstanceEx`
- **Focus**: Expanded the type definition of `pServerInfo` to include `_CArgObject`.