### PR TITLE
Fix UnboundLocalError when all struct packings fail in calc_packing

### DIFF
--- a/comtypes/test/test_packing.py
+++ b/comtypes/test/test_packing.py
@@ -1,0 +1,49 @@
+import unittest
+
+from comtypes.tools import typedesc
+from comtypes.tools.codegenerator.packing import PackingError, calc_packing
+
+
+# Sizes, alignments and offsets are expressed in bits, matching the values
+# produced by ``comtypes.tools.tlbparser`` (e.g. a 32-bit ``int``).
+def _make_field(name, size, align, offset):
+    typ = typedesc.FundamentalType("int", size, align)
+    return typedesc.Field(name, typ, None, offset)
+
+
+class CalcPackingTest(unittest.TestCase):
+    def test_returns_none_for_default_packing(self):
+        # A naturally laid out single-field struct needs no explicit packing.
+        field = _make_field("a", 32, 32, 0)
+        struct = typedesc.Structure(
+            "Good", align=32, members=[field], bases=[], size=32
+        )
+        self.assertIsNone(calc_packing(struct, [field]))
+
+    def test_incomplete_struct_returns_none(self):
+        field = _make_field("a", 32, 32, 0)
+        struct = typedesc.Structure(
+            "Incomplete", align=32, members=[field], bases=[], size=None
+        )
+        self.assertIsNone(calc_packing(struct, [field]))
+
+    def test_raises_packing_error_with_details_when_layout_is_inconsistent(self):
+        # The declared field offset does not match the computed layout, so every
+        # packing attempt raises ``PackingError`` and ``calc_packing`` must
+        # re-raise with the underlying reason.
+        #
+        # Regression test for gh-937: the final ``raise`` referenced the
+        # ``except ... as`` target after it had been cleared, raising
+        # ``UnboundLocalError`` and masking the real ``PackingError``.
+        field = _make_field("x", 32, 32, 64)
+        struct = typedesc.Structure("Bad", align=32, members=[field], bases=[], size=96)
+        with self.assertRaises(PackingError) as ctx:
+            calc_packing(struct, [field])
+        message = str(ctx.exception)
+        self.assertIn("PACKING FAILED", message)
+        # The original failure reason must be preserved, not lost.
+        self.assertIn("field x offset", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comtypes/tools/codegenerator/packing.py
+++ b/comtypes/tools/codegenerator/packing.py
@@ -44,10 +44,15 @@ def _calc_packing(struct, fields, pack, isStruct):
 def calc_packing(struct, fields):
     # try several packings, starting with unspecified packing
     isStruct = isinstance(struct, typedesc.Structure)
+    last_error = None
     for pack in [None, 16 * 8, 8 * 8, 4 * 8, 2 * 8, 1 * 8]:
         try:
             _calc_packing(struct, fields, pack, isStruct)
         except PackingError as details:
+            # The exception target is cleared when the ``except`` block ends
+            # (see https://docs.python.org/3/reference/compound_stmts.html#except-clause),
+            # so keep a reference for the final error message below.
+            last_error = details
             continue
         else:
             if pack is None:
@@ -55,7 +60,7 @@ def calc_packing(struct, fields):
 
             return int(pack / 8)
 
-    raise PackingError(f"PACKING FAILED: {details}")
+    raise PackingError(f"PACKING FAILED: {last_error}")
 
 
 class PackingError(Exception):


### PR DESCRIPTION
## Problem

`comtypes.client.CreateObject(...)` (via `GetModule` -> code generation) can crash with:

```
File ".../comtypes/tools/codegenerator/packing.py", line 58, in calc_packing
    raise PackingError(f"PACKING FAILED: {details}")
UnboundLocalError: local variable 'details' referenced before assignment
```

instead of reporting the actual struct-layout problem. This was reported in #937 when generating wrappers for a vendor type library whose structure layout could not be matched.

## Root cause

`calc_packing()` tries several packings and, on the failure path, re-raises with the captured error:

```python
for pack in [None, 16 * 8, 8 * 8, 4 * 8, 2 * 8, 1 * 8]:
    try:
        _calc_packing(struct, fields, pack, isStruct)
    except PackingError as details:
        continue
    ...
raise PackingError(f"PACKING FAILED: {details}")
```

In Python 3 the `except ... as details` target is deleted when the `except` block ends (see the [language reference](https://docs.python.org/3/reference/compound_stmts.html#except-clause)). So when *every* packing attempt fails and execution reaches the final `raise`, `details` is unbound. The resulting `UnboundLocalError` masks the real `PackingError` and its diagnostic message.

## Fix

Store the last `PackingError` in a separate variable that survives the loop, and use it in the final `raise`. The real layout error is now reported:

```
PackingError: PACKING FAILED: field x offset (0/8)
```

The change is minimal and does not alter behaviour for structs that pack successfully.

## Test evidence

Added `comtypes/test/test_packing.py` with regression coverage for `calc_packing`:

- successful default packing returns `None`
- incomplete struct (`size is None`) returns `None`
- an inconsistent layout raises `PackingError` whose message preserves the underlying reason (`"PACKING FAILED: ... field x offset ..."`)

Before the fix the regression test fails with `UnboundLocalError`; after the fix all tests pass.

```
test_incomplete_struct_returns_none ... ok
test_raises_packing_error_with_details_when_layout_is_inconsistent ... ok
test_returns_none_for_default_packing ... ok
----------------------------------------------------------------------
Ran 3 tests in 0.000s
OK
```

`ruff check` and `ruff format --check` pass on both changed files.

> Note: `comtypes` only imports on Windows, so the new tests were exercised by loading `comtypes.tools.codegenerator.packing` / `comtypes.tools.typedesc_base` directly. On the Windows CI they run via the standard `unittest discover`.

Fixes #937
